### PR TITLE
Add a Phinx\Db\Table::addTimestamps() method.

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -504,6 +504,22 @@ class Table
     public function hasForeignKey($columns, $constraint = null) {
         return $this->getAdapter()->hasForeignKey($this->getName(), $columns, $constraint);
     }
+
+    /**
+     * Add timestamp columns created_at and updated_at to the table.
+     *
+     * @return Table
+     */
+    public function addTimestamps()
+    {
+        $this->addColumn('created_at', 'timestamp')
+             ->addColumn('updated_at', 'timestamp', array(
+                 'null'    => true,
+                 'default' => null
+             ));
+
+        return $this;
+    }
     
     /**
      * Creates a table from the object instance.

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -163,4 +163,22 @@ class TableTest extends \PHPUnit_Framework_TestCase
         $table = new \Phinx\Db\Table('ntable', array(), $adapterStub);
         $table->dropForeignKey('test');
     }
+
+    public function testAddTimestamps()
+    {
+        $adapter = new MysqlAdapter(array());
+        $table = new \Phinx\Db\Table('ntable', array(), $adapter);
+        $table->addTimestamps();
+
+        $columns = $table->getPendingColumns();
+
+        $this->assertEquals('created_at', $columns[0]->getName());
+        $this->assertEquals('timestamp', $columns[0]->getType());
+
+        $this->assertEquals('updated_at', $columns[1]->getName());
+        $this->assertEquals('timestamp', $columns[1]->getType());
+        $this->assertTrue($columns[1]->isNull());
+        $this->assertNull($columns[1]->getDefault());
+    }
+
 }


### PR DESCRIPTION
This method automatically create two timestamp columns: created_at and updated_at.

Using:

``` php
// ...
$table->addTimestamp();
// ...
```

your table has two more fields: `created_at` and `updated_at`, both `timestamp`.
The `create_at` field IS NOT NULL and `updated_at` accept NULL with defaults NULL.

I use `timestamp` columns to allow #68 approach like @valorin said.

@valorin I think using a decent ORM this fields can be updated using callbacks. Isn't excess code.
The updated_at field should be empty after insert statement.

@czogori I think it is a good approach the columns names are not configurable, prefer convention over configuration.
If you need different column name, you can easily add manually.

Closes #41
