### PR TITLE
bugfix: schema support for postgresql is broken

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1039,7 +1039,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $this->createSchema($this->getSchemaName());
         }
 
-        $this->fetchAll(sprintf('SET search_path TO %s', $this->getSchemaName()));
+        $this->execute(sprintf('SET search_path TO %s,"$user",public', $this->getSchemaName()));
 
         return parent::createSchemaTable();
     }
@@ -1179,5 +1179,25 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function castToBool($value)
     {
         return (bool) $value ? 'TRUE' : 'FALSE';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersions()
+    {
+        $this->fetchAll(sprintf('SET search_path TO %s,"$user",public', $this->getSchemaName()));
+
+        return parent::getVersions();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersionLog()
+    {
+        $this->fetchAll(sprintf('SET search_path TO %s,"$user",public', $this->getSchemaName()));
+
+        return parent::getVersionLog();
     }
 }


### PR DESCRIPTION
bugfix: handles support for creating a phinx migration inside custom postgresql schemas (referencing issue robmorgan/phinx#915)

PostgreSQL supports schemas to group tables which phinx has supported since introduction of the postgresql adapter. But with commit robmorgan/phinx@a5d7e65e475e6579ff64adad7da1db36c116d29e the setting of the schema search path has been moved from connection setup (set schema search path at connection phase for every following query) to only the adapter functions that need working on different schemas than the default `public` schema. But the functions for getting the actual version and the applied versions seems to have been missed.
