### PR TITLE
Implemented Dry Runs

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -57,6 +57,10 @@ The <info>migrate</info> command runs all available migrations, optionally up to
 <info>phinx migrate -e development -d 20110103</info>
 <info>phinx migrate -e development -v</info>
 
+The <info>--dry-run</info> option will output the SQL code of the migration(s) which would be executed:
+
+<info>phinx migrate -e development --dry-run</info>
+
 EOT
              );
     }

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -47,7 +47,7 @@ class Migrate extends AbstractCommand
              ->setDescription('Migrate the database')
              ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to migrate to')
              ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to migrate to')
-             ->addOption('--dry-run', '-r', InputOption::VALUE_NONE, 'Output SQL rather than executing it')
+             ->addOption('--dry-run', null, InputOption::VALUE_NONE, 'Output SQL rather than executing it')
              ->setHelp(
 <<<EOT
 The <info>migrate</info> command runs all available migrations, optionally up to a specific version

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -47,6 +47,7 @@ class Migrate extends AbstractCommand
              ->setDescription('Migrate the database')
              ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to migrate to')
              ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to migrate to')
+             ->addOption('--dry-run', '-r', InputOption::VALUE_NONE, 'Output SQL rather than executing it')
              ->setHelp(
 <<<EOT
 The <info>migrate</info> command runs all available migrations, optionally up to a specific version
@@ -74,6 +75,7 @@ EOT
         $version     = $input->getOption('target');
         $environment = $input->getOption('environment');
         $date        = $input->getOption('date');
+        $dryRun      = $input->getOption('dry-run');
 
         if (null === $environment) {
             $environment = $this->getConfig()->getDefaultEnvironment();
@@ -104,13 +106,17 @@ EOT
         if (isset($envOptions['table_suffix'])) {
             $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
         }
+        
+        if ($dryRun) {
+            $output->writeln('<info>Doing dry run</info>');
+        }
 
         // run the migrations
         $start = microtime(true);
         if (null !== $date) {
-            $this->getManager()->migrateToDateTime($environment, new \DateTime($date));
+            $this->getManager()->migrateToDateTime($environment, new \DateTime($date), $dryRun);
         } else {
-            $this->getManager()->migrate($environment, $version);
+            $this->getManager()->migrate($environment, $version, $dryRun);
         }
         $end = microtime(true);
 

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -49,7 +49,7 @@ class Rollback extends AbstractCommand
              ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to rollback to')
              ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to rollback to')
              ->addOption('--force', '-f', InputOption::VALUE_NONE, 'Force rollback to ignore breakpoints')
-             ->addOption('--dry-run', '-r', InputOption::VALUE_NONE, 'Output SQL rather than executing it')
+             ->addOption('--dry-run', null, InputOption::VALUE_NONE, 'Output SQL rather than executing it')
              ->setHelp(
 <<<EOT
 The <info>rollback</info> command reverts the last migration, or optionally up to a specific version

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -67,6 +67,10 @@ The <info>version_order</info> configuration option is used to determine the ord
 This can be used to allow the rolling back of the last executed migration instead of the last created one, or combined 
 with the <info>-d|--date</info> option to rollback to a certain date using the migration start times to order them.
 
+The <info>--dry-run</info> option will output the SQL code of the migration(s) which would be rollbacked:
+
+<info>phinx rollback -e development --dry-run</info>
+
 EOT
              );
     }

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -49,6 +49,7 @@ class Rollback extends AbstractCommand
              ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to rollback to')
              ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to rollback to')
              ->addOption('--force', '-f', InputOption::VALUE_NONE, 'Force rollback to ignore breakpoints')
+             ->addOption('--dry-run', '-r', InputOption::VALUE_NONE, 'Output SQL rather than executing it')
              ->setHelp(
 <<<EOT
 The <info>rollback</info> command reverts the last migration, or optionally up to a specific version
@@ -85,6 +86,7 @@ EOT
         $version     = $input->getOption('target');
         $date        = $input->getOption('date');
         $force       = !!$input->getOption('force');
+        $dryRun      = $input->getOption('dry-run');
 
         $config = $this->getConfig();
 
@@ -111,6 +113,10 @@ EOT
         $versionOrder = $this->getConfig()->getVersionOrder();
         $output->writeln('<info>ordering by </info>' . $versionOrder . " time");
 
+        if ($dryRun) {
+            $output->writeln('<info>Doing dry run</info>');
+        }
+
         // rollback the specified environment
         if (null === $date) {
             $targetMustMatchVersion = true;
@@ -121,7 +127,7 @@ EOT
         }
 
         $start = microtime(true);
-        $this->getManager()->rollback($environment, $target, $force, $targetMustMatchVersion);
+        $this->getManager()->rollback($environment, $target, $force, $targetMustMatchVersion, $dryRun);
         $end = microtime(true);
 
         $output->writeln('');

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -108,6 +108,10 @@ EOT
             $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
         }
 
+        if ($dryRun) {
+            $output->writeln('<info>Doing dry run</info>');
+        }
+
         $start = microtime(true);
 
         if (empty($seedSet)) {

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -46,6 +46,7 @@ class SeedRun extends AbstractCommand
         $this->setName('seed:run')
              ->setDescription('Run database seeders')
              ->addOption('--seed', '-s', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'What is the name of the seeder?')
+             ->addOption('--dry-run', null, InputOption::VALUE_NONE, 'Output SQL rather than executing it')
              ->setHelp(
 <<<EOT
 The <info>seed:run</info> command runs all available or individual seeders
@@ -55,6 +56,9 @@ The <info>seed:run</info> command runs all available or individual seeders
 <info>phinx seed:run -e development -s UserSeeder -s PermissionSeeder -s LogSeeder</info>
 <info>phinx seed:run -e development -v</info>
 
+The <info>--dry-run</info> option will output the SQL code of the seeder(s) which would be run:
+
+<info>phinx seed:run -e development --dry-run</info>
 EOT
              );
     }
@@ -72,6 +76,7 @@ EOT
 
         $seedSet     = $input->getOption('seed');
         $environment = $input->getOption('environment');
+        $dryRun      = $input->getOption('dry-run');
 
         if (null === $environment) {
             $environment = $this->getConfig()->getDefaultEnvironment();
@@ -111,7 +116,7 @@ EOT
         } else {
             // run seed(ers) specified in a comma-separated list of classes
             foreach ($seedSet as $seed) {
-                $this->getManager()->seed($environment, trim($seed));
+                $this->getManager()->seed($environment, trim($seed), $dryRun);
             }
         }
 

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -526,4 +526,18 @@ interface AdapterInterface
      * @return mixed
      */
     public function castToBool($value);
+
+    /**
+     * Enable Dry Run
+     *
+     * @return AdapterInterface
+     */
+    public function enableDryRun();
+
+    /**
+     * Is Dry Run mode enabled?
+     *
+     * @return boolean
+     */
+    public function isDryRun();
 }

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -504,4 +504,20 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     {
         return $this->getAdapter()->castToBool($value);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableDryRun()
+    {
+        $this->getAdapter()->enableDryRun();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDryRun()
+    {
+        return $this->getAdapter()->isDryRun();
+    }
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -73,6 +73,11 @@ abstract class PdoAdapter implements AdapterInterface
     protected $commandStartTime;
 
     /**
+     * @var boolean
+     */
+    private $dryRun = false;
+
+    /**
      * Class Constructor.
      *
      * @param array $options Options
@@ -335,7 +340,13 @@ abstract class PdoAdapter implements AdapterInterface
      */
     public function execute($sql)
     {
-        return $this->getConnection()->exec($sql);
+        if ($this->dryRun) {
+            $this->getOutput()->writeln($sql);
+            return;
+        }
+        else {
+            return $this->getConnection()->exec($sql);
+        }
     }
 
     /**
@@ -596,5 +607,16 @@ abstract class PdoAdapter implements AdapterInterface
     public function castToBool($value)
     {
         return (bool) $value ? 1 : 0;
+    }
+    
+    /**
+     * Enable Dry Run
+     *
+     * @return AdapterInterface
+     */
+    public function enableDryRun()
+    {
+        $this->dryRun = true;
+        return $this;
     }
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -341,7 +341,10 @@ abstract class PdoAdapter implements AdapterInterface
     public function execute($sql)
     {
         if ($this->dryRun) {
-            $this->getOutput()->writeln($sql);
+            // let's hide the transaction mechanism from the user
+            if ($sql != "COMMIT") {
+                $this->getOutput()->writeln($sql);
+            }
             return;
         }
         else {

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -619,4 +619,14 @@ abstract class PdoAdapter implements AdapterInterface
         $this->dryRun = true;
         return $this;
     }
+    
+    /**
+     * Is Dry Run mode enabled?
+     *
+     * @return boolean
+     */
+    public function isDryRun()
+    {
+        return $this->dryRun;
+    }
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -343,13 +343,28 @@ abstract class PdoAdapter implements AdapterInterface
         if ($this->dryRun) {
             // let's hide the transaction mechanism from the user
             if ($sql != "COMMIT" && $sql != "START TRANSACTION") {
-                $this->getOutput()->writeln($sql);
+                $this->writeSqlToOutput($sql);
             }
             return;
         }
         else {
             return $this->getConnection()->exec($sql);
         }
+    }
+
+    /**
+     * Write SQL Code to Output
+     *
+     * @param string $sql the SQL Code to output.
+     * @return void
+     */
+    private function writeSqlToOutput($sql)
+    {
+        // some SQL code will come with the ending ; while some other won't, so 
+        // we just make sure we print it for the sake of presentation
+        $sql = rtrim($sql, ';').';';
+
+        $this->getOutput()->writeln($sql);
     }
 
     /**
@@ -404,10 +419,9 @@ abstract class PdoAdapter implements AdapterInterface
         $values = array_values($row);
 
         if ($this->dryRun) {
-
             $this->quoteValues($values);
             $sql .= " VALUES (" . implode(', ', $values) . ")";
-            $this->getOutput()->writeln($sql);
+            $this->writeSqlToOutput($sql);
         }
         else {
             $sql .= " VALUES (" . implode(', ', array_fill(0, count($columns), '?')) . ")";

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -345,7 +345,7 @@ abstract class PdoAdapter implements AdapterInterface
             if ($sql != "COMMIT" && $sql != "START TRANSACTION") {
                 $this->writeSqlToOutput($sql);
             }
-            return;
+            return 0;
         }
         else {
             return $this->getConnection()->exec($sql);

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -342,7 +342,7 @@ abstract class PdoAdapter implements AdapterInterface
     {
         if ($this->dryRun) {
             // let's hide the transaction mechanism from the user
-            if ($sql != "COMMIT") {
+            if ($sql != "COMMIT" && $sql != "START TRANSACTION") {
                 $this->getOutput()->writeln($sql);
             }
             return;

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -270,4 +270,12 @@ abstract class AbstractMigration implements MigrationInterface
     {
         $this->table($tableName)->drop();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDryRun()
+    {
+        return $this->getAdapter()->isDryRun();
+    }
 }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -394,9 +394,10 @@ class Manager
      *
      * @param string $name Environment Name
      * @param SeedInterface $seed Seed
+     * @param bool $dryRun Do dry run?
      * @return void
      */
-    public function executeSeed($name, SeedInterface $seed)
+    public function executeSeed($name, SeedInterface $seed, $dryRun = false)
     {
         $this->getOutput()->writeln('');
         $this->getOutput()->writeln(
@@ -407,7 +408,7 @@ class Manager
 
         // Execute the seeder and log the time elapsed.
         $start = microtime(true);
-        $this->getEnvironment($name)->executeSeed($seed);
+        $this->getEnvironment($name)->executeSeed($seed, $dryRun);
         $end = microtime(true);
 
         $this->getOutput()->writeln(
@@ -517,9 +518,10 @@ class Manager
      *
      * @param string $environment Environment
      * @param string $seed Seeder
+     * @param bool $dryRun Do dry run?
      * @return void
      */
-    public function seed($environment, $seed = null)
+    public function seed($environment, $seed = null, $dryRun = false)
     {
         $seeds = $this->getSeeds();
 
@@ -527,13 +529,13 @@ class Manager
             // run all seeders
             foreach ($seeds as $seeder) {
                 if (array_key_exists($seeder->getName(), $seeds)) {
-                    $this->executeSeed($environment, $seeder);
+                    $this->executeSeed($environment, $seeder, $dryRun);
                 }
             }
         } else {
             // run only one seeder
             if (array_key_exists($seed, $seeds)) {
-                $this->executeSeed($environment, $seeds[$seed]);
+                $this->executeSeed($environment, $seeds[$seed], $dryRun);
             } else {
                 throw new \InvalidArgumentException(sprintf('The seed class "%s" does not exist', $seed));
             }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -282,7 +282,7 @@ class Manager
         if (count($outstandingMigrations) > 0) {
             $migration = max($outstandingMigrations);
             $this->getOutput()->writeln('Migrating to version ' . $migration);
-            $this->migrate($environment, $migration);
+            $this->migrate($environment, $migration, $dryRun);
         }
     }
 

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -143,15 +143,20 @@ class Environment
      * Executes the specified seeder on this environment.
      *
      * @param SeedInterface $seed
+     * @param bool $dryRun Do dry run?
      * @return void
      */
-    public function executeSeed(SeedInterface $seed)
+    public function executeSeed(SeedInterface $seed, $dryRun = false)
     {
         $seed->setAdapter($this->getAdapter());
 
         // begin the transaction if the adapter supports it
         if ($this->getAdapter()->hasTransactions()) {
             $this->getAdapter()->beginTransaction();
+        }
+
+        if ($dryRun) {
+            $this->getAdapter()->enableDryRun();   
         }
 
         // Run the seeder

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -90,9 +90,10 @@ class Environment
      *
      * @param MigrationInterface $migration Migration
      * @param string $direction Direction
+     * @param bool $dryRun Do dry run?
      * @return void
      */
-    public function executeMigration(MigrationInterface $migration, $direction = MigrationInterface::UP)
+    public function executeMigration(MigrationInterface $migration, $direction = MigrationInterface::UP, $dryRun = false)
     {
         $startTime = time();
         $direction = ($direction === MigrationInterface::UP) ? MigrationInterface::UP : MigrationInterface::DOWN;
@@ -101,6 +102,10 @@ class Environment
         // begin the transaction if the adapter supports it
         if ($this->getAdapter()->hasTransactions()) {
             $this->getAdapter()->beginTransaction();
+        }
+
+        if ($dryRun) {
+            $this->getAdapter()->enableDryRun();   
         }
 
         // Run the migration

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -212,4 +212,11 @@ interface MigrationInterface
      * @return Table
      */
     public function table($tableName, $options);
+    
+    /**
+     * Returns whether the Migration Adapter is in Dry Run mode
+     *
+     * @return boolean
+     */
+    public function isDryRun();
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -132,4 +132,27 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
         $this->assertSame(0, $exitCode);
     }
+    
+    public function testDryRun()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Migrate());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('migrate');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+                    ->method('migrate');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '--dry-run' => true), array('decorated' => false));
+        $this->assertRegExp('/Doing dry run/', $commandTester->getDisplay());
+    }
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -144,7 +144,9 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('migrate');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs(array($this->config, $this->input, $output))
+            ->getMock();
         $managerStub->expects($this->once())
                     ->method('migrate');
 

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -295,7 +295,9 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('rollback');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs(array($this->config, $this->input, $output))
+            ->getMock();
         $managerStub->expects($this->once())
                     ->method('rollback');
 

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -283,4 +283,27 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $commandTester->execute(array('command' => $command->getName(), '-d' => $targetDate), array('decorated' => false));
         $this->assertRegExp('/ordering by execution time/', $commandTester->getDisplay());
     }
+    
+    public function testDryRun()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+                    ->method('rollback');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '--dry-run' => true), array('decorated' => false));
+        $this->assertRegExp('/Doing dry run/', $commandTester->getDisplay());
+    }
 }

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -163,4 +163,27 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
     }
+
+    public function testDryRun()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new SeedRun());
+ 
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('seed:run');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+                    ->method('seed');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '--dry-run' => true), array('decorated' => false));
+        $this->assertRegExp('/Doing dry run/', $commandTester->getDisplay());
+    }
 }

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -175,7 +175,9 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('seed:run');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs(array($this->config, $this->input, $output))
+            ->getMock();
         $managerStub->expects($this->once())
                     ->method('seed');
 

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -2068,7 +2068,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ];
     }
 
-    public function testExecuteSeedWorksAsExpected()
+    public function testSeed()
     {
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
@@ -2083,7 +2083,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('UserSeeder', $output);
     }
 
-    public function testExecuteASingleSeedWorksAsExpected()
+    public function testSeedSingle()
     {
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
@@ -2100,7 +2100,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The seed class "NonExistentSeeder" does not exist
      */
-    public function testExecuteANonExistentSeedWorksAsExpected()
+    public function testSeedNonExistent()
     {
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -2173,7 +2173,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         }
  
         $managerStub->setEnvironments(array('mockenv' => $envStub));
-        $managerStub->rollback('mockenv', $version, false, true);
+        $managerStub->rollback('mockenv', $version, false, true, true);
     }
 
     /**

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -2077,7 +2077,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testMigrateDryRun($availableMigrations, $version, $expectedExecutedMigrations)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->any())
             ->method('getVersions')
             ->will($this->returnValue($availableMigrations));
@@ -2085,7 +2087,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // stub manager
         $config = new Config($this->getConfigArray());
         $output = new StreamOutput(fopen('php://memory', 'a', false));
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array('executeMigration'), array($config, $output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setMethods(array('executeMigration'))
+            ->setConstructorArgs(array($config, $this->input, $output))
+            ->getMock();
  
         $migrations = $managerStub->getMigrations();
 
@@ -2134,15 +2139,20 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackDryRun($availableRollbacks, $version, $expectedRollbackedMigrations)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->any())
-            ->method('getVersions')
+            ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
         // stub manager
         $config = new Config($this->getConfigArray());
         $output = new StreamOutput(fopen('php://memory', 'a', false));
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array('executeMigration'), array($config, $output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setMethods(array('executeMigration'))
+            ->setConstructorArgs(array($config, $this->input, $output))
+            ->getMock();
  
         $migrations = $managerStub->getMigrations();
 
@@ -2163,7 +2173,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         }
  
         $managerStub->setEnvironments(array('mockenv' => $envStub));
-        $managerStub->rollback('mockenv', $version, true);
+        $managerStub->rollback('mockenv', $version, false, true);
     }
 
     /**
@@ -2174,14 +2184,35 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function rollbackDryRunDataProvider()
     {
         return array(
-            'Rollback to one of the versions' => 
-                array(array('20120111235330', '20120116183504'), '20120111235330', array('20120116183504')),
-            'Rollback to the latest version' => 
-                array(array('20120111235330', '20120116183504'), '20120116183504', null),
-            'Rollback all versions (ie. rollback to version 0)' => 
-                array(array('20120111235330', '20120116183504'), '0', array('20120116183504', '20120111235330')),
-            'Rollback last version' => 
-                array(array('20120111235330', '20120116183504'), null, array('20120116183504')),
+            'Rollback to one of the versions' => array(
+                array(
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0]
+                ),
+                '20120111235330',
+                array('20120116183504')
+            ),
+            'Rollback to the latest version' => array(
+                array(
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0]
+                ),
+                '20120116183504',
+                null),
+            'Rollback all versions (ie. rollback to version 0)' => array(
+                array(
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0]
+                ),
+                '0',
+                array('20120116183504', '20120111235330')),
+            'Rollback last version' => array(
+                array(
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0]
+                ),
+                null,
+                array('20120116183504')),
         );
     }
 
@@ -2247,7 +2278,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // stub manager
         $config = new Config($this->getConfigArray());
         $output = new StreamOutput(fopen('php://memory', 'a', false));
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array('executeSeed'), array($config, $output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setMethods(array('executeSeed'))
+            ->setConstructorArgs(array($config, $this->input, $output))
+            ->getMock();
 
         $seeds = $managerStub->getSeeds();
         $userSeeder = $seeds['UserSeeder'];
@@ -2256,7 +2290,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     ->with($this->equalTo('mockenv'), $this->equalTo($userSeeder), $this->equalTo(true));
 
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         
         $managerStub->setEnvironments(array('mockenv' => $envStub));
         $managerStub->seed('mockenv', 'UserSeeder', true);

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -2078,9 +2078,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager->seed('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('GSeeder', $output);
-        $this->assertContains('PostSeeder', $output);
-        $this->assertContains('UserSeeder', $output);
+        $this->assertContains('GSeeder: seeded', $output);
+        $this->assertContains('PostSeeder: seeded', $output);
+        $this->assertContains('UserSeeder: seeded', $output);
     }
 
     public function testSeedSingle()
@@ -2093,7 +2093,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager->seed('mockenv', 'UserSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('UserSeeder', $output);
+        $this->assertContains('UserSeeder: seeded', $output);
     }
 
     /**
@@ -2108,9 +2108,6 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->seed('mockenv', 'NonExistentSeeder');
-        rewind($this->manager->getOutput()->getStream());
-        $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('UserSeeder', $output);
     }
 
     public function testGettingInputObject()


### PR DESCRIPTION
A new `--dry-run` option was added to the Migrate and Rollback commands, which causes the executed/rollbacked Migrations Code to be outputted instead of executed.

Technically speaking, I implemented it in a way that the new option is passed from the Migrate and Rollback Commands to the `Manager` class, whose `executeMigration` method was updated to print a different text header for the migrations being executed/rollbacked when dry-running. The parameter is then passed on to the `Environment` class' `executeMigration` method which enables dry-running in the `PDOAdapter`. Finally, when a statement is executed via the `PDOAdapter.execute` method, if dry-running was enabled it simply prints the SQL code and returns, instead of actually executing it via the underlying database connection.

For #567 and based on https://github.com/wheniwork/phinx/pull/1
