### PR TITLE
MysqlAdapter::renameColumn keep column default

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -380,6 +380,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             if (strcasecmp($row['Field'], $columnName) === 0) {
                 $null = ($row['Null'] == 'NO') ? 'NOT NULL' : 'NULL';
                 $extra = ' ' . strtoupper($row['Extra']);
+                if (!is_null($row['Default'])) {
+                    $extra.= ' DEFAULT ' . (is_numeric($row['Default']) || $row['Default'] == 'CURRENT_TIMESTAMP' ? $row['Default'] : '\'' . $row['Default'] . '\'');
+                }
                 $definition = $row['Type'] . ' ' . $null . $extra;
         
                 $this->writeCommand('renameColumn', array($tableName, $columnName, $newColumnName));


### PR DESCRIPTION
When renaming a column with a default value the default is removed after the rename, this proposal fixes that.
