### PR TITLE
Connection charset for mysql adapter made optional

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -55,12 +55,18 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $dsn = '';
             $db = null;
             $options = $this->getOptions();
+
+            // if charset is configured, set it in connection string
+            $dsnCharset = '';
+            if (isset($options['charset'])) {
+                $dsnCharset = ';charset=' . $options['charset'];
+            }
             
             // if port is specified use it, otherwise use the MySQL default
             if (isset($options['port'])) {
-                $dsn = 'mysql:host=' . $options['host'] . ';port=' . $options['port'] . ';dbname=' . $options['name'];
+                $dsn = 'mysql:host=' . $options['host'] . ';port=' . $options['port'] . ';dbname=' . $options['name'] . $dsnCharset;
             } else {
-                $dsn = 'mysql:host=' . $options['host'] . ';dbname=' . $options['name'];
+                $dsn = 'mysql:host=' . $options['host'] . ';dbname=' . $options['name'] . $dsnCharset;
             }
 
             $driverOptions = array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
I had problems setting the PDO connection to UTF-8.
[This was a working solution for me](http://stackoverflow.com/a/17891372).

That's when I figured it could be a setting for the mysql adapter, hence this PullRequest.

This is tested only in a php 5.5 environment, but should also work in lower versions of PHP.
