### PR TITLE
Moves a MySQL-specific method to the MySQL adapter from the PDO adapter

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -916,4 +916,26 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         }
         return $def;
     }
+
+    /**
+     * Describes a database table. This is a MySQL adapter specific method.
+     * @return array
+     */
+    public function describeTable($tableName)
+    {
+        $options = $this->getOptions();
+
+        // mysql specific
+        $sql = sprintf(
+            'SELECT *'
+            . ' FROM information_schema.tables'
+            . ' WHERE table_schema = "%s"'
+            . ' AND table_name = "%s"',
+            $options['name'],
+            $tableName
+        );
+
+        return $this->fetchRow($sql);
+    }
+
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -351,30 +351,7 @@ abstract class PdoAdapter implements AdapterInterface
 
         return $this;
     }
-    
-    /**
-     * Describes a database table.
-     *
-     * @todo MySQL Specific so move to MysqlAdapter.
-     * @return array
-     */
-    public function describeTable($tableName)
-    {
-        $options = $this->getOptions();
-        
-        // mysql specific
-        $sql = sprintf(
-            'SELECT *'
-            . ' FROM information_schema.tables'
-            . ' WHERE table_schema = "%s"'
-            . ' AND table_name = "%s"',
-            $options['name'],
-            $tableName
-        );
-        
-        return $this->fetchRow($sql);
-    }
-    
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
It's a MySQL specific method, with a MySQL specific query, marked  with an `@TODO` to move it to the MySQL adapter. MySQLMySQLMySQL.

The method's not mentioned anywhere else in the code-base, but it's a public method, so who knows how it's being used. Removing it might break someone's use, but I can't see how moving it to the MYSQL adapter would: `PDOAdapter` is abstract, and the method call wouldn't have worked on anything but `MysqlAdapter`, so it seems like a safe bet.

Or go newkular, and just remove it. Or implement an equivalent for the other languages (`\d+`, something to do with the [sqlite_master](http://www.sqlite.org/faq.html#q7) table), but that's a PR for someone else.
