### PR TITLE
Added valid column types section

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -530,7 +530,6 @@ To rename a column access an instance of the Table object then call the
             }
         }
 
-        
 Working with Indexes
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I always end up routing through the source for the list of valid column types, so I'm sure there are probably others who'd benefit from having this list in the main documentation.
