### PR TITLE
Fixing column names in indexes

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -815,9 +815,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $def = '';
         if ($index->getType() == Index::UNIQUE) {
-            $def .= ' UNIQUE KEY (' . implode(',', $index->getColumns()) . ')';
+            $def .= ' UNIQUE KEY (`' . implode('`,`', $index->getColumns()) . '`)';
         } else {
-            $def .= ' KEY (' . implode(',', $index->getColumns()) . ')';
+            $def .= ' KEY (`' . implode('`,`', $index->getColumns()) . '`)';
         }
         return $def;
     }


### PR DESCRIPTION
- Added quotation around index column names to prevent errors such as using "key" as a column name
