### PR TITLE
Removes PRIMARY KEY column type

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -42,7 +42,6 @@ use Phinx\Migration\MigrationInterface;
  */
 interface AdapterInterface
 {
-    const PHINX_TYPE_PRIMARY_KEY    = 'primary_key';
     const PHINX_TYPE_STRING         = 'string';
     const PHINX_TYPE_TEXT           = 'text';
     const PHINX_TYPE_INTEGER        = 'integer';

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -668,8 +668,6 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     public function getSqlType($type)
     {
         switch ($type) {
-            case static::PHINX_TYPE_PRIMARY_KEY:
-                return self::DEFAULT_PRIMARY_KEY;
             case static::PHINX_TYPE_STRING:
                 return array('name' => 'varchar', 'limit' => 255);
                 break;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -787,8 +787,6 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     public function getSqlType($type)
     {
         switch ($type) {
-            case static::PHINX_TYPE_PRIMARY_KEY:
-                return self::DEFAULT_PRIMARY_KEY;
             case static::PHINX_TYPE_STRING:
                 return array('name' => 'varchar', 'limit' => 255);
                 break;


### PR DESCRIPTION
Primary key is a column option/attribute, not a column data type. References to this deprecated concept are removed. Users should be unaffected by this change, as the column type had an undefined constant, and therefore would have prevented any attempts to use it.
