### PR TITLE
Escape the namespace backslashes

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -124,7 +124,7 @@ Declaring an SQLite database uses a simplified structure:
             adapter: sqlite
             memory: true     # Setting memory to *any* value overrides name
 
-You can provide a custom adapter by registering an implementation of the `Phinx\Db\Adapter\AdapterInterface` with the Environment:
+You can provide a custom adapter by registering an implementation of the `Phinx\\Db\\Adapter\\AdapterInterface` with the Environment:
 
 .. code-block:: php
 


### PR DESCRIPTION
In the final section of the configuration page (http://docs.phinx.org/en/latest/configuration.html#supported-adapters) the AdapterInterface backslashes are missing to separate the different parts of the namespace, so it looks like the interface is called PhinxDbAdapterAdapterInterface
