### PR TITLE
PDO driver options bug

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -69,7 +69,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             // http://php.net/manual/en/ref.pdo-mysql.php#pdo-mysql.constants
             foreach ($options as $key => $option) {
                 if (strpos($key, 'mysql_attr_') === 0) {
-                    $driverOptions[] = array(constant('\PDO::' . strtoupper($key)) => $option);
+                    $driverOptions[constant('\PDO::' . strtoupper($key))] = $option;
                 }
             }
 


### PR DESCRIPTION
is generated bad structure for mysql connect for driver_options parameter, the structure should be the flat array.

This is in PHP documentation for this parameter:
A key=>value array of driver-specific connection options.
