### PR TITLE
Fix docblock-end position in Migration template

### DIFF
--- a/src/Phinx/Migration/Migration.template.php.dist
+++ b/src/Phinx/Migration/Migration.template.php.dist
@@ -12,10 +12,10 @@ class $className extends $baseClassName
      *
      * Uncomment this method if you would like to use it.
      *
+     */
     public function change()
     {
     }
-    */
     
     /**
      * Migrate Up.


### PR DESCRIPTION
As noted in [this blog post](http://josediazgonzalez.com/2014/12/04/schema-migrations-with-cakephp-3/)
