### PR TITLE
Optimize table existence check

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -165,14 +165,15 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     public function hasTable($tableName)
     {
         $options = $this->getOptions();
-        
-        $tables = array();
-        $rows = $this->fetchAll(sprintf('SHOW TABLES IN `%s`', $options['name']));
-        foreach ($rows as $row) {
-            $tables[] = strtolower($row[0]);
-        }
-        
-        return in_array(strtolower($tableName), $tables);
+
+        $exists = $this->fetchRow(sprintf(
+            "SELECT TABLE_NAME
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
+            $options['name'], $tableName
+        ));
+
+        return !empty($exists);
     }
     
     /**


### PR DESCRIPTION
On large databases, running SHOW TABLES will return a large array. Avoid grabbing and looping over that every time by checking the table by name directly. This way we also potentially avoid some disk operations. See here for reference:

http://dev.mysql.com/doc/refman/5.5/en/information-schema-optimization.html

"Within a database, avoid queries that use a nonconstant table name lookup value (or no lookup value) because they require a scan of the database directory to find matching table files."
