### PR TITLE
Allow unknown columns to be used

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -679,7 +679,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'tinyint', 'limit' => 1);
                 break;
             default:
-                throw new \RuntimeException('The type: "' . $type . '" is not supported.');
+                return array('name' => 'type');
         }
     }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -682,7 +682,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case 'binary':
                 return array('name' => 'bytea');
             default:
-                throw new \RuntimeException('The type: "' . $type . '" is not supported');
+                return array('name' => $type);
         }
     }
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -807,7 +807,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'boolean');
                 break;
             default:
-                throw new \RuntimeException('The type: "' . $type . '" is not supported.');
+                return array('name' => $type);
         }
     }
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -433,15 +433,6 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->hasSchema('foo'));
         $this->assertFalse($this->adapter->hasSchema('bar'));
     }
-    
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The type: "idontexist" is not supported
-     */
-    public function testInvalidSqlType()
-    {
-        $this->adapter->getSqlType('idontexist');
-    }
 
     public function testGetPhinxType()
     {


### PR DESCRIPTION
Column types could be not explicitly defined in the adapter, but still be useful.

For example column types like `tinytext`, `mediumtext`, `longtext` etc. could 
be passed to `addColumn()` without having any custom configuration in Phinx 
for them whatsoever.
