### PR TITLE
added decimal precision and scale support for mysql adapter and column class

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -786,6 +786,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         $def = '';
         $def = '';
         $def .= strtoupper($sqlType['name']);
+        if ($column->getPrecision() && $column->getScale()) {
+            $def .= '('.$column->getPrecision().','.$column->getScale().')';
+        }
         $def .= ($column->getLimit() || isset($sqlType['limit']))
                      ? '(' . ($column->getLimit() ? $column->getLimit() : $sqlType['limit']) . ')' : '';
         $def .= ($column->isNull() == false) ? ' NOT NULL' : ' NULL';
@@ -801,7 +804,6 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $def .= ' ON UPDATE ' . $column->getUpdate();
         }
 
-        // TODO - add precision & scale for decimals
         return $def;
     }
     

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -63,6 +63,16 @@ class Column
      * @var boolean
      */
     protected $identity = false;
+
+    /**
+     * @var integer
+     */
+    protected $precision;
+
+    /**
+     * @var integer
+     */
+    protected $scale;
     
     /**
      * @var string
@@ -271,6 +281,50 @@ class Column
     public function getUpdate()
     {
         return $this->update;
+    }
+
+    /**
+     * Sets the column precision for decimal.
+     *
+     * @param string $precision
+     * @return Column
+     */
+    public function setPrecision($precision)
+    {
+        $this->precision = $precision;
+        return $this;
+    }
+    
+    /**
+     * Gets the column precision for decimal.
+     *
+     * @return string
+     */
+    public function getPrecision()
+    {
+        return $this->precision;
+    }
+
+    /**
+     * Sets the column scale for decimal.
+     *
+     * @param string $scale
+     * @return Column
+     */
+    public function setScale($scale)
+    {
+        $this->scale = $scale;
+        return $this;
+    }
+    
+    /**
+     * Gets the column scale for decimal.
+     *
+     * @return string
+     */
+    public function getScale()
+    {
+        return $this->scale;
     }
 
     /**


### PR DESCRIPTION
Added methods getPrecision, setPrecision, setScale, getScale and also modified mysql adapter so that it checks for precision/scale and forms a correct field definition. So now it properly makes DECIMAL(8,2) for 'precision' = 8 and 'scale' = 2
