### PR TITLE
getEnvironment() response includes default_database

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -154,6 +154,10 @@ class Config implements \ArrayAccess
         $environments = $this->getEnvironments();
 
         if (isset($environments[$name])) {
+            if (isset($this->values['environments']['default_database'])) {
+                $environments[$name]['default_database'] =
+                    $this->values['environments']['default_database'];
+            }
             if (isset($this->values['environments']['default_migration_table'])) {
                 $environments[$name]['default_migration_table'] =
                     $this->values['environments']['default_migration_table'];


### PR DESCRIPTION
Hi.

We have found an issue where a feature branch has been open for a while and some older migrations for that branch will be interleaved with those on production that are already live, so when the migrate command is run on the production server, there will be rollback (with potential data loss for new data accumulated) before the new migrations from the new branch are performed, along with the just rollbacked migrations. At the end of all of this, the schema is fine, but, potentially, any data that has been stored with regard to the new migrations from previously deployed branches will be lost.

To circumvent this, we intend to rename our migrations prior to feature closing the branch such that any outstanding migrations will be timestamped after the most recently performed migration.

To that end, we want to read the phinx.yml file using the Phinx\Config\Config class.

In looking at the getDefaultEnvironment() method, we can see that the 'default_database' is returned but not the 'default_migration_table'.
In looking at the getEnvironment() method, we can see that the 'default_migration_table' is returned but not the 'default_database'.

But neither of these methods return both values.

For my use case, I'm not using the getDefaultEnvironment(), only getEnvironment() as I always know which one I'm getting ('production').

The following patch allows both default values to be returned for getEnvironment().
