### PR TITLE
Removes 'primary key' column type reference from documentation

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -373,7 +373,6 @@ Valid Column Types
 
 Column types are specified as strings and can be one of: 
 
--  primary_key
 -  string
 -  text
 -  integer


### PR DESCRIPTION
The `primary key` column type was removed in a previously merged pull request. This pull request removes  a reference to that as an available type from the documentation.
