### PR TITLE
Lock in Symfony component versions for stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     }],
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": "2.*",
-        "symfony/config": "2.*",
-        "symfony/class-loader": "2.*",
-        "symfony/yaml": "2.*"
+        "symfony/console": "~2.5.0",
+        "symfony/config": "~2.5.0",
+        "symfony/class-loader": "~2.5.0",
+        "symfony/yaml": "~2.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Was seeing some confusion from Composer as to what `2.*` meant in a project.
