### PR TITLE
Correct SqlServer charset

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -68,12 +68,12 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
             }
             $dsn .= ';MultipleActiveResultSets=false';
             
-            // charset support
-            if (isset($options['charset'])) {
-                $dsn .= ';charset=' . $options['charset'];
-            }
-
             $driverOptions = array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION);
+
+	        // charset support
+	        if (isset($options['charset'])) {
+		        $driverOptions[\PDO::SQLSRV_ATTR_ENCODING] = $options['charset'];
+	        }
 
             // support arbitrary \PDO::SQLSRV_ATTR_* driver options and pass them to PDO
             // http://php.net/manual/en/ref.pdo-sqlsrv.php#pdo-sqlsrv.constants


### PR DESCRIPTION
SqlServer charset is not done via the DSN, but via a driver flag/option.
