### PR TITLE
Fix foreign key unit test for unsigned ints

### DIFF
--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -515,7 +515,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $refTable->addColumn('field1', 'string')->save();
 
         $table = new \Phinx\Db\Table('table', array(), $this->adapter);
-        $table->addColumn('ref_table_id', 'integer')->save();
+        $table->addColumn('ref_table_id', 'integer', array('signed' => false))->save();
 
         $fk = new \Phinx\Db\Table\ForeignKey();
         $fk->setReferencedTable($refTable)


### PR DESCRIPTION
Commit 8393a98b590529 forced "Automatic mysql ID to be unsigned as default" which made this unit test to fail, because it tries to create a foreign key from signed ref_table_id to unsigned id.
