### PR TITLE
Added box.json for phar packaging with http://box-project.org/ 

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,0 +1,32 @@
+{
+    "alias": "phinx.phar",
+    "chmod": "0755",
+    "compactors": [
+        "Herrera\\Box\\Compactor\\Json",
+        "Herrera\\Box\\Compactor\\Php"
+    ],
+    "directories": ["src"],
+    "files": [
+        "LICENSE"
+    ],
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": [
+                "File",
+                "mikey179",
+                "Net",
+                "phpunit",
+                "phpunit-test-case",
+                "Tester",
+                "Tests",
+                "tests"
+            ],
+            "in": "vendor"
+        }
+    ],
+    "git-version": "git_tag",
+    "main": "bin/phinx",
+    "output": "phinx-@git-version@.phar",
+    "stub": true
+}


### PR DESCRIPTION
http://box-project.org/ greatly simplify phar creation. I found it really useful especially for command line tools like phinx. 

The box.json files defines how the library should be packaged.

Packaging is as simple as

``` bash
git clone git://github.com/robmorgan/phinx.git
cd phinx
composer install
php /path/to/box.phar build
```
