### PR TITLE
hasColumn and getColumns allow reserved keywords in tableName (+ tests)

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -323,7 +323,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     public function getColumns($tableName)
     {
         $columns = array();
-        $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $tableName));
+        $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName)));
         foreach ($rows as $columnInfo) {
             $column = new Column();
             $column->setName($columnInfo['Field'])
@@ -350,7 +350,8 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasColumn($tableName, $columnName)
     {
-        $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $tableName));
+        $sql = sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName));
+        $rows = $this->fetchAll($sql);
         foreach ($rows as $column) {
             if (strcasecmp($column['Field'], $columnName) === 0) {
                 return true;
@@ -895,7 +896,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $sqlType = $this->getSqlType($column->getType());
 
-        // Additional check if a limit along 
+        // Additional check if a limit along
         if (strtoupper($sqlType['name']) === 'TEXT' && $column->getLimit()) {
             $sqlType['name'] = $this->classifyTextColumn($column);
             // Remove the limit since MySQL does't like limit to be specified with a TEXT Type column

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -493,6 +493,37 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGetColumnsReservedTableName()
+    {
+        $table = new \Phinx\Db\Table('group', array(), $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->addColumn('column2', 'integer')
+              ->addColumn('column3', 'biginteger')
+              ->addColumn('column4', 'text')
+              ->addColumn('column5', 'float')
+              ->addColumn('column6', 'decimal')
+              ->addColumn('column7', 'datetime')
+              ->addColumn('column8', 'time')
+              ->addColumn('column9', 'timestamp')
+              ->addColumn('column10', 'date')
+              ->addColumn('column11', 'binary')
+              ->addColumn('column12', 'boolean')
+              ->addColumn('column13', 'string', array('limit' => 10))
+              ->addColumn('column15', 'integer', array('limit' => 10))
+              ->addColumn('column16', 'geometry')
+              ->addColumn('column17', 'point')
+              ->addColumn('column18', 'linestring')
+              ->addColumn('column19', 'polygon');
+        $pendingColumns = $table->getPendingColumns();
+        $table->save();
+        $columns = $this->adapter->getColumns('group');
+        $this->assertCount(count($pendingColumns) + 1, $columns);
+        for ($i = 0; $i++; $i < count($pendingColumns)) {
+            $this->assertEquals($pendingColumns[$i], $columns[$i+1]);
+        }
+    }
+
+
     public function testAddIndex()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
@@ -638,4 +669,26 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
         $this->assertEquals('geometry', $rows[1]['Type']);
     }
+
+    public function testHasColumn()
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->save();
+
+        $this->assertFalse($table->hasColumn('column2'));
+        $this->assertTrue($table->hasColumn('column1'));
+    }
+
+    public function testHasColumnReservedName()
+    {
+        $tableQuoted = new \Phinx\Db\Table('group', array(), $this->adapter);
+        $tableQuoted->addColumn('value', 'string')
+                    ->save();
+
+        $this->assertFalse($tableQuoted->hasColumn('column2'));
+        $this->assertTrue($tableQuoted->hasColumn('value'));
+
+    }
+
 }


### PR DESCRIPTION
In mysql adapter:

hasColumn and getColumns methods has been modified for tablenames support (reserved keyword like group,use, etc..). I also added some tests for this behaviour.

I know this names should not be used but legacy code exists... 

Thanks for this tool, it is useful

Regards
