### PR TITLE
Console commands - allow to override command name

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -50,8 +50,10 @@ class Create extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('create')
-            ->setDescription('Create a new migration')
+        if ($this->getName() === null) {
+            $this->setName('create');
+        }
+        $this->setDescription('Create a new migration')
             ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the migration?')
             ->setHelp(sprintf(
                 '%sCreates a new database migration%s',

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -40,8 +40,10 @@ class Init extends Command
      */
     protected function configure()
     {
-        $this->setName('init')
-            ->setDescription('Initialize the application for Phinx')
+        if ($this->getName() === null) {
+            $this->setName('init');
+        }
+        $this->setDescription('Initialize the application for Phinx')
             ->addArgument('path', InputArgument::OPTIONAL, 'Which path should we initialize for Phinx?')
             ->setHelp(sprintf(
                 '%sInitializes the application for Phinx%s',

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -43,8 +43,10 @@ class Migrate extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
-        $this->setName('migrate')
-             ->setDescription('Migrate the database')
+        if ($this->getName() === null) {
+            $this->setName('migrate');
+        }
+        $this->setDescription('Migrate the database')
              ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to migrate to')
              ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to migrate to')
              ->setHelp(

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -43,8 +43,10 @@ class Rollback extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
-        $this->setName('rollback')
-             ->setDescription('Rollback the last or to a specific migration')
+        if ($this->getName() === null) {
+            $this->setName('rollback');
+        }
+        $this->setDescription('Rollback the last or to a specific migration')
              ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to rollback to')
              ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to rollback to')
              ->addOption('--force', '-f', InputOption::VALUE_NONE, 'Force rollback to ignore breakpoints')

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -44,8 +44,10 @@ class SeedCreate extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName('seed:create')
-            ->setDescription('Create a new database seeder')
+        if ($this->getName() === null) {
+            $this->setName('seed:create');
+        }
+        $this->setDescription('Create a new database seeder')
             ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the seeder?')
             ->setHelp(sprintf(
                 '%sCreates a new database seeder%s',

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -43,8 +43,10 @@ class SeedRun extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
-        $this->setName('seed:run')
-             ->setDescription('Run database seeders')
+        if ($this->getName() === null) {
+            $this->setName('seed:run');
+        }
+        $this->setDescription('Run database seeders')
              ->addOption('--seed', '-s', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'What is the name of the seeder?')
              ->setHelp(
 <<<EOT

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -43,8 +43,10 @@ class Status extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment.');
 
-        $this->setName('status')
-             ->setDescription('Show migration status')
+        if ($this->getName() === null) {
+            $this->setName('status');
+        }
+        $this->setDescription('Show migration status')
              ->addOption('--format', '-f', InputOption::VALUE_REQUIRED, 'The output format: text or json. Defaults to text.')
              ->setHelp(
 <<<EOT

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -47,8 +47,10 @@ class Test extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
-        $this->setName('test')
-             ->setDescription('Verify the configuration file')
+        if ($this->getName() === null) {
+            $this->setName('test');
+        }
+        $this->setDescription('Verify the configuration file')
              ->setHelp(
 <<<EOT
 The <info>test</info> command verifies the YAML configuration file and optionally an environment

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -67,6 +67,17 @@ class CreateTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function testCreateCommandOverrideName()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Create("test:CREATE"));
+        $command = $application->find('test:CREATE');
+        self::assertTrue($command instanceof Create);
+    }
+
+    /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The migration class name "MyDuplicateMigration" already exists
      */

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -43,6 +43,17 @@ class InitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function testCreateCommandOverrideName()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Init("test:INIT"));
+        $command = $application->find('test:INIT');
+        self::assertTrue($command instanceof Init);
+    }
+
+    /**
      * @expectedException              \InvalidArgumentException
      * @expectedExceptionMessageRegExp /The file "(.*)" already exists/
      */

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -55,6 +55,17 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
+    /**
+     * @test
+     */
+    public function testCreateCommandOverrideName()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Migrate("test:Migrate"));
+        $command = $application->find('test:Migrate');
+        self::assertTrue($command instanceof Migrate);
+    }
+
     public function testExecute()
     {
         $application = new PhinxApplication('testing');

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -78,6 +78,17 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
     }
 
+    /**
+     * @test
+     */
+    public function testCreateCommandOverrideName()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Rollback("test:Rollback"));
+        $command = $application->find('test:Rollback');
+        self::assertTrue($command instanceof Rollback);
+    }
+
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -57,6 +57,17 @@ class SeedCreateTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function testCreateCommandOverrideName()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new SeedCreate("test:SeedCreate"));
+        $command = $application->find('test:SeedCreate');
+        self::assertTrue($command instanceof SeedCreate);
+    }
+
+    /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The file "MyDuplicateSeeder.php" already exists
      */

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -56,6 +56,17 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
+    /**
+     * @test
+     */
+    public function testCreateCommandOverrideName()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new SeedRun("test:SeedRun"));
+        $command = $application->find('test:SeedRun');
+        self::assertTrue($command instanceof SeedRun);
+    }
+
     public function testExecute()
     {
         $application = new PhinxApplication('testing');

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -55,6 +55,17 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
+    /**
+     * @test
+     */
+    public function testCreateCommandOverrideName()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Status("test:Status"));
+        $command = $application->find('test:Status');
+        self::assertTrue($command instanceof Status);
+    }
+
     public function testExecute()
     {
         $application = new PhinxApplication('testing');


### PR DESCRIPTION
Add ability to override names of console commands bundled with phinx so that one is able to incorporate them in project's custom console

``` php
use Phinx\Console\Command;

$application = new \Symfony\Component\Console\Application();
// ...
// migrations command
$application->addCommands(array(
    new Command\Init("migration:init"),
    new Command\Create("migration:create"),
    new Command\Migrate("migration:migrate"),
    new Command\Rollback("migration:rollback"),
    new Command\Status("migration:status"),
    new Command\Breakpoint("migration:breakpoint"),
    new Command\Test("migration:test"),
    new Command\SeedCreate("migration:seed-create"),
    new Command\SeedRun("migration:seed-run"),
));
// ...
$application->run();
```

That way we get this:

``` bash
$ ./console.php 
Console Tool

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  breakpoint             Manage breakpoints
  help                   Displays help for a command
  list                   Lists commands
 migration
  migration:create       Create a new migration
  migration:init         Initialize the application for Phinx
  migration:migrate      Migrate the database
  migration:rollback     Rollback the last or to a specific migration
  migration:seed-create  Create a new database seeder
  migration:seed-run     Run database seeders
  migration:status       Show migration status
  migration:test         Verify the configuration file
```

instead of this

``` bash
$ ./console.php
Console Tool

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  breakpoint   Manage breakpoints
  create       Create a new migration
  help         Displays help for a command
  init         Initialize the application for Phinx
  list         Lists commands
  migrate      Migrate the database
  rollback     Rollback the last or to a specific migration
  status       Show migration status
  test         Verify the configuration file
 seed
  seed:create  Create a new database seeder
  seed:run     Run database seeders
```
