### PR TITLE
Added unix socket support to MySQL adapter

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -64,6 +64,11 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             } else {
                 $dsn = 'mysql:host=' . $options['host'] . ';port=' . $options['port'] . ';dbname=' . $options['name'];
             }
+
+            // unix socket support
+            if (isset($options['unix_socket'])) {
+                $dsn .= ';unix_socket=' . $options['unix_socket'];
+            }
             
             // charset support
             if (isset($options['charset'])) {


### PR DESCRIPTION
I needed unix socket support to be able to use phinx with MAMP - all I've done is added the ability for a unix_socket argument to be passed along with all the other connection info:

```
"environments" => array(
    "default_migration_table" => "migrations",
    "default_database" => "dev",
    "dev" => array(
        "adapter" => "mysql",
        "host"        => $_ENV['DB_HOST'],
        "name"        => $_ENV['DB_NAME'],
        "user"        => $_ENV['DB_USER'],
        "pass"        => $_ENV['DB_PASS'],
        "unix_socket" => $_ENV['DB_SOCK']
    )
)
```
