### PR TITLE
Treat PHINX_TYPE_BINARY columns as SQLServer Varbinary

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -843,7 +843,7 @@ ORDER BY T.[name], I.[index_id];";
                 return array('name' => 'date');
                 break;
             case static::PHINX_TYPE_BINARY:
-                return array('name' => 'binary');
+                return array('name' => 'varbinary');
                 break;
             case static::PHINX_TYPE_BOOLEAN:
                 return array('name' => 'bit');
@@ -900,6 +900,7 @@ ORDER BY T.[name], I.[index_id];";
                 return static::PHINX_TYPE_FLOAT;
             case 'binary':
             case 'image':
+            case 'varbinary':
                 return static::PHINX_TYPE_BINARY;
                 break;
             case 'time':


### PR DESCRIPTION
`binary` columns in SqlServer have a maximum length of 8000 bytes. Change to `varbinary` to add support for arbitrary length blobs.
