### PR TITLE
Skip tests based on phpunit constant values

### DIFF
--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -14,6 +14,10 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
     
     public function setUp()
     {
+        if (!TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED) {
+            $this->markTestSkipped('Mysql tests disabled. See TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED constant.');
+        }
+
         $options = array(
             'host' => TESTS_PHINX_DB_ADAPTER_MYSQL_HOST,
             'name' => TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE,

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -14,6 +14,10 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
     
     public function setUp()
     {
+        if (!TESTS_PHINX_DB_ADAPTER_POSTGRES_ENABLED) {
+            $this->markTestSkipped('Postgres tests disabled.  See TESTS_PHINX_DB_ADAPTER_POSTGRES_ENABLED constant.');
+        }
+
         $options = array(
             'host' => TESTS_PHINX_DB_ADAPTER_POSTGRES_HOST,
             'name' => TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE, 
@@ -32,8 +36,10 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
     
     public function tearDown()
     {
-        $this->adapter->dropAllSchemas();
-        unset($this->adapter);
+        if ($this->adapter) {
+            $this->adapter->dropAllSchemas();
+            unset($this->adapter);
+        }
     }
     
     public function testConnection()


### PR DESCRIPTION
This small change takes care of disabling the MySQL/PostgreSQL adapter tests if their constant is set to false in the phpunit configuration.
