### PR TITLE
Table prefix and suffix support

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -82,6 +82,13 @@ EOT
         $envOptions = $this->getConfig()->getEnvironment($environment);
         $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
         $output->writeln('<info>using database</info> ' . $envOptions['name']);
+        
+        if (isset($envOptions['table_prefix'])) {
+            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix']);
+        }
+        if (isset($envOptions['table_suffix'])) {
+            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
+        }
 
         // run the migrations
         $start = microtime(true);

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -1,0 +1,533 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2014 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * 
+ * @package    Phinx
+ * @subpackage Phinx\Db\Adapter
+ */
+namespace Phinx\Db\Adapter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Phinx\Db\Table;
+use Phinx\Db\Table\Column;
+use Phinx\Db\Table\Index;
+use Phinx\Db\Table\ForeignKey;
+use Phinx\Migration\MigrationInterface;
+
+/**
+ * Table prefix/suffix adapter.
+ *
+ * Used for inserting a prefix or suffix into table names.
+ *
+ * @author Samuel Fisher <sam@sfisher.co>
+ */
+class TablePrefixAdapter implements AdapterInterface
+{
+    /**
+     * @var AdapterInterface
+     */
+    protected $adapter;
+    
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+        
+    /**
+     * @var array
+     */
+    protected $commands;
+    
+    /**
+     * Class Constructor.
+     *
+     * @param array $options Options
+     * @param AdapterInterface $adapter The adapter to proxy commands to
+     * @return void
+     */
+    public function __construct(array $options, AdapterInterface $adapter = null)
+    {
+        $this->setOptions($options);
+        if (null !== $adapter) {
+            $this->setAdapter($adapter);
+        }
+    }
+    
+    /**
+     * Sets the database adapter to proxy commands to.
+     *
+     * @param AdapterInterface $adapter Database Adapter
+     * @return AdapterInterface
+     */
+    public function setAdapter(AdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+        return $this;
+    }
+    
+    /**
+     * Gets the database adapter.
+     *
+     * @return AdapterInterface
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+    
+    /**
+     * Sets the adapter options.
+     *
+     * @param array $options Options
+     * @return AdapterInterface
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+        return $this;
+    }
+    
+    /**
+     * Gets the adapter options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function setOutput(OutputInterface $output)
+    {
+        $this->adapter->setOutput($output);
+        return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getOutput()
+    {
+        return $this->adapter->getOutput();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function connect()
+    {
+        $this->getAdapter()->connect();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function disconnect()
+    {
+        $this->getAdapter()->disconnect();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($sql)
+    {
+        return $this->getAdapter()->execute($sql);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function query($sql)
+    {
+        return $this->getAdapter()->query($sql);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchRow($sql)
+    {
+        return $this->getAdapter()->fetchRow($sql);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAll($sql)
+    {
+        return $this->getAdapter()->fetchAll($sql);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersions()
+    {
+        return $this->getAdapter()->getVersions();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
+    {
+        $this->getAdapter()->migrated($migration, $direction, $startTime, $endTime);
+        return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaTable()
+    {
+        return $this->getAdapter()->hasSchemaTable();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function createSchemaTable()
+    {
+        return $this->getAdapter()->createSchemaTable();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdapterType()
+    {
+        return 'ProxyAdapter';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnTypes()
+    {
+        return $this->getAdapter()->getColumnTypes();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function hasTransactions()
+    {
+        return $this->getAdapter()->hasTransactions();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function beginTransaction()
+    {
+        return $this->getAdapter()->beginTransaction();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function commitTransaction()
+    {
+        return $this->getAdapter()->commitTransaction();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function rollbackTransaction()
+    {
+        return $this->getAdapter()->rollbackTransaction();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function quoteTableName($tableName)
+    {
+        return $this->getAdapter()->quoteTableName($tableName);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function quoteColumnName($columnName)
+    {
+        return $this->getAdapter()->quoteColumnName($columnName);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function hasTable($tableName)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        return $this->getAdapter()->hasTable($adapterTableName);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function createTable(Table $table)
+    {
+        $adapterTable = clone $table;
+        $adapterTableName = $this->getAdapterTableName($table->getName());
+        $adapterTable->setName($adapterTableName);
+        $this->getAdapter()->createTable($adapterTable);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function renameTable($tableName, $newTableName)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        $adapterNewTableName = $this->getAdapterTableName($newTableName);
+        $this->getAdapter()->renameTable($adapterTableName, $adapterNewTableName);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function dropTable($tableName)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        $this->getAdapter()->dropTable($adapterTableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumns($tableName)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        return $this->getAdapter()->getColumns($adapterTableName);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function hasColumn($tableName, $columnName)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        return $this->getAdapter()->hasColumn($adapterTableName, $columnName);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function addColumn(Table $table, Column $column)
+    {
+        $adapterTable = clone $table;
+        $adapterTableName = $this->getAdapterTableName($table->getName());
+        $adapterTable->setName($adapterTableName);
+        $this->getAdapter()->addColumn($adapterTable, $column);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function renameColumn($tableName, $columnName, $newColumnName)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        $this->getAdapter()->renameColumn($adapterTableName, $columnName, $newColumnName);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function changeColumn($tableName, $columnName, Column $newColumn)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        $this->getAdapter()->changeColumn($adapterTableName, $columnName, $newColumn);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function dropColumn($tableName, $columnName)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        $this->getAdapter()->dropColumn($adapterTableName, $columnName);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function hasIndex($tableName, $columns)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        return $this->getAdapter()->hasIndex($adapterTableName, $columns);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function addIndex(Table $table, Index $index)
+    {
+        $adapterTable = clone $table;
+        $adapterTableName = $this->getAdapterTableName($table->getName());
+        $adapterTable->setName($adapterTableName);
+        $this->getAdapter()->addIndex($adapterTable, $index);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function dropIndex($tableName, $columns, $options = array())
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        $this->getAdapter()->dropIndex($adapterTableName, $columns, $options);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function dropIndexByName($tableName, $indexName)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        $this->getAdapter()->dropIndexByName($adapterTableName, $indexName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasForeignKey($tableName, $columns, $constraint = null)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        return $this->getAdapter()->hasForeignKey($adapterTableName, $columns, $constraint);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function addForeignKey(Table $table, ForeignKey $foreignKey)
+    {
+        $adapterTable = clone $table;
+        $adapterTableName = $this->getAdapterTableName($table->getName());
+        $adapterTable->setName($adapterTableName);
+        $this->getAdapter()->addForeignKey($adapterTable, $foreignKey);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dropForeignKey($tableName, $columns, $constraint = null)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        $this->getAdapter()->dropForeignKey($adapterTableName, $columns, $constraint);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getSqlType($type)
+    {
+        return $this->getAdapter()->getSqlType($type);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function createDatabase($name, $options = array())
+    {
+        $this->getAdapter()->createDatabase($name, $options);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function hasDatabase($name)
+    {
+        return $this->getAdapter()->hasDatabase($name);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function dropDatabase($name)
+    {
+        return $this->getAdapter()->dropDatabase($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection() {
+        return $this->getAdapter()->getConnection();
+    }
+    
+    /**
+     * Gets the table prefix.
+     * 
+     * @return string
+     */
+    public function getPrefix() {
+        return isset($this->options['table_prefix'])
+            ? $this->options['table_prefix']
+            : '';
+    }
+    
+    /**
+     * Sets the table prefix.
+     * 
+     * @param string $prefix
+     */
+    public function setPrefix($prefix) {
+        $this->options['table_prefix'] = $prefix;
+    }
+    
+    /**
+     * Gets the table suffix.
+     * 
+     * @return string
+     */
+    public function getSuffix() {
+        return isset($this->options['table_suffix'])
+            ? $this->options['table_suffix']
+            : '';
+    }
+    
+    /**
+     * Sets the table suffix.
+     * 
+     * @param string $suffix
+     */
+    public function setSuffix($suffix) {
+        $this->options['table_suffix'] = $suffix;
+    }
+    
+    /**
+     * Applies the prefix and suffix to the table name.
+     * 
+     * @param string $tableName
+     * @return string
+     */
+    public function getAdapterTableName($tableName) {
+        return $this->getPrefix() . $tableName . $this->getSuffix();
+    }
+}

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -35,6 +35,7 @@ use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Db\Adapter\PostgresAdapter;
 use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Db\Adapter\ProxyAdapter;
+use Phinx\Db\Adapter\TablePrefixAdapter;
 use Phinx\Migration\MigrationInterface;
 
 class Environment
@@ -302,6 +303,12 @@ class Environment
         if (!$adapter instanceof AdapterInterface) {
             throw new \RuntimeException('Adapter factory closure did not return an instance of \\Phinx\\Db\\Adapter\\AdapterInterface');
         }
+        
+        // Use the TablePrefixAdapter if table prefix/suffixes are in use
+        if (isset($this->options['table_prefix']) || isset($this->options['table_suffix'])) {
+            $adapter = new TablePrefixAdapter($this->options, $adapter);
+        }
+        
         return $this->adapter = $adapter;
     }
     

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Test\Phinx\Db\Adapter;
+
+use Phinx\Db\Adapter\TablePrefixAdapter;
+use Phinx\Db\Table;
+use Phinx\Db\Table\Column;
+use Phinx\Db\Table\ForeignKey;
+
+class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Phinx\Db\Adapter\TablePrefixAdapter
+     */
+    private $adapter;
+    
+    public function setUp()
+    {
+        $this->adapter = new TablePrefixAdapter(array(
+            'table_prefix' => 'pre_',
+            'table_suffix' => '_suf'
+            ));
+    }
+    
+    protected function getMockAdapter() {
+        return $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+    }
+    
+    public function tearDown()
+    {
+        unset($this->adapter);
+    }
+    
+    public function testGetAdapterTableName() {
+        $tableName = $this->adapter->getAdapterTableName('table');    
+        $this->assertEquals('pre_table_suf', $tableName);
+    }
+    
+    public function testHasTable() {
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('hasTable')
+             ->with($this->equalTo('pre_table_suf'));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->hasTable('table');
+    }
+    
+    public function testCreateTable() {
+        $table = new Table('table');
+        
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('createTable')
+             ->with($this->callback(function($table) {
+                 return $table->getName() == 'pre_table_suf';
+             }));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->createTable($table);
+    }
+    
+    public function testRenameTable() {
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('renameTable')
+             ->with($this->equalTo('pre_old_suf'),
+                    $this->equalTo('pre_new_suf'));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->renameTable('old', 'new');
+    }
+    
+    public function testDropTable() {
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('dropTable')
+             ->with($this->equalTo('pre_table_suf'));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->dropTable('table');
+    }
+    
+    public function testGetColumns() {
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('getColumns')
+             ->with($this->equalTo('pre_table_suf'));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->getColumns('table');
+    }
+    
+    public function testHasColumn() {
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('hasColumn')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo('column'));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->hasColumn('table', 'column');
+    }
+    
+    public function testAddColumn() {
+        $table = new Table('table');
+        $column = new Column();
+        
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('addColumn')
+             ->with($this->callback(function($table) {
+                 return $table->getName() == 'pre_table_suf';
+             }, $this->equalTo($column)));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->addColumn($table, $column);
+    }
+    
+    public function testRenameColumn() {
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('renameColumn')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo('column'),
+                    $this->equalTo('new_column'));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->renameColumn('table', 'column', 'new_column');
+    }
+    
+    public function testChangeColumn() {
+        $newColumn = new Column();
+        
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('changeColumn')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo('column'),
+                    $this->equalTo($newColumn));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->changeColumn('table', 'column', $newColumn);
+    }
+    
+    public function testDropColumn() {
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('dropColumn')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo('column'));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->dropColumn('table', 'column');
+    }
+    
+    public function testHasIndex() {
+        $columns = array();
+        
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('hasIndex')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo($columns));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->hasIndex('table', $columns);
+    }
+    
+    public function testDropIndex() {
+        $columns = array();
+        $options = null;
+        
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('dropIndex')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo($columns),
+                    $this->equalTo($options));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->dropIndex('table', $columns, $options);
+    }
+    
+    public function testDropIndexByName() {
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('dropIndexByName')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo('index'));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->dropIndexByName('table', 'index');
+    }
+    
+    public function testHasForeignKey() {
+        $columns = array();
+        $constraint = null;
+        
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('hasForeignKey')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo($columns),
+                    $this->equalTo($constraint));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->hasForeignKey('table', $columns, $constraint);
+    }
+    
+    public function testAddForeignKey() {
+        $table = new Table('table');
+        $foreignKey = new ForeignKey();
+        
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('addForeignKey')
+             ->with($this->callback(function($table) {
+                 return $table->getName() == 'pre_table_suf';
+             }, $this->equalTo($foreignKey)));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->addForeignKey($table, $foreignKey);
+    }
+    
+    public function testDropForeignKey() {
+        $columns = array();
+        $constraint = null;
+        
+        $mock = $this->getMockAdapter();
+        $mock->expects($this->once())
+             ->method('dropForeignKey')
+             ->with($this->equalTo('pre_table_suf'),
+                    $this->equalTo($columns),
+                    $this->equalTo($constraint));
+        $this->adapter->setAdapter($mock);
+        
+        $this->adapter->dropForeignKey('table', $columns, $constraint);
+    }
+}

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -53,6 +53,15 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     {
         $this->environment->getAdapter();
     }
+    
+    public function testTablePrefixAdapter()
+    {
+        $this->environment->setOptions(array('table_prefix' => 'tbl_', 'adapter' => 'mysql'));
+        $this->assertTrue($this->environment->getAdapter() instanceof \Phinx\Db\Adapter\TablePrefixAdapter);
+        
+        $tablePrefixAdapter = $this->environment->getAdapter();
+        $this->assertTrue($tablePrefixAdapter->getAdapter() instanceof \Phinx\Db\Adapter\MysqlAdapter);
+    }
 
     public function testSchemaName()
     {


### PR DESCRIPTION
Support for specifying a prefix and/or suffix for tables - implements #65.

Choices for implementing this were either:
- Modify `Phinx\Db\Table` to add prefix and suffix when passing down to adapter, but the configuration options are not accessible from that class. Also better to preserve the abstract view of a table, rather than how it is represented in the database, by not modifying this class.
- Modify the database adapters, but this would add the same logic for modifying the table name to each of them.
- Create a proxy adapter to modify the table name before the command is passed on to the real adapter. This solves the above issues and allows `Migration\Manager\Manager` to use the `TablePrefixAdapter` when a prefix/suffix has been specified. _(this option was taken)_

Specify the prefix and/or suffix in the phinx.yml (or other configuration file) for each environment as follows:

```
paths:
    migrations: %%PHINX_CONFIG_DIR%%/migrations

environments:
    default_migration_table: phinxlog
    default_database: development
    production:
        adapter: mysql
        host: localhost
        name: production_db
        user: root
        pass: ''
        port: 3306
        charset: utf8
        table_prefix: tbl_
        table_suffix: _suffix

    development:
        adapter: mysql
        host: localhost
        name: development_db
        user: root
        pass: ''
        port: 3306
        charset: utf8

    testing:
        adapter: mysql
        host: localhost
        name: testing_db
        user: root
        pass: ''
        port: 3306
        charset: utf8
        table_prefix: test_
```
