### PR TITLE
Bugfix

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -177,7 +177,6 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                    ->setIdentity(true);
             
             array_unshift($columns, $column);
-            $options['primary_key'] = 'id';
 
         } elseif (isset($options['id']) && is_string($options['id'])) {
             // Handle id => "field_name" to support AUTO_INCREMENT
@@ -187,7 +186,6 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                    ->setIdentity(true);
 
             array_unshift($columns, $column);
-            $options['primary_key'] = $options['id'];
         }
         
         
@@ -283,9 +281,9 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $column->setType($phinxType['name'])
                    ->setLimit($phinxType['limit']);
 
-            // if ($columnInfo['Extra'] == 'auto_increment') {
-            //     $column->setIdentity(true);
-            // }
+            if ($columnInfo['pk'] == 1) {
+                $column->setIdentity(true);
+            }
 
             $columns[] = $column;
         }
@@ -422,7 +420,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName));
 
         $sql = preg_replace(
-            sprintf("/%s[^,]*/", $this->quoteColumnName($columnName)),
+            sprintf("/%s[^,]*[^\)]/", $this->quoteColumnName($columnName)),
             sprintf("%s %s", $this->quoteColumnName($newColumn->getName()), $this->getColumnSqlDefinition($newColumn)),
             $sql
         );
@@ -950,6 +948,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                 $def .= ' DEFAULT '  . $column->getDefault();
             }
         }
+        $def .= ($column->isIdentity()) ? ' PRIMARY KEY AUTOINCREMENT' : '';
 
         if ($column->getUpdate()) {
             $def .= ' ON UPDATE ' . $column->getUpdate();


### PR DESCRIPTION
- Fixed implementation of SQLite autoincrement that was commented. In SQLite, if exist a field with autoincrement, the primary key definition must be in the line of field and not at the end of create table
- Fixed the regular expression changeColumn method that caused this error to modify the attributes of the column
