### PR TITLE
Automatic mysql ID to be unsigned as default

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -190,6 +190,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $column = new Column();
             $column->setName('id')
                    ->setType('integer')
+                   ->setSigned(false)
                    ->setIdentity(true);
             
             array_unshift($columns, $column);


### PR DESCRIPTION
Hi, I find it reasonable to make automatic ID column as unsigned as they are always positive.
