### PR TITLE
fix bugs in sqlite adapter

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -421,9 +421,10 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName));
 
+        $replacement = (end($columns)['name'] === $newColumn->getName()) ? "%s %s" : "%s %s,";
         $sql = preg_replace(
             sprintf("/%s[^,]*[^\)]/", $this->quoteColumnName($columnName)),
-            sprintf("%s %s", $this->quoteColumnName($newColumn->getName()), $this->getColumnSqlDefinition($newColumn)),
+            sprintf($replacement, $this->quoteColumnName($newColumn->getName()), $this->getColumnSqlDefinition($newColumn)),
             $sql
         );
 


### PR DESCRIPTION
The sqlite adapter was building wrong sql statements because it didn't consider all possible cases.These Bugs have been fixed.
