### PR TITLE
Default inherited configuration values

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,6 +49,25 @@ This means that:
             )
           );
 
+Default Keys
+------------
+
+You can add a default value for every property in the environments array by
+simply prefixing the property name with ``default_``. This allows you to
+provide some default values for adapters, schemas and any other configuration
+that might be identical between environments. To override a default for an
+environment, just provide a another value.
+
+.. code-block:: yaml
+
+    environments:
+        default_adapter: mysql
+        default_host: 10.0.0.1
+        production:
+            #adapter: inherits mysql
+        testing:
+            host: localhost # overrides default 10.0.0.1
+
 Migration Paths
 ---------------
 

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -157,12 +157,19 @@ class Config implements ConfigInterface
      */
     public function getEnvironment($name)
     {
+        $defaultPrefix = 'default_';
         $environments = $this->getEnvironments();
 
         if (isset($environments[$name])) {
-            if (isset($this->values['environments']['default_migration_table'])) {
-                $environments[$name]['default_migration_table'] =
-                    $this->values['environments']['default_migration_table'];
+            // find the default global settings keys
+            $defaults = preg_grep('/' . $defaultPrefix . '/', array_keys($this->values['environments']));
+
+            // populate local settings with defaults (if they aren't already overridden)
+            foreach ($defaults as $default) {
+                $property = substr($default, strlen($defaultPrefix));
+                if (!isset($environments[$name][$property])) {
+                    $environments[$name][$property] = $this->values['environments'][$default];
+                }
             }
 
             return $environments[$name];

--- a/tests/Phinx/Config/AbstractConfigTest.php
+++ b/tests/Phinx/Config/AbstractConfigTest.php
@@ -45,6 +45,8 @@ abstract class AbstractConfigTest extends \PHPUnit_Framework_TestCase
             'environments' => array(
                 'default_migration_table' => 'phinxlog',
                 'default_database' => 'testing',
+                'default_adapter' => 'pgsql',
+                'default_host' => 'localhost',
                 'testing' => array(
                     'adapter' => 'sqllite',
                     'wrapper' => 'testwrapper',

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -88,6 +88,16 @@ class ConfigTest extends AbstractConfigTest
     /**
      * @covers \Phinx\Config\Config::getEnvironment
      */
+    public function testGetDefaultEnvironmentMethod()
+    {
+        $config = new Config($this->getConfigArray());
+        $db = $config->getEnvironment('testing');
+        $this->assertEquals('localhost', $db['host']);
+    }
+
+    /**
+     * @covers \Phinx\Config\Config::getEnvironment
+     */
     public function testHasEnvironmentMethod()
     {
         $configArray = $this->getConfigArray();

--- a/tests/Phinx/Config/ConfigYamlTest.php
+++ b/tests/Phinx/Config/ConfigYamlTest.php
@@ -58,4 +58,26 @@ class ConfigYamlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('externally-specified-environment', $config->getDefaultEnvironment());
         putenv('PHINX_ENVIRONMENT=');
     }
+
+    /**
+     * @covers \Phinx\Config\Config::getDefaultEnvironment
+     */
+    public function testDefaultReplacementValues()
+    {
+        $path = __DIR__ . '/_files';
+        $config = Config::fromYaml($path . '/default_replacement.yml');
+        $this->assertEquals('global_test_schema', $config->getEnvironment('production')['schema']);
+        $this->assertEquals('global_test_user_name', $config->getEnvironment('production')['user']);
+    }
+
+    /**
+     * @covers \Phinx\Config\Config::getDefaultEnvironment
+     */
+    public function testDefaultNotReplaceIfExists()
+    {
+        $path = __DIR__ . '/_files';
+        $config = Config::fromYaml($path . '/default_replacement.yml');
+        $this->assertNotEquals('global_test_schema', $config->getEnvironment('testing')['schema']);
+        $this->assertNotEquals('global_test_user_name', $config->getEnvironment('testing')['user']);
+    }
 }

--- a/tests/Phinx/Config/_files/default_replacement.yml
+++ b/tests/Phinx/Config/_files/default_replacement.yml
@@ -1,0 +1,23 @@
+paths:
+    migrations: %%PHINX_CONFIG_DIR%%/migrations
+
+environments:
+    default_migration_table: phinxlog
+    default_schema: global_test_schema
+    default_user: global_test_user_name
+
+    production:
+        adapter: mysql
+        host: localhost
+        name: production_db
+        pass: ''
+        port: 3306
+
+    testing:
+        adapter: mysql
+        host: localhost
+        name: testing_db
+        schema: local_test_schema
+        user: root
+        pass: ''
+        port: 3306


### PR DESCRIPTION
This refers to issue #937. All values now allow a default value defined under the environments array and will be inherited (if not overridden) into the selected environment. Helpful if a schema is consistently not 'public' or hosts are same between environments. It could probably still do with some work, so please leave some comments/feedback.
