### PR TITLE
Change to encourage the use of tagged releases over dev-master.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -42,7 +42,7 @@ The fastest way to install Phinx in your project is using Composer (http://getco
     ```js
     {
         "require": {
-            "robmorgan/phinx": "*"
+            "robmorgan/phinx": "~0.3.3"
         }
     }
     ```

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,7 +19,7 @@ To install Phinx simply add it as a dependency to your project's
 
     {
         "require": {
-            "robmorgan/phinx": "*"
+            "robmorgan/phinx": "~0.3.3"
         }
     }
 


### PR DESCRIPTION
Thanks to @hkdobrev for his advice, I agree with using ~0.3.3 over v0.3.3.
  Ref: #210 and #209
