### PR TITLE
add column without process conment in postgres adapter

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -374,6 +374,14 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
 
         $this->execute($sql);
         $this->endCommandTimer();
+
+        // process column comment
+        if (!empty($column->getComment())) {
+            $this->startCommandTimer();
+            $this->writeCommand('commentColumn', array($table->getName(), $column->getName(), $column->getComment()));
+            $this->execute($this->getColumnCommentSqlDefinition($column, $table->getName()));
+            $this->endCommandTimer();
+        }
     }
 
     /**


### PR DESCRIPTION
If someone use postgres, and add column to a table, phinx forgeted to process the comment in `$options` array.

``` php
        $table = $this->table('trades');
        $table->addColumn(
            'total_amount', 
            PostgresAdapter::PHINX_TYPE_DECIMAL, 
            ['precision' => 10, 'scale' => 2, 'comment' => 'the trade\'s total amount' ]
        )->update();
```
