### PR TITLE
Added mysql support for

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -57,6 +57,12 @@ interface AdapterInterface
     const PHINX_TYPE_JSON           = 'json';
     const PHINX_TYPE_UUID           = 'uuid';
     const PHINX_TYPE_FILESTREAM     = 'filestream';
+    const PHINX_TYPE_DOUBLE			= 'double';
+    const PHINX_TYPE_LONGBLOB		= 'longblob';
+    const PHINX_TYPE_MEDIUMTEXT		= 'mediumtext';
+    const PHINX_TYPE_TINYINT		= 'tinyint';
+    const PHINX_TYPE_BIT			= 'bit';
+    const PHINX_TYPE_CHAR			= 'char';
 
     /**
      * Get all migrated version numbers.

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -707,6 +707,24 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_BOOLEAN:
                 return array('name' => 'tinyint', 'limit' => 1);
                 break;
+            case static::PHINX_TYPE_DOUBLE:
+                return array('name' => 'double');
+                break;
+            case static::PHINX_TYPE_LONGBLOB:
+                return array('name' => 'longblob');
+                break;
+            case static::PHINX_TYPE_MEDIUMTEXT:
+                return array('name' => 'mediumtext');
+                break;
+            case static::PHINX_TYPE_TINYINT:
+                return array('name' => 'tinyint');
+                break;
+            case static::PHINX_TYPE_BIT:
+                return array('name' => 'bit');
+                break;
+            case static::PHINX_TYPE_CHAR:
+                return array('name' => 'char');
+                break;
             default:
                 throw new \RuntimeException('The type: "' . $type . '" is not supported.');
         }
@@ -756,12 +774,6 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 case 'blob':
                     $type = static::PHINX_TYPE_BINARY;
                     break;
-            }
-            if ($type == 'tinyint') {
-                if ($matches[3] == 1) {
-                    $type = static::PHINX_TYPE_BOOLEAN;
-                    $limit = null;
-                }
             }
 
             $this->getSqlType($type);
@@ -845,10 +857,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         $default = $column->getDefault();
         if (is_numeric($default) || $default == 'CURRENT_TIMESTAMP') {
             $def .= ' DEFAULT ' . $column->getDefault();
-        } else {
+        } else { 
             $def .= is_null($column->getDefault()) ? '' : ' DEFAULT \'' . $column->getDefault() . '\'';
         }
-
         if ($column->getComment()) {
             $def .= ' COMMENT ' . $this->getConnection()->quote($column->getComment());
         }
@@ -896,24 +907,23 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         $def = '';
         if ($foreignKey->getConstraint()) {
             $def .= ' CONSTRAINT ' . $this->quoteColumnName($foreignKey->getConstraint());
-        } else {
-            $columnNames = array();
-            foreach ($foreignKey->getColumns() as $column) {
-                $columnNames[] = $this->quoteColumnName($column);
-            }
-            $def .= ' FOREIGN KEY (' . implode(',', $columnNames) . ')';
-            $refColumnNames = array();
-            foreach ($foreignKey->getReferencedColumns() as $column) {
-                $refColumnNames[] = $this->quoteColumnName($column);
-            }
-            $def .= ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()->getName()) . ' (' . implode(',', $refColumnNames) . ')';
-            if ($foreignKey->getOnDelete()) {
-                $def .= ' ON DELETE ' . $foreignKey->getOnDelete();
-            }
-            if ($foreignKey->getOnUpdate()) {
-                $def .= ' ON UPDATE ' . $foreignKey->getOnUpdate();
-            }
-        }
+        } 
+		$columnNames = array();
+		foreach ($foreignKey->getColumns() as $column) {
+			$columnNames[] = $this->quoteColumnName($column);
+		}
+		$def .= ' FOREIGN KEY (' . implode(',', $columnNames) . ')';
+		$refColumnNames = array();
+		foreach ($foreignKey->getReferencedColumns() as $column) {
+			$refColumnNames[] = $this->quoteColumnName($column);
+		}
+		$def .= ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()->getName()) . ' (' . implode(',', $refColumnNames) . ')';
+		if ($foreignKey->getOnDelete()) {
+			$def .= ' ON DELETE ' . $foreignKey->getOnDelete();
+		}
+		if ($foreignKey->getOnUpdate()) {
+			$def .= ' ON UPDATE ' . $foreignKey->getOnUpdate();
+		}
         return $def;
     }
 

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -406,7 +406,13 @@ abstract class PdoAdapter implements AdapterInterface
             'time',
             'date',
             'binary',
-            'boolean'
+            'boolean',
+			'double',
+			'longblob',
+			'mediumtext',
+			'tinyint',
+			'bit',
+			'char'
         );
     }
 }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -173,7 +173,7 @@ class Column
      */
     public function setNull($null)
     {
-        $this->null = (bool) $null;
+        $this->null = (bool) $null; 
         return $this;
     }
     
@@ -205,9 +205,9 @@ class Column
      */
     public function setDefault($default)
     {
-        if ($default === false || $default === '') {
+        if ($default === false) {
             $default = null;
-        }
+		}
         $this->default = $default;
         return $this;
     }

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -125,10 +125,9 @@ class Index
             if (!in_array($option, $validOptions)) {
                 throw new \RuntimeException('\'' . $option . '\' is not a valid index option.');
             }
-            
             // handle $options['unique']
             if (strtolower($option) == self::UNIQUE) {
-                $this->setType(self::UNIQUE);
+				if( (bool)$value ) $this->setType(self::UNIQUE);
                 continue;
             }
 


### PR DESCRIPTION
Folks: my goal is to use phinx to create a set of migration scripts for a database of 164 tables to be able to then migrate all the tables to a new DB, do a diff and not see any discrepancies between the old and the new.  
double. These changes have allowed that to happen.

Datatypes added:
longblob
mediumtext
tinyint
bit
char

Corrected/added support for default column value for the mysql "empty string" value
Corrected Unique index handling...was always true no matter the value.
Corrected foreign key constraint name handling...did not provide a way to name a foreign key contraint.

My client would appreciate being able to update with composer.

I noticed that github shows spacing issues. I cannot see these descrepancies in my dev environment, so if you have any comments, please direct me.  (4 spaces per indent). 

Signed-off-by: Jonathan Galpin jonathan@iqzero.net
