### PR TITLE
Adding support for mysql adapter to use default collation and engine

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -207,6 +207,15 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             'engine' => 'InnoDB',
             'collation' => 'utf8_general_ci'
         );
+
+        $options = $this->getOptions();
+        if (isset($options['engine'])) {
+            $defaultOptions['engine'] = $options['engine'];
+        }
+        if (isset($options['collation'])) {
+            $defaultOptions['collation'] = $options['collation'];
+        }
+
         $options = array_merge($defaultOptions, $table->getOptions());
 
         // Add the default primary key


### PR DESCRIPTION
This commit makes the mysql adapter to use default collation and engine settings from master configfile, Instead of the fallback of `InnoDB` and `utf8_general_ci` wich were default if no table options were given or present.
