### PR TITLE
use `empty` to check $options['port']

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -57,10 +57,10 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $options = $this->getOptions();
             
             // if port is specified use it, otherwise use the MySQL default
-            if (isset($options['port'])) {
-                $dsn = 'mysql:host=' . $options['host'] . ';port=' . $options['port'] . ';dbname=' . $options['name'];
-            } else {
+            if (empty($options['port'])) {
                 $dsn = 'mysql:host=' . $options['host'] . ';dbname=' . $options['name'];
+            } else {
+                $dsn = 'mysql:host=' . $options['host'] . ';port=' . $options['port'] . ';dbname=' . $options['name'];
             }
 
             $driverOptions = array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
i want use the `port: %%PHINX_DBPORT%%`, but other people maybe like the default port,
so just given a empty port config.
