### PR TITLE
This fixes issue #47 and simplifies the CamelCase regex

### DIFF
--- a/src/Phinx/Migration/Util.php
+++ b/src/Phinx/Migration/Util.php
@@ -22,7 +22,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- * 
+ *
  * @package    Phinx
  * @subpackage Phinx\Migration
  */
@@ -45,7 +45,7 @@ class Util
         $fileName = date('YmdHis') . '_' . strtolower(implode($arr, '_')) . '.php';
         return $fileName;
     }
-    
+
     /**
      * Check if a migration class name is valid.
      *
@@ -59,6 +59,6 @@ class Util
      */
     public static function isValidMigrationClassName($className)
     {
-        return (bool) preg_match('/\b[A-Z][a-zA-Z]*(?:[a-z][a-zA-Z]*[A-Z]|[A-Z][a-zA-Z]*[a-z])[a-zA-Z]*\b/', $className);
+        return (bool) preg_match('/^([A-Z][a-z0-9]+)+$/', $className);
     }
 }


### PR DESCRIPTION
The simplified regex allows the following migration class names:
CamelCase -> camel_case
Camel34 -> camel34
CamelCase23afterSomeBooze -> camel_case23after_some_booze

It does NOT allow (which was previously allowed):
CAmelCase

The mail reason for not allowing consecutive uppercase letters is because something like this:
SOMETHING
gets transformed to:
s_o_m_e_t_h_i_n_g
and i don't really see why anyone would use that other than forgetting the caps lock on by mistake (in which case we'd better warn him)
