### PR TITLE
Fix using InputArgument class constant for addOption

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -31,7 +31,7 @@ namespace Phinx\Console\Command;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Phinx\Config\Config;
 use Phinx\Migration\Manager;
@@ -64,8 +64,8 @@ abstract class AbstractCommand extends Command
      */
     protected function configure()
     {
-        $this->addOption('--configuration', '-c', InputArgument::OPTIONAL, 'The configuration file to load');
-        $this->addOption('--parser', '-p', InputArgument::OPTIONAL, 'Parser used to read the config file. Defaults to YAML');
+        $this->addOption('--configuration', '-c', InputOption::VALUE_REQUIRED, 'The configuration file to load');
+        $this->addOption('--parser', '-p', InputOption::VALUE_REQUIRED, 'Parser used to read the config file. Defaults to YAML');
     }
 
     /**

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -29,7 +29,7 @@
 namespace Phinx\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrate extends AbstractCommand
@@ -41,11 +41,11 @@ class Migrate extends AbstractCommand
     {
         parent::configure();
 
-        $this->addOption('--environment', '-e', InputArgument::OPTIONAL, 'The target environment');
+        $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
         $this->setName('migrate')
              ->setDescription('Migrate the database')
-             ->addOption('--target', '-t', InputArgument::OPTIONAL, 'The version number to migrate to')
+             ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to migrate to')
              ->setHelp(
 <<<EOT
 The <info>migrate</info> command runs all available migrations, optionally up to a specific version

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -29,7 +29,7 @@
 namespace Phinx\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
     
 class Rollback extends AbstractCommand
@@ -41,11 +41,11 @@ class Rollback extends AbstractCommand
     {
         parent::configure();
          
-        $this->addOption('--environment', '-e', InputArgument::OPTIONAL, 'The target environment');
+        $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
         
         $this->setName('rollback')
              ->setDescription('Rollback the last or to a specific migration')
-             ->addOption('--target', '-t', InputArgument::OPTIONAL, 'The version number to rollback to')
+             ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to rollback to')
              ->setHelp(
 <<<EOT
 The <info>rollback</info> command reverts the last migration, or optionally up to a specific version

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -29,7 +29,7 @@
 namespace Phinx\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends AbstractCommand
@@ -41,11 +41,11 @@ class Status extends AbstractCommand
     {
         parent::configure();
          
-        $this->addOption('--environment', '-e', InputArgument::OPTIONAL, 'The target environment.');
+        $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment.');
          
         $this->setName('status')
              ->setDescription('Show migration status')
-             ->addOption('--format', '-f', InputArgument::OPTIONAL, 'The output format: text or json. Defaults to text.')
+             ->addOption('--format', '-f', InputOption::VALUE_REQUIRED, 'The output format: text or json. Defaults to text.')
              ->setHelp(
 <<<EOT
 The <info>status</info> command prints a list of all migrations, along with their current status

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -30,7 +30,7 @@ namespace Phinx\Console\Command;
 
 use Phinx\Migration\Manager\Environment;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -45,7 +45,7 @@ class Test extends AbstractCommand
     {
         parent::configure();
         
-        $this->addOption('--environment', '-e', InputArgument::OPTIONAL, 'The target environment');
+        $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
         $this->setName('test')
              ->setDescription('Verify the configuration file')


### PR DESCRIPTION
InputArgument class constants were used instead of InputOptions class constants for Command::addOption mode parameter (The numerical values were correct, though)
