### PR TITLE
Add support to column comments in MySQL Adapter

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -784,7 +784,6 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $sqlType = $this->getSqlType($column->getType());
         $def = '';
-        $def = '';
         $def .= strtoupper($sqlType['name']);
         if ($column->getPrecision() && $column->getScale()) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
@@ -798,6 +797,10 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $def .= ' DEFAULT ' . $column->getDefault();
         } else {
             $def .= is_null($column->getDefault()) ? '' : ' DEFAULT \'' . $column->getDefault() . '\'';
+        }
+
+        if ($column->getComment()) {
+            $def .= ' COMMENT ' . $this->getConnection()->quote($column->getComment());
         }
 
         if ($column->getUpdate()) {

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -85,6 +85,11 @@ class Column
     protected $update;
 
     /**
+     * @var string
+     */
+    protected $comment;
+
+    /**
      * Sets the column name.
      *
      * @param string $name
@@ -328,6 +333,28 @@ class Column
     }
 
     /**
+     * Sets the column comment.
+     *
+     * @param string $comment
+     * @return Column
+     */
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+        return $this;
+    }
+
+    /**
+     * Gets the column comment.
+     *
+     * @return string
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
      * Utility method that maps an array of column options to this objects methods.
      *
      * @param array $options Options
@@ -336,7 +363,7 @@ class Column
     public function setOptions($options)
     {
         // Valid Options
-        $validOptions = array('limit', 'length', 'default', 'null', 'precision', 'scale', 'after', 'update');
+        $validOptions = array('limit', 'length', 'default', 'null', 'precision', 'scale', 'after', 'update', 'comment');
         foreach ($options as $option => $value) {
             if (!in_array($option, $validOptions)) {
                 throw new \RuntimeException('\'' . $option . '\' is not a valid column option.');

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -459,4 +459,16 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->adapter->hasDatabase('temp_phinx_database'));
         $this->adapter->dropDatabase('temp_phinx_database');
     }
+
+    public function testAddColumnWithComment()
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->addColumn('column1', 'string', array('comment' => $comment = 'Comments from "column1"'))
+              ->save();
+
+        $rows = $this->adapter->fetchAll('SELECT column_name, column_comment FROM information_schema.columns WHERE table_name = "table1"');
+        $columnWithComment = $rows[1];
+
+        $this->assertEquals($comment, $columnWithComment['column_comment'], 'Dont set column comment correctly');
+    }
 }


### PR DESCRIPTION
``` php
$this->table('table1')
     ->addColumn('column1', 'string', array('comment' => 'Comments from "column1"'))
     ->save();
// expected :
// ..... column1` VARCHAR(255) NOT NULL COMMENT 'Comments from \"column1\"' ...
```
