### PR TITLE
Updates documentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,6 +27,21 @@ The first option specifies the path to your migration directory. Phinx uses
     ``%%PHINX_CONFIG_DIR%%`` is a special token and is automatically replaced
     with the root directory where your ``phinx.yml`` file is stored.
 
+In order to overwrite the default ``%%PHINX_CONFIG_DIR%%/migrations``, you need
+to add the following to the yaml configuration.
+
+.. code-block:: yaml
+
+    paths:
+        migrations: /your/full/path
+
+You can also use the ``%%PHINX_CONFIG_DIR%%`` token in your path.
+
+.. code-block:: yaml
+
+    paths:
+        migrations: %%PHINX_CONFIG_DIR%%/your/relative/path
+
 Environments
 ------------
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -803,6 +803,8 @@ The following are valid column options:
 You can pass one or more of these options to any column with the optional
 third argument array.
 
+The default and update column options can accept 'CURRENT_TIMESTAMP' as a value.
+
 The Save Method
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I just added a few things to the documentation.
- The migrations folder in the yaml
- The fact that you can specify 'CURRENT_TIMESTAMP' as a string in the migration.
