### PR TITLE
Support empty string as default value for a column

### DIFF
--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -205,7 +205,7 @@ class Column
      */
     public function setDefault($default)
     {
-        if ($default === false || $default === '') {
+        if ($default === false) {
             $default = null;
         }
         $this->default = $default;


### PR DESCRIPTION
This is basically the same issue as #107, but I can't send a pull request for an issue that I don't own, so here goes this one.

As far as I can see this could cause only some backward compatibility issues (if someone used empty string to denote NULL value).
