### PR TITLE
auto timestamp migration class names if auto_timestamp_class is set in configuration

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -251,7 +251,21 @@ class Config implements \ArrayAccess
 
         return $path;
     }
-    
+
+    /**
+     * Get the flag tp auto timestamp migration class names
+     * If missing return false for backward compatibility
+     * 
+     * @return boolean
+     */
+    public function getAutoTimestampClass()
+    {
+        if (!isset($this->values['auto_timestamp_class'])) {
+            return false;
+        }
+        return filter_var($this->values['auto_timestamp_class'], FILTER_VALIDATE_BOOLEAN);
+    }
+
     /**
      * Replace tokens in the specified array.
      *

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -74,10 +74,10 @@ class Create extends AbstractCommand
                 $path
             ));
         }
-        
+
         $path = realpath($path);
-        $className = $input->getArgument('name');
-        
+        $className = ucfirst($input->getArgument('name'));
+
         if (!Util::isValidMigrationClassName($className)) {
             throw new \InvalidArgumentException(sprintf(
                 'The migration class name "%s" is invalid. Please use CamelCase format.',
@@ -85,8 +85,18 @@ class Create extends AbstractCommand
             ));
         }
         
+        // if true, class names will automatically be suffixed by timestamp
+        $autoTimestampClass = $this->getConfig()->getAutoTimestampClass();
+
         // Compute the file path
-        $fileName = Util::mapClassNameToFileName($className);
+        if ($autoTimestampClass) {
+            $timestamp = date('YmdHis');
+            $fileName  = Util::mapClassNameToFileName($className, $timestamp);
+            $className = $className . '_' . $timestamp;
+        } else {
+            $fileName = Util::mapClassNameToFileName($className);
+        }
+
         $filePath = $path . DIRECTORY_SEPARATOR . $fileName;
         
         if (file_exists($filePath)) {

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -375,7 +375,7 @@ class Manager
                     if (isset($versions[$version])) {
                         throw new \InvalidArgumentException(sprintf('Duplicate migration - "%s" has the same version as "%s"', $filePath, $versions[$version]->getVersion()));
                     }
-                    
+
                     // convert the filename to a class name
                     $class = preg_replace('/^[0-9]+_/', '', basename($filePath));
                     $class = str_replace('_', ' ', $class);
@@ -384,7 +384,14 @@ class Manager
                     if (false !== strpos($class, '.')) {
                         $class = substr($class, 0, strpos($class, '.'));
                     }
-                    
+
+                    // if true, class names will automatically be suffixed by timestamp
+                    $autoTimestampClass = $this->getConfig()->getAutoTimestampClass();
+                    $timestamp          = strstr(basename($filePath), '_', true);
+                    if ($autoTimestampClass) {
+                        $class = $class . '_' . $timestamp;
+                    }
+
                     if (isset($fileNames[$class])) {
                         throw new \InvalidArgumentException(sprintf(
                             'Migration "%s" has the same name as "%s"',

--- a/src/Phinx/Migration/Util.php
+++ b/src/Phinx/Migration/Util.php
@@ -36,13 +36,17 @@ class Util
      * '12345678901234_limit_resource_names_to_30_chars.php'.
      *
      * @param string $className Class Name
+     * @param string $timestamp Timestamp injecteable from outside to be in sync with class name
      * @return string
      */
-    public static function mapClassNameToFileName($className)
+    public static function mapClassNameToFileName($className, $timestamp = null)
     {
         $arr = preg_split('/(?=[A-Z])/', $className);
         unset($arr[0]); // remove the first element ('')
-        $fileName = date('YmdHis') . '_' . strtolower(implode($arr, '_')) . '.php';
+        if ($timestamp === null) {
+            $timestamp = date('YmdHis');
+        }
+        $fileName = $timestamp . '_' . strtolower(implode($arr, '_')) . '.php';
         return $fileName;
     }
 


### PR DESCRIPTION
This is implementation of the issue #306. I'm missing this feature too, it is even a blocker for me.

I've created a new configuration option named "auto_timestamp_class". When this is set to "yes", "true" or 1, the class name will be suffixed by the timestamp, which avoids conflict in names. If the configuration value is missing or "no", "false" or "0" it works as before (thus it is backward compatible)

I've chosen postfix instead of prefix because PHP class names must start with a letter or underscore.

I've also included a small fix to upper case the first letter of the migration name automatically, i.e. it is now equivalent
phinx create Abc
and
phinx create abc

I've tested the code, but I didn't run unit tests.
