### PR TITLE
docs: rephrase sentence on auto-incrementing column

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -304,8 +304,8 @@ Finally calling ``save()`` commits the changes to the database.
 
 .. note::
 
-    Phinx automatically creates an auto-incrementing primary key for every
-    table called ``id``.
+    Phinx automatically creates an auto-incrementing column and primary key called ``id`` for every
+    table.
 
 To specify an alternate primary key you can specify the ``primary_key`` option
 when accessing the Table object. Let's disable the automatic ``id`` column and


### PR DESCRIPTION
I didn't understand what that sentence was saying until I actually tried to add an `id` column, this should be clearer.
