### PR TITLE
Support for arbitrary \PDO::MYSQL_ATTR_* driver options 

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -66,7 +66,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $driverOptions = array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION);
 
             // support arbitrary \PDO::MYSQL_ATTR_* driver options and pass them to PDO
-            foreach($driverOptions as $key => $option) {
+            foreach($options as $key => $option) {
                 if (strpos($key, 'mysql_attr_') === 0) {
                     $driverOptions = $driverOptions + array( constant('\PDO::' . strtoupper($key)) => $option);
                 }


### PR DESCRIPTION
These changes allow you to specify [arbitrary](http://php.net/manual/en/ref.pdo-mysql.php#pdo-mysql.constants) `\PDO::MYSQL_ATTR_*` driver options in phinx.yml.

We are using this to allow Phinx to connect to a remote MySQL server using SSL encryption, with the `\PDO::MYSQL_ATTR_SSL_CA` driver option. Our server requires SSL encryption for this user to log in, so we can't use Phinx unless it will connect over SSL.

A snipped example of our phinx.yml showing the use of this custom driver option:

```
    staging:
        adapter: mysql
        host: 1.2.3.4
        name: some_db
        user: some_user
        pass: some_pass
        mysql_attr_ssl_ca: /etc/mysql/ca-cert.pem
```

This driver option is passed to the PDO constructor, so our connection is made over SSL and authentication succeeds.

This pull request, however, allows you to supply [any one of the `MYSQL_ATTR` constants](http://php.net/manual/en/ref.pdo-mysql.php#pdo-mysql.constants) in phinx.yml and have that passed to the PDO constructor, so may be useful in any other case where setting driver options is beneficial.

To specify a driver option, add its [constant name](http://php.net/manual/en/ref.pdo-mysql.php#pdo-mysql.constants) in lowercase, not including the `\PDO::` namespace, to the correct stage in the phinx.yml file, and set the value to the desired value of that driver option.
