### PR TITLE
Rollback --target using migration name

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -407,7 +407,7 @@ class Manager
      * Rollback an environment to the specified version.
      *
      * @param string $environment Environment
-     * @param int $target
+     * @param int|string $target
      * @param bool $force
      * @param bool $targetMustMatchVersion
      * @return void


### PR DESCRIPTION
This replaces PR #939.

There is a bug where a any number less than the first migration time stamp (or a typo) supplied to the `--target` option will cause all migrations to be rolled back. Referring to PR #939, I don't think this should be the case and optimistically the `--target` option should actually take the migration name, not the migration id (time stamp) because this functionality is basically incorporated into `--date`. 

What this pull request does is add an explicit check for `all` or `0` passed to the `--target` option to trigger a rollback of all migrations. This doesn't allow typos or small numbers to incorrectly rollback all.

Going forward, I would either prefer the `--target` functionality be changed to take the name, or a new option be added to specify the name. Either way, there may be an issue of non-unique migration names.
