### PR TITLE
Fix date format so it works when mssql is not configured in us-english.

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1169,6 +1169,10 @@ SQL;
      * {@inheritdoc}
      */
     public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime) {
+	    // Fix date format so it works when mssql is not configured in us-english.
+        $startTime = \DateTime::createFromFormat('Y-m-d H:i:s', $startTime)->format('Y-m-d\TH:i:s');
+        $endTime = \DateTime::createFromFormat('Y-m-d H:i:s', $endTime)->format('Y-m-d\TH:i:s');
+		
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(


### PR DESCRIPTION
We cannot run migrations due to problems with date format in the phinxlog table. We use mssql with spanish date format: "dmy". Phinx always use the format 'Y-m-d H:i:s' which is not recognized by mssql with this configuration. Our change sets a date format in the SqlServerAdapter that is always recognized by mssql, regardless language configuration.

Environment:
PHP 5.4.45
SQL Server 2012
