### PR TITLE
Corrected mysql biginteger default value

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -632,7 +632,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'int', 'limit' => 11);
                 break;
             case 'biginteger':
-                return array('name' => 'bigint', 'limit' => 11);
+                return array('name' => 'bigint', 'limit' => 20);
                 break;
             case 'float':
                 return array('name' => 'float');
@@ -697,7 +697,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                     }
                     break;
                 case 'bigint':
-                    if ($limit == 11) {
+                    if ($limit == 20) {
                         $limit = null;
                     }
                     $type = 'biginteger';


### PR DESCRIPTION
By default, the column type 'biginteger' should default to limit 20. Currently, it defaults to limit 11.
