### PR TITLE
Postgres enum/set/double/bytea support

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1025,6 +1025,11 @@ $$ language sql;
 
         $buffer[] = $column->isNull() ? 'NULL' : 'NOT NULL';
 
+        $properties = $column->getProperties();
+        if(isset($properties['references'])){
+            $buffer[] = ' REFERENCES '.$properties['references'];
+        }
+        
         if (!is_null($column->getDefault())) {
             $buffer[] = $this->getDefaultValueDefinition($column->getDefault());
         }

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -860,6 +860,9 @@ $$ language sql;
                 if($type == 'double'){
                     return array('name' => 'DOUBLE PRECISION');
                 }
+                if($type == 'tsrange'){
+                    return array('name' => 'tsrange');
+                }
                 // Return array type
                 throw new \RuntimeException('The type: "' . $type . '" is not supported');
         }
@@ -1245,7 +1248,7 @@ $$ language sql;
      */
     public function getColumnTypes()
     {
-        return array_merge(parent::getColumnTypes(), array('json', 'jsonb','enum','set','double'));
+        return array_merge(parent::getColumnTypes(), array('json', 'jsonb','enum','set','double','tsrange'));
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -44,6 +44,19 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      * @var array
      */
     protected $columnsWithComments = array();
+    /**
+     * Custom enums list
+     * 
+     * @var array 
+     */
+    private $enums = array();
+
+    /**
+     * Custom sets emulation list
+     * 
+     * @var array 
+     */
+    private $sets = array();
 
     /**
      * {@inheritdoc}
@@ -171,11 +184,50 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function createTable(Table $table)
     {
+        $sql = '';
         $this->startCommandTimer();
         $options = $table->getOptions();
 
          // Add the default primary key
         $columns = $table->getPendingColumns();
+        
+        // Create Enum Types
+        foreach ($columns as $col){
+            switch ($col->getType()) {
+                case 'enum':
+                    $typename = strtoupper($table->getName().'_'.$col->getName());
+                    $sql .= 'CREATE TYPE ' . $typename . ' AS ENUM (';
+                    $sql .= implode(',', array_map(function($a) {
+                                                return "'".$a."'";
+                                         }, $col->getValues()));
+                    $sql .= ");\n";
+                    $this->addEnumType($typename);
+                    $col->setType($typename);
+                    break;
+                case 'set':
+                    $sql .= "CREATE OR REPLACE FUNCTION has_unique_value(varchar[]) returns boolean as $$
+    select (select count(distinct c) from unnest($1) as dt(c)) = array_length($1, 1);
+$$ language sql;
+";
+                    
+                    $maxval = 0;
+                    foreach ($col->getValues() as $value) {
+                        if(strlen($value)>$maxval){
+                            $maxval = strlen($value);
+                        }
+                    }
+                    $col->setType('varchar('.$maxval.')[]');
+                    $this->addSet(array($col->getName()=>'varchar('.$maxval.')[]'));
+                    $default = $col->getDefault();
+                    if($default){
+                        $col->setDefault('{'.$default.'}');
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        
         if (!isset($options['id']) || (isset($options['id']) && $options['id'] === true)) {
             $column = new Column();
             $column->setName('id')
@@ -197,7 +249,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         }
 
         // TODO - process table options like collation etc
-        $sql = 'CREATE TABLE ';
+        $sql .= 'CREATE TABLE ';
         $sql .= $this->quoteTableName($table->getName()) . ' (';
 
         $this->columnsWithComments = array();
@@ -354,6 +406,22 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     {
         $this->startCommandTimer();
         $this->writeCommand('addColumn', array($table->getName(), $column->getName(), $column->getType()));
+        
+        if ($column->getType() == 'enum') {
+            $typename = strtoupper($table->getName() . '_' . $column->getName());
+            if(!$this->isKnownEnum($typename)){
+                $sql = 'CREATE TYPE ' . $typename . ' AS ENUM (';
+                $sql .= implode(',', array_map(function($a) {
+                            return "'" . $a . "'";
+                        }, $column->getValues()));
+                $sql .= ");\n";
+                if($this->addEnumType($typename)){
+                    $this->execute($sql);
+                    $column->setType($typename);
+                }
+            }
+        }
+
         $sql = sprintf(
             'ALTER TABLE %s ADD %s %s',
             $this->quoteTableName($table->getName()),
@@ -783,6 +851,15 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 if ($this->isArrayType($type)) {
                     return array('name' => $type);
                 }
+                if(array_key_exists($type, $this->enums)){
+                    return array('name' => $type);
+                }
+                if($colname = array_search($type, $this->sets)){
+                    return array('name' => $colname.' '.$type);
+                }
+                if($type == 'double'){
+                    return array('name' => 'DOUBLE PRECISION');
+                }
                 // Return array type
                 throw new \RuntimeException('The type: "' . $type . '" is not supported');
         }
@@ -804,6 +881,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case 'char':
                 return static::PHINX_TYPE_CHAR;
             case 'text':
+            case 'mediumtext':
                 return static::PHINX_TYPE_TEXT;
             case 'json':
                 return static::PHINX_TYPE_JSON;
@@ -916,7 +994,13 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $buffer[] = 'SERIAL';
         } else {
             $sqlType = $this->getSqlType($column->getType(), $column->getLimit());
-            $buffer[] = strtoupper($sqlType['name']);
+
+            if(array_search($column->getType(), $this->sets)){
+                $buffer[] = $column->getType(); //"Set" 
+            } else {
+                $buffer[] = strtoupper($sqlType['name']);
+            }
+            
             // integers cant have limits in postgres
             if (static::PHINX_TYPE_DECIMAL === $sqlType['name'] && ($column->getPrecision() || $column->getScale())) {
                 $buffer[] = sprintf(
@@ -924,7 +1008,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                     $column->getPrecision() ? $column->getPrecision() : $sqlType['precision'],
                     $column->getScale() ? $column->getScale() : $sqlType['scale']
                 );
-            } elseif (!in_array($sqlType['name'], array('integer', 'smallint'))) {
+            } elseif (!in_array($sqlType['name'], array('integer', 'smallint','bytea'))) {
                 if ($column->getLimit() || isset($sqlType['limit'])) {
                     $buffer[] = sprintf('(%s)', $column->getLimit() ? $column->getLimit() : $sqlType['limit']);
                 }
@@ -945,6 +1029,13 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $buffer[] = $this->getDefaultValueDefinition($column->getDefault());
         }
 
+        if(array_search($column->getType(), $this->sets)){
+            $buffer[] = ",
+    check (". $column->getName() ." <@ ARRAY[". implode(',', array_map(function($a) {
+                                                return "'".$a."'";
+            }, $column->getValues())) ."]::varchar[] and has_unique_value(". $column->getName() ."))
+";
+        }        
         return implode(' ', $buffer);
     }
 
@@ -1149,7 +1240,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function getColumnTypes()
     {
-        return array_merge(parent::getColumnTypes(), array('json', 'jsonb'));
+        return array_merge(parent::getColumnTypes(), array('json', 'jsonb','enum','set','double'));
     }
 
     /**
@@ -1187,4 +1278,34 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         $options = $this->getOptions();
         return empty($options['schema']) ? 'public' : $options['schema'];
     }
+
+    /**
+     * Add definiton of new custom enum
+     * 
+     * @param string $typename
+     */
+    public function addEnumType($typename) {
+        $this->enums[$typename] = strtoupper($typename);
+        return $this->isKnownEnum($typename);
+    }
+
+    /**
+     * Add definiton of new "custom set emulation"
+     * 
+     * @param string $set
+     */
+    public function addSet( array $set) {
+        $this->sets[key($set)] = current($set);
+    }
+
+    /**
+     * Is given Enum known ?
+     * 
+     * @param string $typename
+     * @return boolean
+     */
+    public function isKnownEnum($typename) {
+        return isset($this->enums[$typename]);
+    }
+
 }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -242,6 +242,9 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('email', 'string')
               ->save();
         $this->assertTrue($table->hasColumn('email'));
+        
+        $table->addColumn('enumtest', 'enum', array('default' => 'unknown','values' => array('one', 'two', 'unknown')));
+        $this->assertTrue($table->hasColumn('enumtest'));
     }
 
     public function testAddColumnWithDefaultValue()

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -243,7 +243,8 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
               ->save();
         $this->assertTrue($table->hasColumn('email'));
         
-        $table->addColumn('enumtest', 'enum', array('default' => 'unknown','values' => array('one', 'two', 'unknown')));
+        $table->addColumn('enumtest', 'enum', array('default' => 'unknown','values' => array('one', 'two', 'unknown')))
+              ->save();
         $this->assertTrue($table->hasColumn('enumtest'));
     }
 
@@ -896,4 +897,36 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $rows[0]['column2']);
         $this->assertEquals(2, $rows[1]['column2']);
     }
+    
+    /**
+     * Add definiton of new custom enum
+     */
+    public function testaddEnumType() {
+        $this->assertTrue($this->adapter->addEnumType('ENUM_MAYBE'));
+    }
+
+    /**
+     * Add definiton of new "custom set emulation"
+     * 
+    public function testaddSet() {
+        $this->adapter->addSet(array('set'=> array('set1','set2')));
+        $this->assertArrayHasKey($this->adapter->sets,'set');
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+    */
+
+    /**
+     * Is given Enum known ?
+     * 
+     * @param string $typename
+     * @return boolean
+     */
+    public function testisKnownEnum() {
+        $this->adapter->addEnumType('ENUM_MAYBE');
+        $this->assertTrue($this->adapter->isKnownEnum('ENUM_MAYBE'));
+    }
+
+    
 }


### PR DESCRIPTION
This patch allow you to create tables with enum/set column types
Also added small fixes for double and bytea postgresql data types
