### PR TITLE
Using a more clear case naming

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -80,7 +80,7 @@ class Create extends AbstractCommand
         
         if (!Util::isValidMigrationClassName($className)) {
             throw new \InvalidArgumentException(sprintf(
-                'The migration class name "%s" is invalid. Please use CamelCase format.',
+                'The migration class name "%s" is invalid. Please use PascalCase format.',
                 $className
             ));
         }


### PR DESCRIPTION
Pascal case has many variations. The variation with the first letter being an uppercase letter is known as "PascalCase", and the variation with the first letter being lower is known as "camelCase". This change aims to avoid confusion.
