### PR TITLE
Add support for pgsql 'double precision' type.

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -48,6 +48,7 @@ interface AdapterInterface
     const PHINX_TYPE_INTEGER        = 'integer';
     const PHINX_TYPE_BIG_INTEGER    = 'biginteger';
     const PHINX_TYPE_FLOAT          = 'float';
+    const PHINX_TYPE_DOUBLE         = 'double';
     const PHINX_TYPE_DECIMAL        = 'decimal';
     const PHINX_TYPE_DATETIME       = 'datetime';
     const PHINX_TYPE_TIMESTAMP      = 'timestamp';

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -457,6 +457,7 @@ abstract class PdoAdapter implements AdapterInterface
             'integer',
             'biginteger',
             'float',
+            'double',
             'decimal',
             'datetime',
             'timestamp',

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -757,6 +757,8 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'bigint');
             case static::PHINX_TYPE_FLOAT:
                 return array('name' => 'real');
+            case static::PHINX_TYPE_DOUBLE:
+                return array('name' => 'double precision');
             case static::PHINX_TYPE_DATETIME:
             case static::PHINX_TYPE_TIMESTAMP:
                 return array('name' => 'timestamp');
@@ -827,6 +829,9 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case 'real':
             case 'float4':
                 return static::PHINX_TYPE_FLOAT;
+            case 'double precision':
+            case 'float8':
+                return static::PHINX_TYPE_DOUBLE;
             case 'bytea':
                 return static::PHINX_TYPE_BINARY;
                 break;


### PR DESCRIPTION
Just throwing it out in case somebody wants to pick it up and work on it further.

Adds support for float8 and double precision PostgreSQL types in Phinx.
