### PR TITLE
Bootstrap and custom parsers

### DIFF
--- a/src/Phinx/Config/Parser/Parser.php
+++ b/src/Phinx/Config/Parser/Parser.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2013 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Config
+ */
+namespace Phinx\Config\Parser;
+
+/**
+ * Phinx parser interface
+ *
+ * @package Phinx
+ * @author  Rob Morgan
+ */
+interface Parser
+{
+    /**
+     * Create a new instance of the config class using file path
+     *
+     * @param   string $configFilePath
+     * @throws \RuntimeException
+     * @return  array
+     */
+    public static function parse($configFilePath);
+
+}

--- a/src/Phinx/Config/Parser/PhpParser.php
+++ b/src/Phinx/Config/Parser/PhpParser.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2013 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Config
+ */
+namespace Phinx\Config\Parser;
+
+/**
+ * Phinx PHP parser
+ *
+ * @package Phinx
+ * @author  Rob Morgan
+ */
+class PhpParser implements Parser
+{
+    /**
+     * Create a new instance of the config class using a PHP file path.
+     *
+     * @param   string $configFilePath
+     * @throws \RuntimeException
+     * @return  array
+     */
+    public static function parse($configFilePath)
+    {
+        ob_start();
+        $configArray = include($configFilePath);
+
+        // Hide console output
+        $content = ob_get_clean();
+
+        if ( ! is_array($configArray)) {
+            throw new \RuntimeException(sprintf('PHP file \'%s\' must return an array', $configFilePath));
+        }
+        return $configArray;
+    }
+
+}

--- a/src/Phinx/Config/Parser/YamlParser.php
+++ b/src/Phinx/Config/Parser/YamlParser.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2013 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Config
+ */
+namespace Phinx\Config\Parser;
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Phinx Yaml parser
+ *
+ * @package Phinx
+ * @author Rob Morgan
+ */
+class YamlParser implements Parser
+{
+    /**
+     * Create a config array using a Yaml file
+     *
+     * @param   string  $configFilePath
+     * @return  array
+     */
+    public static function parse($configFilePath)
+    {
+        return Yaml::parse($configFilePath);
+    }
+
+}

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -66,7 +66,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         
         // test using a Yaml file without the 'default_database' key.
         // (it should default to the first one).
-        $config = \Phinx\Config\Config::fromYaml($path . '/no_default_database_key.yml');
+        $config = \Phinx\Config\Config::fromFile($path . '/no_default_database_key.yml');
         $this->assertEquals('production', $config->getDefaultEnvironment());
     }
     
@@ -78,7 +78,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     {
         // test using a Yaml file with no key or entries
         $path = __DIR__ . '/_files';
-        $config = \Phinx\Config\Config::fromYaml($path . '/empty.yml');
+        $config = \Phinx\Config\Config::fromFile($path . '/empty.yml');
         $config->getDefaultEnvironment();
     }
     
@@ -91,7 +91,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         // test using a Yaml file with a 'default_database' key, but without a
         // corresponding entry
         $path = __DIR__ . '/_files';
-        $config = \Phinx\Config\Config::fromYaml($path . '/missing_environment_entry.yml');
+        $config = \Phinx\Config\Config::fromFile($path . '/missing_environment_entry.yml');
         $config->getDefaultEnvironment();
     }
     


### PR DESCRIPTION
Hello,

I needed a custom parser since my application configuration file keeps environment information in ini files and in different keys than Phinx expects them in. Since I don't want to duplicate the information in a file Phinx can read, I modified the Phinx code.

I put the parsers logic in it's own namespace and class to support custom parsers and added an optional bootstrap argument so it can autoload my custom parser from the cli.

The --parser argument on the cli doesn't need the extension (php or yml) anymore but accepts the custom parser class, e.g. --parser=Phinx\Config\Parser\IniParser. The correct parser is loaded based on the extension of the configuration file. Yaml (.yml) and PHP are supported by default and don't need the --parser argument.
