### PR TITLE
Added support for 'ON UPDATE' column function, and updated 'timestamp' column type.

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -623,7 +623,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'datetime');
                 break;
             case 'timestamp':
-                return array('name' => 'datetime');
+                return array('name' => 'timestamp');
                 break;
             case 'time':
                 return array('name' => 'time');
@@ -770,11 +770,16 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         $def .= ($column->isNull() == false) ? ' NOT NULL' : ' NULL';
         $def .= ($column->isIdentity()) ? ' AUTO_INCREMENT' : '';
         $default = $column->getDefault();
-        if (is_numeric($default)) {
+        if (is_numeric($default) || $default == "CURRENT_TIMESTAMP") {
             $def .= ' DEFAULT ' . $column->getDefault();
         } else {
             $def .= is_null($column->getDefault()) ? '' : ' DEFAULT \'' . $column->getDefault() . '\'';
         }
+
+        if ($column->getUpdate()) {
+            $def .= " ON UPDATE {$column->getUpdate()} ";
+        }
+
         // TODO - add precision & scale for decimals
         return $def;
     }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -68,7 +68,12 @@ class Column
      * @var string
      */
     protected $after;
-    
+
+    /**
+     * @var string
+     */
+    protected $update;
+
     /**
      * Sets the column name.
      *
@@ -245,7 +250,29 @@ class Column
     {
         return $this->after;
     }
-    
+
+    /**
+     * Sets the 'ON UPDATE' mysql column function
+     *
+     * @param  string $update On Update function
+     * @return Column
+     */
+    public function setUpdate($update)
+    {
+        $this->update = $update;
+        return $this;
+    }
+
+    /**
+     * Returns the value of the ON UPDATE column function
+     *
+     * @return string
+     */
+    public function getUpdate()
+    {
+        return $this->update;
+    }
+
     /**
      * Utility method that maps an array of column options to this objects methods.
      *
@@ -255,7 +282,7 @@ class Column
     public function setOptions($options)
     {
         // Valid Options
-        $validOptions = array('limit', 'length', 'default', 'null', 'precision', 'scale', 'after');
+        $validOptions = array('limit', 'length', 'default', 'null', 'precision', 'scale', 'after', 'update');
         foreach ($options as $option => $value) {
             if (!in_array($option, $validOptions)) {
                 throw new \RuntimeException('\'' . $option . '\' is not a valid column option.');


### PR DESCRIPTION
To facilitate specifying a column as: `timestamp default current_timestamp on update current_timestamp`, I've made a couple of changes:
1. The `timestamp` column type now specifies the MySQL `timestamp` column type. This was previously the `datetime` column type, however, this column type does not support the `ON UPDATE` or `CURRENT_TIMESTAMP` options. This is the one questionable change that I have made, as it may possibly cause issues with other projects relying on the `datetime` column... thoughts?
2. When the `default` option is specified for a column with the value `CURRENT_TIMESTAMP`, it is no longer quoted into the SQL. This is needed to ensure the SQL accepts it as a function, rather than a value.
3. The `update` column option was added to provide a way to specify the MySQL function to use `ON UPDATE` for the column.

Example usage:

``` php
$table->addColumn('updated', 'timestamp', 
    Array('default' => "CURRENT_TIMESTAMP", 'update' => "CURRENT_TIMESTAMP"));
```

I'm happy to make changes if any of this doesn't fit with your design/plans for Phinx :)
