### PR TITLE
Improve performance of hasTable

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -164,17 +164,14 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
-        $options = $this->getOptions();
-        
-        $tables = array();
-        $rows = $this->fetchAll(sprintf('SHOW TABLES IN `%s`', $options['name']));
-        foreach ($rows as $row) {
-            $tables[] = strtolower($row[0]);
+        try {
+            $this->query(sprintf('SELECT 1 FROM %s LIMIT 1', $this->quoteTableName($tableName)));
+        } catch (\PDOException $e) {
+            return false;
         }
-        
-        return in_array(strtolower($tableName), $tables);
+        return true;
     }
-    
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
I know this might be a bit controversial, but current approach should change one way or another.

Running "SHOW TABLES" every time we need to check if a single table exists is a non-starter for us. In our own systems we had to change table existence checks to the approach proposed here even though we were already caching everything aggressively. 

In a system such as phinx, caching would make no sense since creating and dropping tables happens all the time. However, if this request is deemed too much of a hack, there should at least be some attempt to keep track of tables being dropped and created, so that we do not have to run the full SHOW TABLES on every call to hasTable.
