### PR TITLE
Use single quotes to quote string literals

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -588,7 +588,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $foreignKeys = array();
         $rows = $this->fetchAll(sprintf(
-            'SELECT
+            "SELECT
               CONSTRAINT_NAME,
               TABLE_NAME,
               COLUMN_NAME,
@@ -597,8 +597,8 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             FROM information_schema.KEY_COLUMN_USAGE
             WHERE REFERENCED_TABLE_SCHEMA = DATABASE()
               AND REFERENCED_TABLE_NAME IS NOT NULL
-              AND TABLE_NAME = "%s"
-            ORDER BY POSITION_IN_UNIQUE_CONSTRAINT',
+              AND TABLE_NAME = '%s'
+            ORDER BY POSITION_IN_UNIQUE_CONSTRAINT",
             $tableName
         ));
         foreach ($rows as $row) {
@@ -652,14 +652,14 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         } else {
             foreach ($columns as $column) {
                 $rows = $this->fetchAll(sprintf(
-                    'SELECT
+                    "SELECT
                         CONSTRAINT_NAME
                       FROM information_schema.KEY_COLUMN_USAGE
                       WHERE REFERENCED_TABLE_SCHEMA = DATABASE()
                         AND REFERENCED_TABLE_NAME IS NOT NULL
-                        AND TABLE_NAME = "%s"
-                        AND COLUMN_NAME = "%s"
-                      ORDER BY POSITION_IN_UNIQUE_CONSTRAINT',
+                        AND TABLE_NAME = '%s'
+                        AND COLUMN_NAME = '%s'
+                      ORDER BY POSITION_IN_UNIQUE_CONSTRAINT",
                     $tableName,
                     $column
                 ));
@@ -947,10 +947,10 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
 
         // mysql specific
         $sql = sprintf(
-            'SELECT *'
-            . ' FROM information_schema.tables'
-            . ' WHERE table_schema = "%s"'
-            . ' AND table_name = "%s"',
+            "SELECT *
+             FROM information_schema.tables
+             WHERE table_schema = '%s'
+             AND table_name = '%s'",
             $options['name'],
             $tableName
         );

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -201,7 +201,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('realname', 'string')
               ->save();
         $this->assertTrue($this->adapter->hasTable('ntable'));
-        $row = $this->adapter->fetchRow(sprintf('SHOW TABLE STATUS WHERE Name = "%s"', 'ntable'));
+        $row = $this->adapter->fetchRow(sprintf("SHOW TABLE STATUS WHERE Name = '%s'", 'ntable'));
         $this->assertEquals('MyISAM', $row['Engine']);
     }
     
@@ -211,7 +211,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('name', 'string')
               ->save();
         $this->assertTrue($this->adapter->hasTable('latin1_table'));
-        $row = $this->adapter->fetchRow(sprintf('SHOW TABLE STATUS WHERE Name = "%s"', 'latin1_table'));
+        $row = $this->adapter->fetchRow(sprintf("SHOW TABLE STATUS WHERE Name = '%s'", 'latin1_table'));
         $this->assertEquals('latin1_general_ci', $row['Collation']);
     }
     
@@ -564,7 +564,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('column1', 'string', array('comment' => $comment = 'Comments from "column1"'))
               ->save();
 
-        $rows = $this->adapter->fetchAll('SELECT column_name, column_comment FROM information_schema.columns WHERE table_name = "table1"');
+        $rows = $this->adapter->fetchAll("SELECT column_name, column_comment FROM information_schema.columns WHERE table_name = 'table1'");
         $columnWithComment = $rows[1];
 
         $this->assertEquals($comment, $columnWithComment['column_comment'], 'Dont set column comment correctly');


### PR DESCRIPTION
Double quotes are allowed in MySQL by default, but not if ANSI_QUOTES are on.

See: http://dev.mysql.com/doc/refman/5.0/en/string-literals.html
