### PR TITLE
Move Phinx-type references to interface constants

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -42,6 +42,21 @@ use Phinx\Migration\MigrationInterface;
  */
 interface AdapterInterface
 {
+    const PHINX_TYPE_PRIMARY_KEY    = 'primary_key';
+    const PHINX_TYPE_STRING         = 'string';
+    const PHINX_TYPE_TEXT           = 'text';
+    const PHINX_TYPE_INTEGER        = 'integer';
+    const PHINX_TYPE_BIG_INTEGER    = 'biginteger';
+    const PHINX_TYPE_FLOAT          = 'float';
+    const PHINX_TYPE_DECIMAL        = 'decimal';
+    const PHINX_TYPE_DATETIME       = 'datetime';
+    const PHINX_TYPE_TIMESTAMP      = 'timestamp';
+    const PHINX_TYPE_TIME           = 'time';
+    const PHINX_TYPE_DATE           = 'date';
+    const PHINX_TYPE_BINARY         = 'binary';
+    const PHINX_TYPE_BOOLEAN        = 'boolean';
+    const PHINX_TYPE_JSON           = 'json';
+
     /**
      * Get all migrated version numbers.
      *

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -665,42 +665,42 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     public function getSqlType($type)
     {
         switch ($type) {
-            case 'primary_key':
+            case static::PHINX_TYPE_PRIMARY_KEY:
                 return self::DEFAULT_PRIMARY_KEY;
-            case 'string':
+            case static::PHINX_TYPE_STRING:
                 return array('name' => 'varchar', 'limit' => 255);
                 break;
-            case 'text':
+            case static::PHINX_TYPE_TEXT:
                 return array('name' => 'text');
                 break;
-            case 'integer':
+            case static::PHINX_TYPE_INTEGER:
                 return array('name' => 'int', 'limit' => 11);
                 break;
-            case 'biginteger':
+            case static::PHINX_TYPE_BIG_INTEGER:
                 return array('name' => 'bigint', 'limit' => 20);
                 break;
-            case 'float':
+            case static::PHINX_TYPE_FLOAT:
                 return array('name' => 'float');
                 break;
-            case 'decimal':
+            case static::PHINX_TYPE_DECIMAL:
                 return array('name' => 'decimal');
                 break;
-            case 'datetime':
+            case static::PHINX_TYPE_DATETIME:
                 return array('name' => 'datetime');
                 break;
-            case 'timestamp':
+            case static::PHINX_TYPE_TIMESTAMP:
                 return array('name' => 'timestamp');
                 break;
-            case 'time':
+            case static::PHINX_TYPE_TIME:
                 return array('name' => 'time');
                 break;
-            case 'date':
+            case static::PHINX_TYPE_DATE:
                 return array('name' => 'date');
                 break;
-            case 'binary':
+            case static::PHINX_TYPE_BINARY:
                 return array('name' => 'blob');
                 break;
-            case 'boolean':
+            case static::PHINX_TYPE_BOOLEAN:
                 return array('name' => 'tinyint', 'limit' => 1);
                 break;
             default:
@@ -730,13 +730,13 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             }
             switch ($matches[1]) {
                 case 'varchar':
-                    $type = 'string';
+                    $type = static::PHINX_TYPE_STRING;
                     if ($limit == 255) {
                         $limit = null;
                     }
                     break;
                 case 'int':
-                    $type = 'integer';
+                    $type = static::PHINX_TYPE_INTEGER;
                     if ($limit == 11) {
                         $limit = null;
                     }
@@ -745,15 +745,15 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                     if ($limit == 20) {
                         $limit = null;
                     }
-                    $type = 'biginteger';
+                    $type = static::PHINX_TYPE_BIG_INTEGER;
                     break;
                 case 'blob':
-                    $type = 'binary';
+                    $type = static::PHINX_TYPE_BINARY;
                     break;
             }
             if ($type == 'tinyint') {
                 if ($matches[3] == 1) {
-                    $type = 'boolean';
+                    $type = static::PHINX_TYPE_BOOLEAN;
                     $limit = null;
                 }
             }

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -690,24 +690,24 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function getSqlType($type)
     {
         switch ($type) {
-            case 'integer':
-            case 'text':
-            case 'decimal':
-            case 'time':
-            case 'date':
-            case 'boolean':
-            case 'json':
+            case static::PHINX_TYPE_INTEGER:
+            case static::PHINX_TYPE_TEXT:
+            case static::PHINX_TYPE_DECIMAL:
+            case static::PHINX_TYPE_TIME:
+            case static::PHINX_TYPE_DATE:
+            case static::PHINX_TYPE_BOOLEAN:
+            case static::PHINX_TYPE_JSON:
                 return array('name' => $type);
-            case 'string':
+            case static::PHINX_TYPE_STRING:
                 return array('name' => 'character varying', 'limit' => 255);
-            case 'biginteger':
+            case static::PHINX_TYPE_BIG_INTEGER:
                 return array('name' => 'bigint');
-            case 'float':
+            case static::PHINX_TYPE_FLOAT:
                 return array('name' => 'real');
-            case 'datetime':
-            case 'timestamp':
+            case static::PHINX_TYPE_DATETIME:
+            case static::PHINX_TYPE_TIMESTAMP:
                 return array('name' => 'timestamp');
-            case 'binary':
+            case static::PHINX_TYPE_BINARY:
                 return array('name' => 'bytea');
             default:
                 throw new \RuntimeException('The type: "' . $type . '" is not supported');
@@ -725,41 +725,41 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         switch ($sqlType) {
             case 'character varying':
             case 'varchar':
-                return 'string';
+                return static::PHINX_TYPE_STRING;
             case 'text':
             case 'json':
-                return 'text';
+                return static::PHINX_TYPE_TEXT;
             case 'int':
             case 'int4':
             case 'integer':
-                return 'integer';
+                return static::PHINX_TYPE_INTEGER;
             case 'decimal':
             case 'numeric':
-                return 'decimal';
+                return static::PHINX_TYPE_DECIMAL;
             case 'bigint':
             case 'int8':
-                return 'biginteger';
+                return static::PHINX_TYPE_BIG_INTEGER;
             case 'real':
             case 'float4':
-                return 'float';
+                return static::PHINX_TYPE_FLOAT;
             case 'bytea':
-                return 'binary';
+                return static::PHINX_TYPE_BINARY;
                 break;
             case 'time':
             case 'timetz':
             case 'time with time zone':
             case 'time without time zone':
-                return 'time';
+                return static::PHINX_TYPE_TIME;
             case 'date':
-                return 'date';
+                return static::PHINX_TYPE_DATE;
             case 'timestamp':
             case 'timestamptz':
             case 'timestamp with time zone':
             case 'timestamp without time zone':
-                return 'datetime';
+                return static::PHINX_TYPE_DATETIME;
             case 'bool':
             case 'boolean':
-                return 'boolean';
+                return static::PHINX_TYPE_BOOLEAN;
             default:
                 throw new \RuntimeException('The PostgreSQL type: "' . $sqlType . '" is not supported');
         }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -787,42 +787,42 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     public function getSqlType($type)
     {
         switch ($type) {
-            case 'primary_key':
+            case static::PHINX_TYPE_PRIMARY_KEY:
                 return self::DEFAULT_PRIMARY_KEY;
-            case 'string':
+            case static::PHINX_TYPE_STRING:
                 return array('name' => 'varchar', 'limit' => 255);
                 break;
-            case 'text':
+            case static::PHINX_TYPE_TEXT:
                 return array('name' => 'text');
                 break;
-            case 'integer':
+            case static::PHINX_TYPE_INTEGER:
                 return array('name' => 'integer');
                 break;
-            case 'biginteger':
+            case static::PHINX_TYPE_BIG_INTEGER:
                 return array('name' => 'bigint');
                 break;
-            case 'float':
+            case static::PHINX_TYPE_FLOAT:
                 return array('name' => 'float');
                 break;
-            case 'decimal':
+            case static::PHINX_TYPE_DECIMAL:
                 return array('name' => 'decimal');
                 break;
-            case 'datetime':
+            case static::PHINX_TYPE_DATETIME:
                 return array('name' => 'datetime');
                 break;
-            case 'timestamp':
+            case static::PHINX_TYPE_TIMESTAMP:
                 return array('name' => 'datetime');
                 break;
-            case 'time':
+            case static::PHINX_TYPE_TIME:
                 return array('name' => 'time');
                 break;
-            case 'date':
+            case static::PHINX_TYPE_DATE:
                 return array('name' => 'date');
                 break;
-            case 'binary':
+            case static::PHINX_TYPE_BINARY:
                 return array('name' => 'blob');
                 break;
-            case 'boolean':
+            case static::PHINX_TYPE_BOOLEAN:
                 return array('name' => 'boolean');
                 break;
             default:
@@ -852,13 +852,13 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             }
             switch ($matches[1]) {
                 case 'varchar':
-                    $type = 'string';
+                    $type = static::PHINX_TYPE_STRING;
                     if ($limit == 255) {
                         $limit = null;
                     }
                     break;
                 case 'int':
-                    $type = 'integer';
+                    $type = static::PHINX_TYPE_INTEGER;
                     if ($limit == 11) {
                         $limit = null;
                     }
@@ -867,15 +867,15 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                     if ($limit == 11) {
                         $limit = null;
                     }
-                    $type = 'biginteger';
+                    $type = static::PHINX_TYPE_BIG_INTEGER;
                     break;
                 case 'blob':
-                    $type = 'binary';
+                    $type = static::PHINX_TYPE_BINARY;
                     break;
             }
             if ($type == 'tinyint') {
                 if ($matches[3] == 1) {
-                    $type = 'boolean';
+                    $type = static::PHINX_TYPE_BOOLEAN;
                     $limit = null;
                 }
             }


### PR DESCRIPTION
By moving the Phinx types to constants, code within the adapters is more readable. The adapter-specific column type strings are clearly distinguishable from the abstract Phinx types (both were represented as similarly formatted strings). As well, having the tool's supported types collected together in the `AdapterInterface` definition helps in understanding the code's architecture, and will facilitate developing new adapters.
