### PR TITLE
AdapterInterface: also provide method to quote string values

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -298,6 +298,14 @@ interface AdapterInterface
     public function quoteColumnName($columnName);
 
     /**
+     * Quotes a string value for use in an sql expression.
+     *
+     * @param string $stringValue the string
+     * @return string
+     */
+    public function quoteStringValue($stringValue);
+
+    /**
      * Checks to see if a table exists.
      *
      * @param string $tableName Table Name

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -324,6 +324,14 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
+    public function quoteStringValue($stringValue)
+    {
+        return $this->getAdapter()->quoteStringValue($stringValue);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasTable($tableName)
     {
         return $this->getAdapter()->hasTable($tableName);

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -333,6 +333,16 @@ abstract class PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
+    public function quoteStringValue($stringValue)
+    {
+        // Note: for example with postgres and mysql, correctly quoting
+        // a string value depends on server and/or connection settings.
+        return $this->getConnection()->quote($stringValue);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function execute($sql)
     {
         return $this->getConnection()->exec($sql);


### PR DESCRIPTION
strictly speaking, a concrete migration must not assume, that
the used adapter is subclass of PdoAdapter (although currently
always is), thus using $this->getAdapter()->getConnection()->quote(..)
is a clutch.
Instead, AdapterInterface should provide the proposed quoteStringValue(...)
function for quoting string values.

Although I think this will not be used often, i would
  a) consider AdapterInterface incomplete without it,
  b) will it indeed be necessary in exceptional cases.
