### PR TITLE
fixing bug where schema existance is not properly checked for some postgres installations

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -866,8 +866,8 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function hasSchema($schemaName)
     {        
         $sql = sprintf("SELECT count(*) 
-            FROM information_schema.schemata 
-            WHERE schema_name = '%s'",
+            FROM pg_namespace
+            WHERE nspname = '%s'",
             $schemaName);
         $result = $this->fetchRow($sql);
         return  $result['count'] > 0;


### PR DESCRIPTION
I ran into an issue when I setup Phinx with my Postgres DB. For some reason my information_schema.schemata table is empty, so when Phinx tries to check if a schema exists, it incorrectly said it did not. I tried uninstalling Postgres and reinstalling and the issue remained. I did some research and found that there is a more direct way to check if a schema exists, http://stackoverflow.com/a/13877950. When using the query he listed, Phinx worked fine for me. I don't think this is a common issue but one that some people might run into.
