### PR TITLE
Updates self:: References to static::

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -666,7 +666,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         switch ($type) {
             case 'primary_key':
-                return self::DEFAULT_PRIMARY_KEY;
+                return static::DEFAULT_PRIMARY_KEY;
             case 'string':
                 return array('name' => 'varchar', 'limit' => 255);
                 break;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -788,7 +788,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     {
         switch ($type) {
             case 'primary_key':
-                return self::DEFAULT_PRIMARY_KEY;
+                return static::DEFAULT_PRIMARY_KEY;
             case 'string':
                 return array('name' => 'varchar', 'limit' => 255);
                 break;

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -220,8 +220,8 @@ class ForeignKey
 
             // handle $options['delete'] as $options['update']
             if (strtolower($option) == 'delete' || strtolower($option) == 'update') {
-                if (defined('self::' . strtoupper($value))) {
-                    $this->{'setOn' . ucfirst(strtolower($option))}(constant('self::' . strtoupper($value)));
+                if (defined('static::' . strtoupper($value))) {
+                    $this->{'setOn' . ucfirst(strtolower($option))}(constant('static::' . strtoupper($value)));
                 }
             } else {
                 $method = 'set' . ucfirst($option);

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -126,8 +126,8 @@ class Index
             }
             
             // handle $options['unique']
-            if (strtolower($option) == self::UNIQUE) {
-                $this->setType(self::UNIQUE);
+            if (strtolower($option) == static::UNIQUE) {
+                $this->setType(static::UNIQUE);
                 continue;
             }
 


### PR DESCRIPTION
Replaces several `self::` references with late static binding `static::` references, which gives a more predictable inherited reference behaviour.
