### PR TITLE
dropConstraint method added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
 before_script:
     - travis_retry composer self-update
     - travis_retry composer update --no-interaction --prefer-source --prefer-stable ${COMPOSER_FLAGS}
-    - mysql -e 'create database phinx_testing;'
-    - psql -c 'create database phinx_testing;' -U postgres
+    - mysql -e 'create database public;'
+    - psql -c 'create database public;' -U postgres
 
 script:
     - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
 before_script:
     - travis_retry composer self-update
     - travis_retry composer update --no-interaction --prefer-source --prefer-stable ${COMPOSER_FLAGS}
-    - mysql -e 'create database public;'
-    - psql -c 'create database public;' -U postgres
+    - mysql -e 'create database phinx_testing;'
+    - psql -c 'create database phinx_testing;' -U postgres
 
 script:
     - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
   - echo extension=php_openssl.dll >> php.ini
   - echo extension=php_sqlsrv.dll >> php.ini
   - echo extension=php_pdo_sqlsrv.dll >> php.ini
+  - echo extension=php_pdo_mysql.dll >> php.ini
   - cd C:\projects\phinx
   - php -r "readfile('https://getcomposer.org/installer');" | php
   - php composer.phar install --prefer-dist --no-interaction --dev

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "robmorgan/phinx",
+    "name": "chilimatic/phinx",
     "type": "library",
-    "description": "Phinx makes it ridiculously easy to manage the database migrations for your PHP app.",
+    "description": "This is only because he didn't accept my pull request and i cannot wait forever",
     "keywords": ["phinx", "migrations", "database", "db", "database migrations"],
     "homepage": "https://phinx.org",
     "license": "MIT",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,7 +31,7 @@
         <env name="TESTS_PHINX_DB_ADAPTER_POSTGRES_USERNAME" value="postgres" />
         <env name="TESTS_PHINX_DB_ADAPTER_POSTGRES_PASSWORD" value="" />
         <env name="TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE" value="phinx_testing" />
-        <env name="TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE_SCHEMA" value="public" />
+        <env name="TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE_SCHEMA" value="phinx_testing" />
         <env name="TESTS_PHINX_DB_ADAPTER_POSTGRES_PORT" value="5432" />
         <!-- SQLite -->
         <env name="TESTS_PHINX_DB_ADAPTER_SQLITE_ENABLED" value="true" />

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -331,9 +331,14 @@ interface AdapterInterface
     public function dropTable($tableName);
 
     /**
+     * this will drop the primary key in MySQL & SQLite but in pgSQL they are called constraints that why it's called
+     * drop constraint and not drop primary key because a primary key is only a special form of a constraint
+     * still the procedures for mysql and sqlite will only remove the primary key.
+     *
      * @param $tableName
      * @param null $columnName
      * @param null $constraintName
+     * @throws \InvalidArgumentException
      * @return mixed
      */
     public function dropConstraint($tableName, $columnName = null, $constraintName = null);
@@ -490,6 +495,7 @@ interface AdapterInterface
      *
      * @param string $type
      * @param integer $limit
+     * @throws \RuntimeException
      * @return string
      */
     public function getSqlType($type, $limit = null);

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -331,6 +331,14 @@ interface AdapterInterface
     public function dropTable($tableName);
 
     /**
+     * @param $tableName
+     * @param null $columnName
+     * @param null $constraintName
+     * @return mixed
+     */
+    public function dropConstraint($tableName, $columnName = null, $constraintName = null);
+
+    /**
      * Returns table columns
      *
      * @param string $tableName Table Name
@@ -372,6 +380,7 @@ interface AdapterInterface
      * @param string $tableName  Table Name
      * @param string $columnName Column Name
      * @param Column $newColumn  New Column
+     * @throws \InvalidArgumentException
      * @return Table
      */
     public function changeColumn($tableName, $columnName, Column $newColumn);
@@ -381,6 +390,7 @@ interface AdapterInterface
      *
      * @param string $tableName Table Name
      * @param string $columnName Column Name
+     * @throws \InvalidArgumentException
      * @return void
      */
     public function dropColumn($tableName, $columnName);
@@ -455,6 +465,7 @@ interface AdapterInterface
      * @param string   $tableName
      * @param string[] $columns    Column(s)
      * @param string   $constraint Constraint name
+     * @throws \InvalidArgumentException
      * @return void
      */
     public function dropForeignKey($tableName, $columns, $constraint = null);

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -189,7 +189,8 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             "SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
-            $options['name'], $tableName
+            (string) isset($options['name']) ? $options['name'] : '',
+            $tableName
         ));
 
         return !empty($exists);

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -331,6 +331,18 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
+    public function dropConstraint($tableName, $columnName = null, $constraintName = null)
+    {
+        $this->startCommandTimer();
+        $this->writeCommand('dropPrimaryKey', array($tableName));
+        $this->execute(sprintf('ALTER TABLE %s DROP PRIMARY KEY', $this->quoteTableName($tableName)));
+        $this->endCommandTimer();
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
     public function getColumns($tableName)
     {
         $columns = array();
@@ -627,7 +639,6 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             return false;
         } else {
             foreach ($foreignKeys as $key) {
-                $a = array_diff($columns, $key['columns']);
                 if ($columns == $key['columns']) {
                     return true;
                 }
@@ -848,7 +859,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'set');
                 break;
             case static::TYPE_YEAR:
-                if (!$limit || in_array($limit, array(2, 4)))
+                if (!$limit || in_array($limit, array(2, 4), false))
                     $limit = 4;
                 return array('name' => 'year', 'limit' => $limit);
                 break;

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -334,7 +334,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     public function dropConstraint($tableName, $columnName = null, $constraintName = null)
     {
         $this->startCommandTimer();
-        $this->writeCommand('dropPrimaryKey', array($tableName));
+        $this->writeCommand('dropConstraint', array($tableName));
         $this->execute(sprintf('ALTER TABLE %s DROP PRIMARY KEY', $this->quoteTableName($tableName)));
         $this->endCommandTimer();
     }

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -502,7 +502,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      * @param string $tableName Table Name
      * @return array
      */
-    protected function getIndexes($tableName)
+    public function getIndexes($tableName)
     {
         $indexes = array();
         $sql = "SELECT

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -740,7 +740,12 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function dropConstraint($tableName, $columnName = null, $constraintName = null)
     {
+        // this is not ideal but the dropping of the key is set at least
+        $this->startCommandTimer();
+        $this->writeCommand('dropConstraint', array($tableName, $columnName));
+        // since the foreign key already contains the logic DRY
         $this->dropForeignKey($tableName, $columnName, $constraintName);
+        $this->endCommandTimer();
     }
 
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -738,6 +738,15 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
+    public function dropConstraint($tableName, $columnName = null, $constraintName = null)
+    {
+        $this->dropForeignKey($tableName, $columnName, $constraintName);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
     public function getSqlType($type, $limit = null)
     {
         switch ($type) {

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -151,6 +151,11 @@ class ProxyAdapter extends AdapterWrapper
         $this->recordCommand('dropForeignKey', array($columns, $constraint));
     }
 
+    public function dropConstraint($tableName, $columnName = null, $constraintName = null)
+    {
+        $this->recordCommand('dropConstraint', array($columnName, $constraintName));
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -801,7 +801,7 @@ class SQLiteAdapter extends PdoAdapter
 
         // removes the two different syntax forms (id int primary key, .... ) && (id int, PRIMARY KEY (id))
         $sql = preg_replace("/([,][\s]+PRIMARY KEY[\s]*\((?:[\w `][,]?)+\)|PRIMARY KEY[\s]*[,]?)/", '', $sql);
-
+        $sql = str_ireplace('AUTOINCREMENT', '', $sql);
 
         $this->renameTable($tableName, $tmpTableName);
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -38,7 +38,7 @@ use Phinx\Db\Table\ForeignKey;
  *
  * @author Rob Morgan <robbym@gmail.com>
  */
-class SqlServerAdapter extends PdoAdapter implements AdapterInterface
+class SqlServerAdapter extends PdoAdapter
 {
     protected $schema = 'dbo';
 
@@ -881,6 +881,14 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * {@inheritdoc}
      */
+    public function dropConstraint($tableName, $columnName = null, $constraintName = null) {
+        $this->dropForeignKey($tableName, $columnName, $constraintName);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
     public function getSqlType($type, $limit = null)
     {
         switch ($type) {
@@ -943,7 +951,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * Returns Phinx type by SQL type
      *
-     * @param $sqlTypeDef
+     * @param $sqlType
      * @throws \RuntimeException
      * @internal param string $sqlType SQL type
      * @returns string Phinx type

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -231,6 +231,15 @@ class TablePrefixAdapter extends AdapterWrapper
     /**
      * {@inheritdoc}
      */
+    public function dropConstraint($tableName, $columnName = null, $constraintName = null)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+        return parent::dropConstraint($adapterTableName, $columnName, $constraintName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function insert(Table $table, $row)
     {
         $adapterTable = clone $table;

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -540,6 +540,21 @@ class Table
         return $this;
     }
 
+
+    /**
+     * drops the primary key of a table
+     *
+     * @param $column
+     * @param null $constraint
+     * @throws \InvalidArgumentException
+     */
+    public function dropContraint($column, $constraint = null) {
+        if (!is_string($column)) {
+            throw new \InvalidArgumentException('Column parameter has to be of type string');
+        }
+        $this->getAdapter()->dropConstraint($this->getName(), $column, $constraint);
+    }
+
     /**
      * Checks to see if a foreign key exists.
      *
@@ -600,6 +615,7 @@ class Table
         $this->data[] = $data;
         return $this;
     }
+
 
     /**
      * Creates a table from the object instance.

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -548,10 +548,7 @@ class Table
      * @param null $constraint
      * @throws \InvalidArgumentException
      */
-    public function dropContraint($column, $constraint = null) {
-        if (!is_string($column)) {
-            throw new \InvalidArgumentException('Column parameter has to be of type string');
-        }
+    public function dropConstraint($column, $constraint = null) {
         $this->getAdapter()->dropConstraint($this->getName(), $column, $constraint);
     }
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -505,7 +505,7 @@ class Column
             'signed',
             'timezone',
             'properties',
-            'values',
+            'values'
         );
     }
 

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -79,7 +79,19 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -104,7 +116,19 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -126,7 +150,19 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
 
         $this->config['templates'] = array(
             'file' => 'MyTemplate',
@@ -186,7 +222,19 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;
@@ -248,7 +296,19 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;
@@ -309,7 +369,19 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -65,8 +65,21 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'migrate'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+        $managerStub->expects(static::once())
                     ->method('migrate');
 
         $command->setConfig($this->config);
@@ -89,8 +102,21 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
-        $managerStub->expects($this->any())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'migrate'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+        $managerStub->expects(static::any())
                     ->method('migrate');
 
         $command->setConfig($this->config);
@@ -113,8 +139,22 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'migrate'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+
+        $managerStub->expects(static::once())
                     ->method('migrate');
 
         $command->setConfig($this->config);

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -79,7 +79,7 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $managerStub->setConfig($this->config);
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('migrate');
 
         $command->setConfig($this->config);
@@ -116,7 +116,7 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $managerStub->setConfig($this->config);
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
-        $managerStub->expects(static::any())
+        $managerStub->expects($this->any())
                     ->method('migrate');
 
         $command->setConfig($this->config);
@@ -154,7 +154,7 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
 
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('migrate');
 
         $command->setConfig($this->config);

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -65,8 +65,21 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'rollback'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+        $managerStub->expects(static::once())
                     ->method('rollback');
 
         $command->setConfig($this->config);
@@ -88,8 +101,21 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'rollback'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+        $managerStub->expects(static::once())
                     ->method('rollback');
 
         $command->setConfig($this->config);
@@ -110,8 +136,21 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'rollback'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+
+        $managerStub->expects(static::once())
                     ->method('rollback');
 
         $command->setConfig($this->config);

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -79,7 +79,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $managerStub->setConfig($this->config);
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('rollback');
 
         $command->setConfig($this->config);
@@ -115,7 +115,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $managerStub->setConfig($this->config);
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('rollback');
 
         $command->setConfig($this->config);
@@ -150,7 +150,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
 
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('rollback');
 
         $command->setConfig($this->config);

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -70,7 +70,19 @@ class SeedCreateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -94,7 +106,19 @@ class SeedCreateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -80,7 +80,7 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         $managerStub->setConfig($this->config);
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('seed')->with($this->identicalTo('development'), $this->identicalTo(null));
 
         $command->setConfig($this->config);
@@ -116,7 +116,7 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         $managerStub->setConfig($this->config);
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
-        $managerStub->expects(static::any())
+        $managerStub->expects($this->any())
                     ->method('migrate');
 
         $command->setConfig($this->config);
@@ -152,7 +152,7 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
 
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('seed');
 
         $command->setConfig($this->config);
@@ -188,7 +188,7 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
 
-        $managerStub->expects(static::exactly(3))
+        $managerStub->expects($this->exactly(3))
                     ->method('seed')->withConsecutive(
                         array($this->identicalTo('development'), $this->identicalTo('One')),
                         array($this->identicalTo('development'), $this->identicalTo('Two')),

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -66,8 +66,21 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'seed'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+        $managerStub->expects(static::once())
                     ->method('seed')->with($this->identicalTo('development'), $this->identicalTo(null));
 
         $command->setConfig($this->config);
@@ -89,8 +102,21 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->any())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'migrate'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+        $managerStub->expects(static::any())
                     ->method('migrate');
 
         $command->setConfig($this->config);
@@ -111,8 +137,22 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'seed'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+
+        $managerStub->expects(static::once())
                     ->method('seed');
 
         $command->setConfig($this->config);
@@ -133,8 +173,22 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->exactly(3))
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'seed'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+
+        $managerStub->expects(static::exactly(3))
                     ->method('seed')->withConsecutive(
                         array($this->identicalTo('development'), $this->identicalTo('One')),
                         array($this->identicalTo('development'), $this->identicalTo('Two')),

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -65,10 +65,24 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'printStatus'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+
+        $managerStub->expects(static::once())
                     ->method('printStatus')
-                    ->will($this->returnValue(0));
+                    ->will(static::returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -90,10 +104,23 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'printStatus'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+        $managerStub->expects(static::once())
                     ->method('printStatus')
-                    ->will($this->returnValue(0));
+                    ->will(static::returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -114,10 +141,24 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
-        $managerStub->expects($this->once())
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'setConfig',
+                    'setInput',
+                    'setOutput',
+                    'printStatus'
+                ]
+            )
+            ->getMock();
+        $managerStub->setConfig($this->config);
+        $managerStub->setInput($this->input);
+        $managerStub->setOutput($this->output);
+
+        $managerStub->expects(static::once())
                     ->method('printStatus')
-                    ->will($this->returnValue(0));
+                    ->will(static::returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -80,9 +80,9 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
 
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('printStatus')
-                    ->will(static::returnValue(0));
+                    ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -118,9 +118,9 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $managerStub->setConfig($this->config);
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('printStatus')
-                    ->will(static::returnValue(0));
+                    ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -156,9 +156,9 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $managerStub->setInput($this->input);
         $managerStub->setOutput($this->output);
 
-        $managerStub->expects(static::once())
+        $managerStub->expects($this->once())
                     ->method('printStatus')
-                    ->will(static::returnValue(0));
+                    ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -90,7 +90,9 @@ class AdapterFactoryTest extends \PHPUnit_Framework_TestCase
 
     private function getAdapterMock()
     {
-        return $this->getMock('Phinx\Db\Adapter\AdapterInterface', array());
+        return $this->getMockBuilder('Phinx\Db\Adapter\AdapterInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     public function testGetWrapper()

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -1508,6 +1508,11 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         $this->adapter->dropForeignKey('table_name', 'column_name', 'fk1');
     }
 
+    public function testDropContraint() {
+        $this->assertExecuteSql('ALTER TABLE `table_name` DROP PRIMARY KEY');
+        $this->adapter->dropConstraint('table_name');
+    }
+
     public function _testDropForeignKeyAsArrayByConstraint()
     {
         $this->assertExecuteSql('ALTER TABLE `table_name` DROP FOREIGN KEY fk1');

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -1508,7 +1508,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         $this->adapter->dropForeignKey('table_name', 'column_name', 'fk1');
     }
 
-    public function testDropContraint() {
+    public function testDropConstraint() {
         $this->assertExecuteSql('ALTER TABLE `table_name` DROP PRIMARY KEY');
         $this->adapter->dropConstraint('table_name');
     }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -87,26 +87,26 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     // helper methods for easy mocking
     private function assertExecuteSql($expected_sql)
     {
-        $this->conn->expects(static::once())
+        $this->conn->expects($this->once())
                    ->method('exec')
                    ->with($this->equalTo($expected_sql));
     }
 
     private function assertQuerySql($expectedSql, $returnValue = null)
     {
-        $expect = $this->conn->expects(static::once())
+        $expect = $this->conn->expects($this->once())
                        ->method('query')
                        ->with($this->equalTo($expectedSql));
         if (!is_null($returnValue)) {
-            $expect->will(static::returnValue($returnValue));
+            $expect->will($this->returnValue($returnValue));
         }
     }
 
     private function assertFetchRowSql($expectedSql, $returnValue)
     {
-        $this->result->expects(static::once())
+        $this->result->expects($this->once())
                      ->method('fetch')
-                     ->will(static::returnValue($returnValue));
+                     ->will($this->returnValue($returnValue));
         $this->assertQuerySql($expectedSql, $this->result);
     }
 
@@ -123,12 +123,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
     public function testHasDatabaseExists()
     {
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue(array('SCHEMA_NAME' => 'database_name')));
-        $this->result->expects(static::at(1))
+                     ->will($this->returnValue(array('SCHEMA_NAME' => 'database_name')));
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'database_name'", $this->result);
 
@@ -137,9 +137,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
     public function testHasDatabaseNotExists()
     {
-        $this->result->expects(static::once())
+        $this->result->expects($this->once())
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'database_name2'", $this->result);
 
@@ -229,9 +229,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     public function testHasTableExists()
     {
         $this->adapter->setOptions(array('name'=>'database_name'));
-        $this->result->expects(static::once())
+        $this->result->expects($this->once())
                      ->method('fetch')
-                     ->will(static::returnValue(array('somecontent')));
+                     ->will($this->returnValue(array('somecontent')));
         $expectedSql = 'SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA = \'database_name\' AND TABLE_NAME = \'table_name\'';
@@ -242,9 +242,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     public function testHasTableNotExists()
     {
         $this->adapter->setOptions(array('name'=>'database_name'));
-        $this->result->expects(static::once())
+        $this->result->expects($this->once())
                      ->method('fetch')
-                     ->will(static::returnValue(array()));
+                     ->will($this->returnValue(array()));
         $expectedSql = 'SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA = \'database_name\' AND TABLE_NAME = \'table_name\'';
@@ -259,31 +259,31 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column1->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column1->expects(static::any())->method('getType')->will(static::returnValue('string'));
-        $column1->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column1->expects(static::at(0))->method('getLimit')->will(static::returnValue('64'));
+        $column1->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column1->expects($this->any())->method('getType')->will($this->returnValue('string'));
+        $column1->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column1->expects($this->at(0))->method('getLimit')->will($this->returnValue('64'));
 
         $column2 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column2->expects(static::any())->method('getName')->will(static::returnValue('column_name2'));
-        $column2->expects(static::any())->method('getType')->will(static::returnValue('integer'));
-        $column2->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column2->expects(static::at(0))->method('getLimit')->will(static::returnValue('4'));
+        $column2->expects($this->any())->method('getName')->will($this->returnValue('column_name2'));
+        $column2->expects($this->any())->method('getType')->will($this->returnValue('integer'));
+        $column2->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column2->expects($this->at(0))->method('getLimit')->will($this->returnValue('4'));
 
         $table = $this->getMockBuilder('Phinx\Db\Table')
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName', 'getOptions', 'getPendingColumns', 'getIndexes', 'getForeignKeys'))
                       ->getMock();
 
-        $table->expects(static::any())->method('getPendingColumns')->will(static::returnValue(array($column1,$column2)));
-        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
-        $table->expects(static::any())->method('getOptions')->will(static::returnValue(array()));
-        $table->expects(static::any())->method('getIndexes')->will(static::returnValue(array()));
-        $table->expects(static::any())->method('getForeignKeys')->will(static::returnValue(array()));
+        $table->expects($this->any())->method('getPendingColumns')->will($this->returnValue(array($column1,$column2)));
+        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
+        $table->expects($this->any())->method('getOptions')->will($this->returnValue(array()));
+        $table->expects($this->any())->method('getIndexes')->will($this->returnValue(array()));
+        $table->expects($this->any())->method('getForeignKeys')->will($this->returnValue(array()));
 
         $expectedSql = 'CREATE TABLE `table_name` (`id` INT(11) NOT NULL AUTO_INCREMENT, `column_name` VARCHAR(255) NOT NULL, `column_name2` INT(11) NOT NULL, PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;';
         $this->assertExecuteSql($expectedSql);
@@ -297,20 +297,20 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column1->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column1->expects(static::any())->method('getType')->will(static::returnValue('string'));
-        $column1->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column1->expects(static::at(0))->method('getLimit')->will(static::returnValue('64'));
+        $column1->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column1->expects($this->any())->method('getType')->will($this->returnValue('string'));
+        $column1->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column1->expects($this->at(0))->method('getLimit')->will($this->returnValue('64'));
 
         $column2 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column2->expects(static::any())->method('getName')->will(static::returnValue('column_name2'));
-        $column2->expects(static::any())->method('getType')->will(static::returnValue('integer'));
-        $column2->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column2->expects(static::at(0))->method('getLimit')->will(static::returnValue('4'));
+        $column2->expects($this->any())->method('getName')->will($this->returnValue('column_name2'));
+        $column2->expects($this->any())->method('getType')->will($this->returnValue('integer'));
+        $column2->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column2->expects($this->at(0))->method('getLimit')->will($this->returnValue('4'));
 
         $table = $this->getMockBuilder('Phinx\Db\Table')
                       ->disableOriginalConstructor()
@@ -318,11 +318,11 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->getMock();
 
         $tableOptions = array('id' => 'column_name2');
-        $table->expects(static::any())->method('getPendingColumns')->will(static::returnValue(array($column1,$column2)));
-        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
-        $table->expects(static::any())->method('getOptions')->will(static::returnValue($tableOptions));
-        $table->expects(static::any())->method('getIndexes')->will(static::returnValue(array()));
-        $table->expects(static::any())->method('getForeignKeys')->will(static::returnValue(array()));
+        $table->expects($this->any())->method('getPendingColumns')->will($this->returnValue(array($column1,$column2)));
+        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
+        $table->expects($this->any())->method('getOptions')->will($this->returnValue($tableOptions));
+        $table->expects($this->any())->method('getIndexes')->will($this->returnValue(array()));
+        $table->expects($this->any())->method('getForeignKeys')->will($this->returnValue(array()));
 
         $expectedSql = 'CREATE TABLE `table_name` (`column_name2` INT(11) NOT NULL AUTO_INCREMENT, `column_name` VARCHAR(255) NOT NULL, `column_name2` INT(11) NOT NULL, PRIMARY KEY (`column_name2`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;';
         $this->assertExecuteSql($expectedSql);
@@ -336,7 +336,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName', 'getOptions', 'getPendingColumns', 'getIndexes', 'getForeignKeys'))
                       ->getMock();
-        $refTable->expects(static::any())->method('getName')->will(static::returnValue('other_table'));
+        $refTable->expects($this->any())->method('getName')->will($this->returnValue('other_table'));
 
 
         $table = $this->getMockBuilder('Phinx\Db\Table')
@@ -349,44 +349,44 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                               'id' => array('ref_id','other_table_id'),
                               'primary_key' => array('ref_id','other_table_id'),
                               'comment' => "Table Comment");
-        $this->conn->expects(static::any())->method('quote')->with('Table Comment')->will(static::returnValue('`Table Comment`'));
+        $this->conn->expects($this->any())->method('quote')->with('Table Comment')->will($this->returnValue('`Table Comment`'));
 
         $column1 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column1->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column1->expects(static::any())->method('getType')->will(static::returnValue('string'));
-        $column1->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column1->expects(static::at(0))->method('getLimit')->will(static::returnValue('64'));
+        $column1->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column1->expects($this->any())->method('getType')->will($this->returnValue('string'));
+        $column1->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column1->expects($this->at(0))->method('getLimit')->will($this->returnValue('64'));
 
         $column2 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column2->expects(static::any())->method('getName')->will(static::returnValue('other_table_id'));
-        $column2->expects(static::any())->method('getType')->will(static::returnValue('integer'));
-        $column2->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column2->expects(static::at(0))->method('getLimit')->will(static::returnValue('4'));
+        $column2->expects($this->any())->method('getName')->will($this->returnValue('other_table_id'));
+        $column2->expects($this->any())->method('getType')->will($this->returnValue('integer'));
+        $column2->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column2->expects($this->at(0))->method('getLimit')->will($this->returnValue('4'));
 
         $column3 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column3->expects(static::any())->method('getName')->will(static::returnValue('ref_id'));
-        $column3->expects(static::any())->method('getType')->will(static::returnValue('integer'));
-        $column3->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column3->expects(static::at(0))->method('getLimit')->will(static::returnValue('11'));
+        $column3->expects($this->any())->method('getName')->will($this->returnValue('ref_id'));
+        $column3->expects($this->any())->method('getType')->will($this->returnValue('integer'));
+        $column3->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column3->expects($this->at(0))->method('getLimit')->will($this->returnValue('11'));
 
         $index = $this->getMockBuilder('Phinx\Db\Table\Index')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getColumns'))
                       ->getMock();
 
-        $index->expects(static::any())->method('getColumns')->will(static::returnValue(array('column_name')));
+        $index->expects($this->any())->method('getColumns')->will($this->returnValue(array('column_name')));
 
         $foreignkey = $this->getMockBuilder('Phinx\Db\Table\ForeignKey')
                            ->disableOriginalConstructor()
@@ -398,18 +398,18 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                                                'getReferencedTable'))
                            ->getMock();
 
-        $foreignkey->expects(static::any())->method('getColumns')->will(static::returnValue(array('other_table_id')));
-        $foreignkey->expects(static::any())->method('getConstraint')->will(static::returnValue('fk1'));
-        $foreignkey->expects(static::any())->method('getReferencedColumns')->will(static::returnValue(array('id')));
-        $foreignkey->expects(static::any())->method('getReferencedTable')->will(static::returnValue($refTable));
-        $foreignkey->expects(static::any())->method('getOnDelete')->will(static::returnValue(null));
-        $foreignkey->expects(static::any())->method('getOnUpdate')->will(static::returnValue(null));
+        $foreignkey->expects($this->any())->method('getColumns')->will($this->returnValue(array('other_table_id')));
+        $foreignkey->expects($this->any())->method('getConstraint')->will($this->returnValue('fk1'));
+        $foreignkey->expects($this->any())->method('getReferencedColumns')->will($this->returnValue(array('id')));
+        $foreignkey->expects($this->any())->method('getReferencedTable')->will($this->returnValue($refTable));
+        $foreignkey->expects($this->any())->method('getOnDelete')->will($this->returnValue(null));
+        $foreignkey->expects($this->any())->method('getOnUpdate')->will($this->returnValue(null));
 
-        $table->expects(static::any())->method('getPendingColumns')->will(static::returnValue(array($column1, $column2, $column3)));
-        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
-        $table->expects(static::any())->method('getOptions')->will(static::returnValue($tableOptions));
-        $table->expects(static::any())->method('getIndexes')->will(static::returnValue(array($index)));
-        $table->expects(static::any())->method('getForeignKeys')->will(static::returnValue(array($foreignkey)));
+        $table->expects($this->any())->method('getPendingColumns')->will($this->returnValue(array($column1, $column2, $column3)));
+        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
+        $table->expects($this->any())->method('getOptions')->will($this->returnValue($tableOptions));
+        $table->expects($this->any())->method('getIndexes')->will($this->returnValue(array($index)));
+        $table->expects($this->any())->method('getForeignKeys')->will($this->returnValue(array($foreignkey)));
 
         $expectedSql ='CREATE TABLE `table_name` (`column_name` VARCHAR(255) NOT NULL, `other_table_id` INT(11) NOT NULL, `ref_id` INT(11) NOT NULL, PRIMARY KEY (`ref_id`,`other_table_id`),  KEY (`column_name`),  CONSTRAINT `fk1` FOREIGN KEY (`other_table_id`) REFERENCES `other_table` (`id`)) ENGINE = MyISAM CHARACTER SET latin1 COLLATE latin1_swedish_ci COMMENT=`Table Comment`;';
         $this->assertExecuteSql($expectedSql);
@@ -436,15 +436,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Key'     => '',
                          'Extra'   => '');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($column1));
-        $this->result->expects(static::at(1))
+                     ->will($this->returnValue($column1));
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue($column2));
-        $this->result->expects(static::at(2))
+                     ->will($this->returnValue($column2));
+        $this->result->expects($this->at(2))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql("SHOW COLUMNS FROM `table_name`", $this->result);
 
@@ -485,15 +485,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($column1));
-        $this->result->expects(static::at(1))
+                     ->will($this->returnValue($column1));
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue($column2));
-        $this->result->expects(static::at(2))
+                     ->will($this->returnValue($column2));
+        $this->result->expects($this->at(2))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql('SHOW COLUMNS FROM `table_name`', $this->result);
 
@@ -507,10 +507,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit'))
                       ->getMock();
 
-        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column->expects(static::any())->method('getLimit')->will(static::returnValue('11'));
-        $column->expects(static::any())->method('getType')->will(static::returnValue('integer'));
+        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column->expects($this->any())->method('getLimit')->will($this->returnValue('11'));
+        $column->expects($this->any())->method('getType')->will($this->returnValue('integer'));
 
         $this->assertEquals("INT(11) NOT NULL",
                             $this->adapter->getColumnSqlDefinition($column));
@@ -523,11 +523,11 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit', 'getScale', 'getPrecision'))
                       ->getMock();
 
-        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column->expects(static::any())->method('getType')->will(static::returnValue('float'));
-        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column->expects(static::any())->method('getPrecision')->will(static::returnValue('8'));
-        $column->expects(static::any())->method('getScale')->will(static::returnValue('3'));
+        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column->expects($this->any())->method('getType')->will($this->returnValue('float'));
+        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column->expects($this->any())->method('getPrecision')->will($this->returnValue('8'));
+        $column->expects($this->any())->method('getScale')->will($this->returnValue('3'));
 
         $this->assertEquals("FLOAT(8,3) NOT NULL",
                             $this->adapter->getColumnSqlDefinition($column));
@@ -543,11 +543,11 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column->expects(static::any())->method('getType')->will(static::returnValue('text'));
-        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column->expects(static::at(0))->method('getLimit')->will(static::returnValue('2048'));
-        $column->expects(static::at(1))->method('getLimit')->will(static::returnValue(null));
+        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column->expects($this->any())->method('getType')->will($this->returnValue('text'));
+        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column->expects($this->at(0))->method('getLimit')->will($this->returnValue('2048'));
+        $column->expects($this->at(1))->method('getLimit')->will($this->returnValue(null));
 
         $this->assertEquals("TEXT NOT NULL",
                             $this->adapter->getColumnSqlDefinition($column));
@@ -555,10 +555,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
     public function testGetColumnSqlDefinitionComplete()
     {
-        $this->conn->expects(static::once())
+        $this->conn->expects($this->once())
                    ->method('quote')
                    ->with($this->equalTo('Custom Comment'))
-                   ->will(static::returnValue("`Custom Comment`"));
+                   ->will($this->returnValue("`Custom Comment`"));
 
         $column = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
@@ -573,15 +573,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                                           'getUpdate'))
                       ->getMock();
 
-        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column->expects(static::any())->method('isIdentity')->will(static::returnValue(true));
-        $column->expects(static::any())->method('getComment')->will(static::returnValue('Custom Comment'));
-        $column->expects(static::any())->method('getUpdate')->will(static::returnValue('CASCADE'));
-        $column->expects(static::any())->method('getLimit')->will(static::returnValue(''));
-        $column->expects(static::any())->method('getScale')->will(static::returnValue('2'));
-        $column->expects(static::any())->method('getPrecision')->will(static::returnValue('8'));
-        $column->expects(static::any())->method('getType')->will(static::returnValue('float'));
+        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column->expects($this->any())->method('isIdentity')->will($this->returnValue(true));
+        $column->expects($this->any())->method('getComment')->will($this->returnValue('Custom Comment'));
+        $column->expects($this->any())->method('getUpdate')->will($this->returnValue('CASCADE'));
+        $column->expects($this->any())->method('getLimit')->will($this->returnValue(''));
+        $column->expects($this->any())->method('getScale')->will($this->returnValue('2'));
+        $column->expects($this->any())->method('getPrecision')->will($this->returnValue('8'));
+        $column->expects($this->any())->method('getType')->will($this->returnValue('float'));
 
         $this->assertEquals("FLOAT(8,2) NOT NULL AUTO_INCREMENT COMMENT `Custom Comment` ON UPDATE CASCADE",
                             $this->adapter->getColumnSqlDefinition($column));
@@ -601,15 +601,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($column1));
-        $this->result->expects(static::at(1))
+                     ->will($this->returnValue($column1));
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue($column2));
-        $this->result->expects(static::at(2))
+                     ->will($this->returnValue($column2));
+        $this->result->expects($this->at(2))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql('SHOW COLUMNS FROM `table_name`', $this->result);
 
@@ -630,15 +630,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($column1));
-        $this->result->expects(static::at(1))
+                     ->will($this->returnValue($column1));
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue($column2));
-        $this->result->expects(static::at(2))
+                     ->will($this->returnValue($column2));
+        $this->result->expects($this->at(2))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql('SHOW COLUMNS FROM `table_name`', $this->result);
 
@@ -658,7 +658,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName'))
                       ->getMock();
-        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
+        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
 
 
         $column = $this->getMockBuilder('Phinx\Db\Table\Column')
@@ -666,10 +666,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit'))
                       ->getMock();
 
-        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
-        $column->expects(static::any())->method('getLimit')->will(static::returnValue('11'));
-        $column->expects(static::any())->method('getType')->will(static::returnValue('integer'));
+        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
+        $column->expects($this->any())->method('getLimit')->will($this->returnValue('11'));
+        $column->expects($this->any())->method('getType')->will($this->returnValue('integer'));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD `column_name` INT(11) NOT NULL');
         $this->adapter->addColumn($table, $column);
@@ -681,7 +681,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName'))
                       ->getMock();
-        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
+        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
 
 
         $column = $this->getMockBuilder('Phinx\Db\Table\Column')
@@ -689,10 +689,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit'))
                       ->getMock();
 
-        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column->expects(static::any())->method('getAfter')->will(static::returnValue('column_name2'));
-        $column->expects(static::any())->method('getLimit')->will(static::returnValue('11'));
-        $column->expects(static::any())->method('getType')->will(static::returnValue('integer'));
+        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column->expects($this->any())->method('getAfter')->will($this->returnValue('column_name2'));
+        $column->expects($this->any())->method('getLimit')->will($this->returnValue('11'));
+        $column->expects($this->any())->method('getType')->will($this->returnValue('integer'));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD `column_name` INT(11) NOT NULL AFTER `column_name2`');
         $this->adapter->addColumn($table, $column);
@@ -705,9 +705,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit'))
                       ->getMock();
 
-        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
-        $column->expects(static::any())->method('getLimit')->will(static::returnValue('11'));
-        $column->expects(static::any())->method('getType')->will(static::returnValue('integer'));
+        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
+        $column->expects($this->any())->method('getLimit')->will($this->returnValue('11'));
+        $column->expects($this->any())->method('getType')->will($this->returnValue('integer'));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` CHANGE `column1` `column_name` INT(11) NOT NULL');
         $this->adapter->changeColumn('table_name', 'column1', $column);
@@ -727,15 +727,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($column1));
-        $this->result->expects(static::at(1))
+                     ->will($this->returnValue($column1));
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue($column2));
-        $this->result->expects(static::at(2))
+                     ->will($this->returnValue($column2));
+        $this->result->expects($this->at(2))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql("DESCRIBE `table_name`", $this->result);
 
@@ -758,15 +758,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($column1));
-        $this->result->expects(static::at(1))
+                     ->will($this->returnValue($column1));
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue($column2));
-        $this->result->expects(static::at(2))
+                     ->will($this->returnValue($column2));
+        $this->result->expects($this->at(2))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql("DESCRIBE `table_name`", $this->result);
 
@@ -801,10 +801,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDefaultValueDefinitionString()
     {
-        $this->conn->expects(static::once())
+        $this->conn->expects($this->once())
                    ->method('quote')
                    ->with($this->equalTo('str'))
-                   ->will(static::returnValue("`str`"));
+                   ->will($this->returnValue("`str`"));
         $this->assertEquals(' DEFAULT `str`', $this->adapter->getDefaultValueDefinition('str'));
     }
 
@@ -1044,9 +1044,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getColumns', 'getName', 'getType'))
                       ->getMock();
 
-        $index->expects(static::any())->method('getColumns')->will(static::returnValue(array('column_name')));
-        $index->expects(static::any())->method('getName')->will(static::returnValue('index_name'));
-        $index->expects(static::any())->method('getType')->will(static::returnValue(\Phinx\Db\Table\Index::INDEX));
+        $index->expects($this->any())->method('getColumns')->will($this->returnValue(array('column_name')));
+        $index->expects($this->any())->method('getName')->will($this->returnValue('index_name'));
+        $index->expects($this->any())->method('getType')->will($this->returnValue(\Phinx\Db\Table\Index::INDEX));
         $this->assertEquals(' KEY `index_name` (`column_name`)', $this->adapter->getIndexSqlDefinition($index));
     }
 
@@ -1057,17 +1057,17 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getColumns', 'getName', 'getType'))
                       ->getMock();
 
-        $index->expects(static::any())->method('getColumns')->will(static::returnValue(array('column_name')));
-        $index->expects(static::any())->method('getName')->will(static::returnValue('index_name'));
-        $index->expects(static::any())->method('getType')->will(static::returnValue(\Phinx\Db\Table\Index::UNIQUE));
+        $index->expects($this->any())->method('getColumns')->will($this->returnValue(array('column_name')));
+        $index->expects($this->any())->method('getName')->will($this->returnValue('index_name'));
+        $index->expects($this->any())->method('getType')->will($this->returnValue(\Phinx\Db\Table\Index::UNIQUE));
         $this->assertEquals(' UNIQUE KEY `index_name` (`column_name`)', $this->adapter->getIndexSqlDefinition($index));
     }
 
     public function testGetIndexesEmpty()
     {
-        $this->result->expects(static::once())
+        $this->result->expects($this->once())
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql("SHOW INDEXES FROM `table_name`", $this->result);
 
@@ -1134,25 +1134,25 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                         'Comment' => '',
                         'Index_comment'   => '');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($index1));
+                     ->will($this->returnValue($index1));
 
-        $this->result->expects(static::at(1))
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue($index2));
+                     ->will($this->returnValue($index2));
 
-        $this->result->expects(static::at(2))
+        $this->result->expects($this->at(2))
                      ->method('fetch')
-                     ->will(static::returnValue($index3));
+                     ->will($this->returnValue($index3));
 
-        $this->result->expects(static::at(3))
+        $this->result->expects($this->at(3))
                      ->method('fetch')
-                     ->will(static::returnValue($index4));
+                     ->will($this->returnValue($index4));
 
-        $this->result->expects(static::at(4))
+        $this->result->expects($this->at(4))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $this->assertQuerySql("SHOW INDEXES FROM `table_name`", $this->result);
         return array($index1, $index2, $index3, $index4);
@@ -1206,7 +1206,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     public function testAddIndexWithLimit()
     {
         list($table, $index) = $this->prepareAddIndex(array('getColumns', 'getLimit'));
-        $index->expects(static::any())->method('getLimit')->will(static::returnValue(50));
+        $index->expects($this->any())->method('getLimit')->will($this->returnValue(50));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD  KEY (`column_name`(50))');
         $this->adapter->addIndex($table, $index);
@@ -1223,7 +1223,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->setMethods(array('getName'))
             ->getMock();
-        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
+        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
 
 
         $index = $this->getMockBuilder('Phinx\Db\Table\Index')
@@ -1231,7 +1231,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
             ->setMethods($methods)
             ->getMock();
 
-        $index->expects(static::any())->method('getColumns')->will(static::returnValue(array('column_name')));
+        $index->expects($this->any())->method('getColumns')->will($this->returnValue(array('column_name')));
         return array($table, $index);
     }
 
@@ -1279,21 +1279,21 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                     'REFERENCED_TABLE_NAME'   => 'other_table',
                     'REFERENCED_COLUMN_NAME'  => 'id');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($fk));
+                     ->will($this->returnValue($fk));
 
-        $this->result->expects(static::at(1))
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue($fk1));
+                     ->will($this->returnValue($fk1));
 
-        $this->result->expects(static::at(2))
+        $this->result->expects($this->at(2))
                      ->method('fetch')
-                     ->will(static::returnValue($fk2));
+                     ->will($this->returnValue($fk2));
 
-        $this->result->expects(static::at(3))
+        $this->result->expects($this->at(3))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $expectedSql = 'SELECT
               CONSTRAINT_NAME,
@@ -1377,13 +1377,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName'))
                       ->getMock();
-        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
+        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
 
         $refTable = $this->getMockBuilder('Phinx\Db\Table')
                          ->disableOriginalConstructor()
                          ->setMethods(array('getName'))
                          ->getMock();
-        $refTable->expects(static::any())->method('getName')->will(static::returnValue('other_table'));
+        $refTable->expects($this->any())->method('getName')->will($this->returnValue('other_table'));
 
         $foreignkey = $this->getMockBuilder('Phinx\Db\Table\ForeignKey')
                            ->disableOriginalConstructor()
@@ -1395,12 +1395,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                                                'getReferencedTable'))
                            ->getMock();
 
-        $foreignkey->expects(static::any())->method('getColumns')->will(static::returnValue(array('other_table_id')));
-        $foreignkey->expects(static::any())->method('getConstraint')->will(static::returnValue('fk1'));
-        $foreignkey->expects(static::any())->method('getReferencedColumns')->will(static::returnValue(array('id')));
-        $foreignkey->expects(static::any())->method('getReferencedTable')->will(static::returnValue($refTable));
-        $foreignkey->expects(static::any())->method('getOnDelete')->will(static::returnValue(null));
-        $foreignkey->expects(static::any())->method('getOnUpdate')->will(static::returnValue(null));
+        $foreignkey->expects($this->any())->method('getColumns')->will($this->returnValue(array('other_table_id')));
+        $foreignkey->expects($this->any())->method('getConstraint')->will($this->returnValue('fk1'));
+        $foreignkey->expects($this->any())->method('getReferencedColumns')->will($this->returnValue(array('id')));
+        $foreignkey->expects($this->any())->method('getReferencedTable')->will($this->returnValue($refTable));
+        $foreignkey->expects($this->any())->method('getOnDelete')->will($this->returnValue(null));
+        $foreignkey->expects($this->any())->method('getOnUpdate')->will($this->returnValue(null));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD  CONSTRAINT `fk1` FOREIGN KEY (`other_table_id`) REFERENCES `other_table` (`id`)');
         $this->adapter->addForeignKey($table, $foreignkey);
@@ -1413,13 +1413,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName'))
                       ->getMock();
-        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
+        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
 
         $refTable = $this->getMockBuilder('Phinx\Db\Table')
                          ->disableOriginalConstructor()
                          ->setMethods(array('getName'))
                          ->getMock();
-        $refTable->expects(static::any())->method('getName')->will(static::returnValue('other_table'));
+        $refTable->expects($this->any())->method('getName')->will($this->returnValue('other_table'));
 
         $foreignkey = $this->getMockBuilder('Phinx\Db\Table\ForeignKey')
                            ->disableOriginalConstructor()
@@ -1431,12 +1431,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                                                'getReferencedTable'))
                            ->getMock();
 
-        $foreignkey->expects(static::any())->method('getColumns')->will(static::returnValue(array('other_table_id')));
-        $foreignkey->expects(static::any())->method('getConstraint')->will(static::returnValue('fk1'));
-        $foreignkey->expects(static::any())->method('getReferencedColumns')->will(static::returnValue(array('id')));
-        $foreignkey->expects(static::any())->method('getReferencedTable')->will(static::returnValue($refTable));
-        $foreignkey->expects(static::any())->method('getOnDelete')->will(static::returnValue('CASCADE'));
-        $foreignkey->expects(static::any())->method('getOnUpdate')->will(static::returnValue('CASCADE'));
+        $foreignkey->expects($this->any())->method('getColumns')->will($this->returnValue(array('other_table_id')));
+        $foreignkey->expects($this->any())->method('getConstraint')->will($this->returnValue('fk1'));
+        $foreignkey->expects($this->any())->method('getReferencedColumns')->will($this->returnValue(array('id')));
+        $foreignkey->expects($this->any())->method('getReferencedTable')->will($this->returnValue($refTable));
+        $foreignkey->expects($this->any())->method('getOnDelete')->will($this->returnValue('CASCADE'));
+        $foreignkey->expects($this->any())->method('getOnUpdate')->will($this->returnValue('CASCADE'));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD  CONSTRAINT `fk1` FOREIGN KEY (`other_table_id`) REFERENCES `other_table` (`id`) ON DELETE CASCADE ON UPDATE CASCADE');
         $this->adapter->addForeignKey($table, $foreignkey);
@@ -1450,13 +1450,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                     'REFERENCED_TABLE_NAME'   => 'other_table',
                     'REFERENCED_COLUMN_NAME'  => 'id');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($fk));
+                     ->will($this->returnValue($fk));
 
-        $this->result->expects(static::at(1))
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $expectedSql = 'SELECT
                         CONSTRAINT_NAME
@@ -1480,13 +1480,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                     'REFERENCED_TABLE_NAME'   => 'other_table',
                     'REFERENCED_COLUMN_NAME'  => 'id');
 
-        $this->result->expects(static::at(0))
+        $this->result->expects($this->at(0))
                      ->method('fetch')
-                     ->will(static::returnValue($fk));
+                     ->will($this->returnValue($fk));
 
-        $this->result->expects(static::at(1))
+        $this->result->expects($this->at(1))
                      ->method('fetch')
-                     ->will(static::returnValue(null));
+                     ->will($this->returnValue(null));
 
         $expectedSql = 'SELECT
                         CONSTRAINT_NAME

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -87,26 +87,26 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     // helper methods for easy mocking
     private function assertExecuteSql($expected_sql)
     {
-        $this->conn->expects($this->once())
+        $this->conn->expects(static::once())
                    ->method('exec')
                    ->with($this->equalTo($expected_sql));
     }
 
     private function assertQuerySql($expectedSql, $returnValue = null)
     {
-        $expect = $this->conn->expects($this->once())
+        $expect = $this->conn->expects(static::once())
                        ->method('query')
                        ->with($this->equalTo($expectedSql));
         if (!is_null($returnValue)) {
-            $expect->will($this->returnValue($returnValue));
+            $expect->will(static::returnValue($returnValue));
         }
     }
 
     private function assertFetchRowSql($expectedSql, $returnValue)
     {
-        $this->result->expects($this->once())
+        $this->result->expects(static::once())
                      ->method('fetch')
-                     ->will($this->returnValue($returnValue));
+                     ->will(static::returnValue($returnValue));
         $this->assertQuerySql($expectedSql, $this->result);
     }
 
@@ -123,12 +123,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
     public function testHasDatabaseExists()
     {
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue(array('SCHEMA_NAME' => 'database_name')));
-        $this->result->expects($this->at(1))
+                     ->will(static::returnValue(array('SCHEMA_NAME' => 'database_name')));
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'database_name'", $this->result);
 
@@ -137,9 +137,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
     public function testHasDatabaseNotExists()
     {
-        $this->result->expects($this->once())
+        $this->result->expects(static::once())
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'database_name2'", $this->result);
 
@@ -229,9 +229,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     public function testHasTableExists()
     {
         $this->adapter->setOptions(array('name'=>'database_name'));
-        $this->result->expects($this->once())
+        $this->result->expects(static::once())
                      ->method('fetch')
-                     ->will($this->returnValue(array('somecontent')));
+                     ->will(static::returnValue(array('somecontent')));
         $expectedSql = 'SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA = \'database_name\' AND TABLE_NAME = \'table_name\'';
@@ -242,9 +242,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     public function testHasTableNotExists()
     {
         $this->adapter->setOptions(array('name'=>'database_name'));
-        $this->result->expects($this->once())
+        $this->result->expects(static::once())
                      ->method('fetch')
-                     ->will($this->returnValue(array()));
+                     ->will(static::returnValue(array()));
         $expectedSql = 'SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA = \'database_name\' AND TABLE_NAME = \'table_name\'';
@@ -259,31 +259,31 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column1->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column1->expects($this->any())->method('getType')->will($this->returnValue('string'));
-        $column1->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column1->expects($this->at(0))->method('getLimit')->will($this->returnValue('64'));
+        $column1->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column1->expects(static::any())->method('getType')->will(static::returnValue('string'));
+        $column1->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column1->expects(static::at(0))->method('getLimit')->will(static::returnValue('64'));
 
         $column2 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column2->expects($this->any())->method('getName')->will($this->returnValue('column_name2'));
-        $column2->expects($this->any())->method('getType')->will($this->returnValue('integer'));
-        $column2->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column2->expects($this->at(0))->method('getLimit')->will($this->returnValue('4'));
+        $column2->expects(static::any())->method('getName')->will(static::returnValue('column_name2'));
+        $column2->expects(static::any())->method('getType')->will(static::returnValue('integer'));
+        $column2->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column2->expects(static::at(0))->method('getLimit')->will(static::returnValue('4'));
 
         $table = $this->getMockBuilder('Phinx\Db\Table')
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName', 'getOptions', 'getPendingColumns', 'getIndexes', 'getForeignKeys'))
                       ->getMock();
 
-        $table->expects($this->any())->method('getPendingColumns')->will($this->returnValue(array($column1,$column2)));
-        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
-        $table->expects($this->any())->method('getOptions')->will($this->returnValue(array()));
-        $table->expects($this->any())->method('getIndexes')->will($this->returnValue(array()));
-        $table->expects($this->any())->method('getForeignKeys')->will($this->returnValue(array()));
+        $table->expects(static::any())->method('getPendingColumns')->will(static::returnValue(array($column1,$column2)));
+        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
+        $table->expects(static::any())->method('getOptions')->will(static::returnValue(array()));
+        $table->expects(static::any())->method('getIndexes')->will(static::returnValue(array()));
+        $table->expects(static::any())->method('getForeignKeys')->will(static::returnValue(array()));
 
         $expectedSql = 'CREATE TABLE `table_name` (`id` INT(11) NOT NULL AUTO_INCREMENT, `column_name` VARCHAR(255) NOT NULL, `column_name2` INT(11) NOT NULL, PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;';
         $this->assertExecuteSql($expectedSql);
@@ -297,20 +297,20 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column1->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column1->expects($this->any())->method('getType')->will($this->returnValue('string'));
-        $column1->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column1->expects($this->at(0))->method('getLimit')->will($this->returnValue('64'));
+        $column1->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column1->expects(static::any())->method('getType')->will(static::returnValue('string'));
+        $column1->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column1->expects(static::at(0))->method('getLimit')->will(static::returnValue('64'));
 
         $column2 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column2->expects($this->any())->method('getName')->will($this->returnValue('column_name2'));
-        $column2->expects($this->any())->method('getType')->will($this->returnValue('integer'));
-        $column2->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column2->expects($this->at(0))->method('getLimit')->will($this->returnValue('4'));
+        $column2->expects(static::any())->method('getName')->will(static::returnValue('column_name2'));
+        $column2->expects(static::any())->method('getType')->will(static::returnValue('integer'));
+        $column2->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column2->expects(static::at(0))->method('getLimit')->will(static::returnValue('4'));
 
         $table = $this->getMockBuilder('Phinx\Db\Table')
                       ->disableOriginalConstructor()
@@ -318,11 +318,11 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->getMock();
 
         $tableOptions = array('id' => 'column_name2');
-        $table->expects($this->any())->method('getPendingColumns')->will($this->returnValue(array($column1,$column2)));
-        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
-        $table->expects($this->any())->method('getOptions')->will($this->returnValue($tableOptions));
-        $table->expects($this->any())->method('getIndexes')->will($this->returnValue(array()));
-        $table->expects($this->any())->method('getForeignKeys')->will($this->returnValue(array()));
+        $table->expects(static::any())->method('getPendingColumns')->will(static::returnValue(array($column1,$column2)));
+        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
+        $table->expects(static::any())->method('getOptions')->will(static::returnValue($tableOptions));
+        $table->expects(static::any())->method('getIndexes')->will(static::returnValue(array()));
+        $table->expects(static::any())->method('getForeignKeys')->will(static::returnValue(array()));
 
         $expectedSql = 'CREATE TABLE `table_name` (`column_name2` INT(11) NOT NULL AUTO_INCREMENT, `column_name` VARCHAR(255) NOT NULL, `column_name2` INT(11) NOT NULL, PRIMARY KEY (`column_name2`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;';
         $this->assertExecuteSql($expectedSql);
@@ -336,7 +336,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName', 'getOptions', 'getPendingColumns', 'getIndexes', 'getForeignKeys'))
                       ->getMock();
-        $refTable->expects($this->any())->method('getName')->will($this->returnValue('other_table'));
+        $refTable->expects(static::any())->method('getName')->will(static::returnValue('other_table'));
 
 
         $table = $this->getMockBuilder('Phinx\Db\Table')
@@ -349,44 +349,44 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                               'id' => array('ref_id','other_table_id'),
                               'primary_key' => array('ref_id','other_table_id'),
                               'comment' => "Table Comment");
-        $this->conn->expects($this->any())->method('quote')->with('Table Comment')->will($this->returnValue('`Table Comment`'));
+        $this->conn->expects(static::any())->method('quote')->with('Table Comment')->will(static::returnValue('`Table Comment`'));
 
         $column1 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column1->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column1->expects($this->any())->method('getType')->will($this->returnValue('string'));
-        $column1->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column1->expects($this->at(0))->method('getLimit')->will($this->returnValue('64'));
+        $column1->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column1->expects(static::any())->method('getType')->will(static::returnValue('string'));
+        $column1->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column1->expects(static::at(0))->method('getLimit')->will(static::returnValue('64'));
 
         $column2 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column2->expects($this->any())->method('getName')->will($this->returnValue('other_table_id'));
-        $column2->expects($this->any())->method('getType')->will($this->returnValue('integer'));
-        $column2->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column2->expects($this->at(0))->method('getLimit')->will($this->returnValue('4'));
+        $column2->expects(static::any())->method('getName')->will(static::returnValue('other_table_id'));
+        $column2->expects(static::any())->method('getType')->will(static::returnValue('integer'));
+        $column2->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column2->expects(static::at(0))->method('getLimit')->will(static::returnValue('4'));
 
         $column3 = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column3->expects($this->any())->method('getName')->will($this->returnValue('ref_id'));
-        $column3->expects($this->any())->method('getType')->will($this->returnValue('integer'));
-        $column3->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column3->expects($this->at(0))->method('getLimit')->will($this->returnValue('11'));
+        $column3->expects(static::any())->method('getName')->will(static::returnValue('ref_id'));
+        $column3->expects(static::any())->method('getType')->will(static::returnValue('integer'));
+        $column3->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column3->expects(static::at(0))->method('getLimit')->will(static::returnValue('11'));
 
         $index = $this->getMockBuilder('Phinx\Db\Table\Index')
                       ->disableOriginalConstructor()
                       ->setMethods(array( 'getColumns'))
                       ->getMock();
 
-        $index->expects($this->any())->method('getColumns')->will($this->returnValue(array('column_name')));
+        $index->expects(static::any())->method('getColumns')->will(static::returnValue(array('column_name')));
 
         $foreignkey = $this->getMockBuilder('Phinx\Db\Table\ForeignKey')
                            ->disableOriginalConstructor()
@@ -398,18 +398,18 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                                                'getReferencedTable'))
                            ->getMock();
 
-        $foreignkey->expects($this->any())->method('getColumns')->will($this->returnValue(array('other_table_id')));
-        $foreignkey->expects($this->any())->method('getConstraint')->will($this->returnValue('fk1'));
-        $foreignkey->expects($this->any())->method('getReferencedColumns')->will($this->returnValue(array('id')));
-        $foreignkey->expects($this->any())->method('getReferencedTable')->will($this->returnValue($refTable));
-        $foreignkey->expects($this->any())->method('getOnDelete')->will($this->returnValue(null));
-        $foreignkey->expects($this->any())->method('getOnUpdate')->will($this->returnValue(null));
+        $foreignkey->expects(static::any())->method('getColumns')->will(static::returnValue(array('other_table_id')));
+        $foreignkey->expects(static::any())->method('getConstraint')->will(static::returnValue('fk1'));
+        $foreignkey->expects(static::any())->method('getReferencedColumns')->will(static::returnValue(array('id')));
+        $foreignkey->expects(static::any())->method('getReferencedTable')->will(static::returnValue($refTable));
+        $foreignkey->expects(static::any())->method('getOnDelete')->will(static::returnValue(null));
+        $foreignkey->expects(static::any())->method('getOnUpdate')->will(static::returnValue(null));
 
-        $table->expects($this->any())->method('getPendingColumns')->will($this->returnValue(array($column1, $column2, $column3)));
-        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
-        $table->expects($this->any())->method('getOptions')->will($this->returnValue($tableOptions));
-        $table->expects($this->any())->method('getIndexes')->will($this->returnValue(array($index)));
-        $table->expects($this->any())->method('getForeignKeys')->will($this->returnValue(array($foreignkey)));
+        $table->expects(static::any())->method('getPendingColumns')->will(static::returnValue(array($column1, $column2, $column3)));
+        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
+        $table->expects(static::any())->method('getOptions')->will(static::returnValue($tableOptions));
+        $table->expects(static::any())->method('getIndexes')->will(static::returnValue(array($index)));
+        $table->expects(static::any())->method('getForeignKeys')->will(static::returnValue(array($foreignkey)));
 
         $expectedSql ='CREATE TABLE `table_name` (`column_name` VARCHAR(255) NOT NULL, `other_table_id` INT(11) NOT NULL, `ref_id` INT(11) NOT NULL, PRIMARY KEY (`ref_id`,`other_table_id`),  KEY (`column_name`),  CONSTRAINT `fk1` FOREIGN KEY (`other_table_id`) REFERENCES `other_table` (`id`)) ENGINE = MyISAM CHARACTER SET latin1 COLLATE latin1_swedish_ci COMMENT=`Table Comment`;';
         $this->assertExecuteSql($expectedSql);
@@ -436,15 +436,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Key'     => '',
                          'Extra'   => '');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($column1));
-        $this->result->expects($this->at(1))
+                     ->will(static::returnValue($column1));
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue($column2));
-        $this->result->expects($this->at(2))
+                     ->will(static::returnValue($column2));
+        $this->result->expects(static::at(2))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql("SHOW COLUMNS FROM `table_name`", $this->result);
 
@@ -485,15 +485,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($column1));
-        $this->result->expects($this->at(1))
+                     ->will(static::returnValue($column1));
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue($column2));
-        $this->result->expects($this->at(2))
+                     ->will(static::returnValue($column2));
+        $this->result->expects(static::at(2))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql('SHOW COLUMNS FROM `table_name`', $this->result);
 
@@ -507,10 +507,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit'))
                       ->getMock();
 
-        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column->expects($this->any())->method('getLimit')->will($this->returnValue('11'));
-        $column->expects($this->any())->method('getType')->will($this->returnValue('integer'));
+        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column->expects(static::any())->method('getLimit')->will(static::returnValue('11'));
+        $column->expects(static::any())->method('getType')->will(static::returnValue('integer'));
 
         $this->assertEquals("INT(11) NOT NULL",
                             $this->adapter->getColumnSqlDefinition($column));
@@ -523,11 +523,11 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit', 'getScale', 'getPrecision'))
                       ->getMock();
 
-        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column->expects($this->any())->method('getType')->will($this->returnValue('float'));
-        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column->expects($this->any())->method('getPrecision')->will($this->returnValue('8'));
-        $column->expects($this->any())->method('getScale')->will($this->returnValue('3'));
+        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column->expects(static::any())->method('getType')->will(static::returnValue('float'));
+        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column->expects(static::any())->method('getPrecision')->will(static::returnValue('8'));
+        $column->expects(static::any())->method('getScale')->will(static::returnValue('3'));
 
         $this->assertEquals("FLOAT(8,3) NOT NULL",
                             $this->adapter->getColumnSqlDefinition($column));
@@ -543,11 +543,11 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit', 'setLimit'))
                       ->getMock();
 
-        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column->expects($this->any())->method('getType')->will($this->returnValue('text'));
-        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column->expects($this->at(0))->method('getLimit')->will($this->returnValue('2048'));
-        $column->expects($this->at(1))->method('getLimit')->will($this->returnValue(null));
+        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column->expects(static::any())->method('getType')->will(static::returnValue('text'));
+        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column->expects(static::at(0))->method('getLimit')->will(static::returnValue('2048'));
+        $column->expects(static::at(1))->method('getLimit')->will(static::returnValue(null));
 
         $this->assertEquals("TEXT NOT NULL",
                             $this->adapter->getColumnSqlDefinition($column));
@@ -555,10 +555,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
     public function testGetColumnSqlDefinitionComplete()
     {
-        $this->conn->expects($this->once())
+        $this->conn->expects(static::once())
                    ->method('quote')
                    ->with($this->equalTo('Custom Comment'))
-                   ->will($this->returnValue("`Custom Comment`"));
+                   ->will(static::returnValue("`Custom Comment`"));
 
         $column = $this->getMockBuilder('Phinx\Db\Table\Column')
                       ->disableOriginalConstructor()
@@ -573,15 +573,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                                           'getUpdate'))
                       ->getMock();
 
-        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column->expects($this->any())->method('isIdentity')->will($this->returnValue(true));
-        $column->expects($this->any())->method('getComment')->will($this->returnValue('Custom Comment'));
-        $column->expects($this->any())->method('getUpdate')->will($this->returnValue('CASCADE'));
-        $column->expects($this->any())->method('getLimit')->will($this->returnValue(''));
-        $column->expects($this->any())->method('getScale')->will($this->returnValue('2'));
-        $column->expects($this->any())->method('getPrecision')->will($this->returnValue('8'));
-        $column->expects($this->any())->method('getType')->will($this->returnValue('float'));
+        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column->expects(static::any())->method('isIdentity')->will(static::returnValue(true));
+        $column->expects(static::any())->method('getComment')->will(static::returnValue('Custom Comment'));
+        $column->expects(static::any())->method('getUpdate')->will(static::returnValue('CASCADE'));
+        $column->expects(static::any())->method('getLimit')->will(static::returnValue(''));
+        $column->expects(static::any())->method('getScale')->will(static::returnValue('2'));
+        $column->expects(static::any())->method('getPrecision')->will(static::returnValue('8'));
+        $column->expects(static::any())->method('getType')->will(static::returnValue('float'));
 
         $this->assertEquals("FLOAT(8,2) NOT NULL AUTO_INCREMENT COMMENT `Custom Comment` ON UPDATE CASCADE",
                             $this->adapter->getColumnSqlDefinition($column));
@@ -601,15 +601,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($column1));
-        $this->result->expects($this->at(1))
+                     ->will(static::returnValue($column1));
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue($column2));
-        $this->result->expects($this->at(2))
+                     ->will(static::returnValue($column2));
+        $this->result->expects(static::at(2))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql('SHOW COLUMNS FROM `table_name`', $this->result);
 
@@ -630,15 +630,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($column1));
-        $this->result->expects($this->at(1))
+                     ->will(static::returnValue($column1));
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue($column2));
-        $this->result->expects($this->at(2))
+                     ->will(static::returnValue($column2));
+        $this->result->expects(static::at(2))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql('SHOW COLUMNS FROM `table_name`', $this->result);
 
@@ -658,7 +658,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName'))
                       ->getMock();
-        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
+        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
 
 
         $column = $this->getMockBuilder('Phinx\Db\Table\Column')
@@ -666,10 +666,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit'))
                       ->getMock();
 
-        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column->expects($this->any())->method('getAfter')->will($this->returnValue(null));
-        $column->expects($this->any())->method('getLimit')->will($this->returnValue('11'));
-        $column->expects($this->any())->method('getType')->will($this->returnValue('integer'));
+        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column->expects(static::any())->method('getAfter')->will(static::returnValue(null));
+        $column->expects(static::any())->method('getLimit')->will(static::returnValue('11'));
+        $column->expects(static::any())->method('getType')->will(static::returnValue('integer'));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD `column_name` INT(11) NOT NULL');
         $this->adapter->addColumn($table, $column);
@@ -681,7 +681,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName'))
                       ->getMock();
-        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
+        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
 
 
         $column = $this->getMockBuilder('Phinx\Db\Table\Column')
@@ -689,10 +689,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit'))
                       ->getMock();
 
-        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column->expects($this->any())->method('getAfter')->will($this->returnValue('column_name2'));
-        $column->expects($this->any())->method('getLimit')->will($this->returnValue('11'));
-        $column->expects($this->any())->method('getType')->will($this->returnValue('integer'));
+        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column->expects(static::any())->method('getAfter')->will(static::returnValue('column_name2'));
+        $column->expects(static::any())->method('getLimit')->will(static::returnValue('11'));
+        $column->expects(static::any())->method('getType')->will(static::returnValue('integer'));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD `column_name` INT(11) NOT NULL AFTER `column_name2`');
         $this->adapter->addColumn($table, $column);
@@ -705,9 +705,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getName', 'getAfter', 'getType', 'getLimit'))
                       ->getMock();
 
-        $column->expects($this->any())->method('getName')->will($this->returnValue('column_name'));
-        $column->expects($this->any())->method('getLimit')->will($this->returnValue('11'));
-        $column->expects($this->any())->method('getType')->will($this->returnValue('integer'));
+        $column->expects(static::any())->method('getName')->will(static::returnValue('column_name'));
+        $column->expects(static::any())->method('getLimit')->will(static::returnValue('11'));
+        $column->expects(static::any())->method('getType')->will(static::returnValue('integer'));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` CHANGE `column1` `column_name` INT(11) NOT NULL');
         $this->adapter->changeColumn('table_name', 'column1', $column);
@@ -727,15 +727,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($column1));
-        $this->result->expects($this->at(1))
+                     ->will(static::returnValue($column1));
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue($column2));
-        $this->result->expects($this->at(2))
+                     ->will(static::returnValue($column2));
+        $this->result->expects(static::at(2))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql("DESCRIBE `table_name`", $this->result);
 
@@ -758,15 +758,15 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                          'Default' => 'NULL',
                          'Extra'   => '');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($column1));
-        $this->result->expects($this->at(1))
+                     ->will(static::returnValue($column1));
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue($column2));
-        $this->result->expects($this->at(2))
+                     ->will(static::returnValue($column2));
+        $this->result->expects(static::at(2))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql("DESCRIBE `table_name`", $this->result);
 
@@ -801,10 +801,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDefaultValueDefinitionString()
     {
-        $this->conn->expects($this->once())
+        $this->conn->expects(static::once())
                    ->method('quote')
                    ->with($this->equalTo('str'))
-                   ->will($this->returnValue("`str`"));
+                   ->will(static::returnValue("`str`"));
         $this->assertEquals(' DEFAULT `str`', $this->adapter->getDefaultValueDefinition('str'));
     }
 
@@ -1044,9 +1044,9 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getColumns', 'getName', 'getType'))
                       ->getMock();
 
-        $index->expects($this->any())->method('getColumns')->will($this->returnValue(array('column_name')));
-        $index->expects($this->any())->method('getName')->will($this->returnValue('index_name'));
-        $index->expects($this->any())->method('getType')->will($this->returnValue(\Phinx\Db\Table\Index::INDEX));
+        $index->expects(static::any())->method('getColumns')->will(static::returnValue(array('column_name')));
+        $index->expects(static::any())->method('getName')->will(static::returnValue('index_name'));
+        $index->expects(static::any())->method('getType')->will(static::returnValue(\Phinx\Db\Table\Index::INDEX));
         $this->assertEquals(' KEY `index_name` (`column_name`)', $this->adapter->getIndexSqlDefinition($index));
     }
 
@@ -1057,17 +1057,17 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->setMethods(array( 'getColumns', 'getName', 'getType'))
                       ->getMock();
 
-        $index->expects($this->any())->method('getColumns')->will($this->returnValue(array('column_name')));
-        $index->expects($this->any())->method('getName')->will($this->returnValue('index_name'));
-        $index->expects($this->any())->method('getType')->will($this->returnValue(\Phinx\Db\Table\Index::UNIQUE));
+        $index->expects(static::any())->method('getColumns')->will(static::returnValue(array('column_name')));
+        $index->expects(static::any())->method('getName')->will(static::returnValue('index_name'));
+        $index->expects(static::any())->method('getType')->will(static::returnValue(\Phinx\Db\Table\Index::UNIQUE));
         $this->assertEquals(' UNIQUE KEY `index_name` (`column_name`)', $this->adapter->getIndexSqlDefinition($index));
     }
 
     public function testGetIndexesEmpty()
     {
-        $this->result->expects($this->once())
+        $this->result->expects(static::once())
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql("SHOW INDEXES FROM `table_name`", $this->result);
 
@@ -1134,25 +1134,25 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                         'Comment' => '',
                         'Index_comment'   => '');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($index1));
+                     ->will(static::returnValue($index1));
 
-        $this->result->expects($this->at(1))
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue($index2));
+                     ->will(static::returnValue($index2));
 
-        $this->result->expects($this->at(2))
+        $this->result->expects(static::at(2))
                      ->method('fetch')
-                     ->will($this->returnValue($index3));
+                     ->will(static::returnValue($index3));
 
-        $this->result->expects($this->at(3))
+        $this->result->expects(static::at(3))
                      ->method('fetch')
-                     ->will($this->returnValue($index4));
+                     ->will(static::returnValue($index4));
 
-        $this->result->expects($this->at(4))
+        $this->result->expects(static::at(4))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $this->assertQuerySql("SHOW INDEXES FROM `table_name`", $this->result);
         return array($index1, $index2, $index3, $index4);
@@ -1206,7 +1206,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     public function testAddIndexWithLimit()
     {
         list($table, $index) = $this->prepareAddIndex(array('getColumns', 'getLimit'));
-        $index->expects($this->any())->method('getLimit')->will($this->returnValue(50));
+        $index->expects(static::any())->method('getLimit')->will(static::returnValue(50));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD  KEY (`column_name`(50))');
         $this->adapter->addIndex($table, $index);
@@ -1223,7 +1223,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->setMethods(array('getName'))
             ->getMock();
-        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
+        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
 
 
         $index = $this->getMockBuilder('Phinx\Db\Table\Index')
@@ -1231,7 +1231,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
             ->setMethods($methods)
             ->getMock();
 
-        $index->expects($this->any())->method('getColumns')->will($this->returnValue(array('column_name')));
+        $index->expects(static::any())->method('getColumns')->will(static::returnValue(array('column_name')));
         return array($table, $index);
     }
 
@@ -1279,21 +1279,21 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                     'REFERENCED_TABLE_NAME'   => 'other_table',
                     'REFERENCED_COLUMN_NAME'  => 'id');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($fk));
+                     ->will(static::returnValue($fk));
 
-        $this->result->expects($this->at(1))
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue($fk1));
+                     ->will(static::returnValue($fk1));
 
-        $this->result->expects($this->at(2))
+        $this->result->expects(static::at(2))
                      ->method('fetch')
-                     ->will($this->returnValue($fk2));
+                     ->will(static::returnValue($fk2));
 
-        $this->result->expects($this->at(3))
+        $this->result->expects(static::at(3))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $expectedSql = 'SELECT
               CONSTRAINT_NAME,
@@ -1377,13 +1377,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName'))
                       ->getMock();
-        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
+        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
 
         $refTable = $this->getMockBuilder('Phinx\Db\Table')
                          ->disableOriginalConstructor()
                          ->setMethods(array('getName'))
                          ->getMock();
-        $refTable->expects($this->any())->method('getName')->will($this->returnValue('other_table'));
+        $refTable->expects(static::any())->method('getName')->will(static::returnValue('other_table'));
 
         $foreignkey = $this->getMockBuilder('Phinx\Db\Table\ForeignKey')
                            ->disableOriginalConstructor()
@@ -1395,12 +1395,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                                                'getReferencedTable'))
                            ->getMock();
 
-        $foreignkey->expects($this->any())->method('getColumns')->will($this->returnValue(array('other_table_id')));
-        $foreignkey->expects($this->any())->method('getConstraint')->will($this->returnValue('fk1'));
-        $foreignkey->expects($this->any())->method('getReferencedColumns')->will($this->returnValue(array('id')));
-        $foreignkey->expects($this->any())->method('getReferencedTable')->will($this->returnValue($refTable));
-        $foreignkey->expects($this->any())->method('getOnDelete')->will($this->returnValue(null));
-        $foreignkey->expects($this->any())->method('getOnUpdate')->will($this->returnValue(null));
+        $foreignkey->expects(static::any())->method('getColumns')->will(static::returnValue(array('other_table_id')));
+        $foreignkey->expects(static::any())->method('getConstraint')->will(static::returnValue('fk1'));
+        $foreignkey->expects(static::any())->method('getReferencedColumns')->will(static::returnValue(array('id')));
+        $foreignkey->expects(static::any())->method('getReferencedTable')->will(static::returnValue($refTable));
+        $foreignkey->expects(static::any())->method('getOnDelete')->will(static::returnValue(null));
+        $foreignkey->expects(static::any())->method('getOnUpdate')->will(static::returnValue(null));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD  CONSTRAINT `fk1` FOREIGN KEY (`other_table_id`) REFERENCES `other_table` (`id`)');
         $this->adapter->addForeignKey($table, $foreignkey);
@@ -1413,13 +1413,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                       ->disableOriginalConstructor()
                       ->setMethods(array('getName'))
                       ->getMock();
-        $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
+        $table->expects(static::any())->method('getName')->will(static::returnValue('table_name'));
 
         $refTable = $this->getMockBuilder('Phinx\Db\Table')
                          ->disableOriginalConstructor()
                          ->setMethods(array('getName'))
                          ->getMock();
-        $refTable->expects($this->any())->method('getName')->will($this->returnValue('other_table'));
+        $refTable->expects(static::any())->method('getName')->will(static::returnValue('other_table'));
 
         $foreignkey = $this->getMockBuilder('Phinx\Db\Table\ForeignKey')
                            ->disableOriginalConstructor()
@@ -1431,12 +1431,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                                                'getReferencedTable'))
                            ->getMock();
 
-        $foreignkey->expects($this->any())->method('getColumns')->will($this->returnValue(array('other_table_id')));
-        $foreignkey->expects($this->any())->method('getConstraint')->will($this->returnValue('fk1'));
-        $foreignkey->expects($this->any())->method('getReferencedColumns')->will($this->returnValue(array('id')));
-        $foreignkey->expects($this->any())->method('getReferencedTable')->will($this->returnValue($refTable));
-        $foreignkey->expects($this->any())->method('getOnDelete')->will($this->returnValue('CASCADE'));
-        $foreignkey->expects($this->any())->method('getOnUpdate')->will($this->returnValue('CASCADE'));
+        $foreignkey->expects(static::any())->method('getColumns')->will(static::returnValue(array('other_table_id')));
+        $foreignkey->expects(static::any())->method('getConstraint')->will(static::returnValue('fk1'));
+        $foreignkey->expects(static::any())->method('getReferencedColumns')->will(static::returnValue(array('id')));
+        $foreignkey->expects(static::any())->method('getReferencedTable')->will(static::returnValue($refTable));
+        $foreignkey->expects(static::any())->method('getOnDelete')->will(static::returnValue('CASCADE'));
+        $foreignkey->expects(static::any())->method('getOnUpdate')->will(static::returnValue('CASCADE'));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD  CONSTRAINT `fk1` FOREIGN KEY (`other_table_id`) REFERENCES `other_table` (`id`) ON DELETE CASCADE ON UPDATE CASCADE');
         $this->adapter->addForeignKey($table, $foreignkey);
@@ -1450,13 +1450,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                     'REFERENCED_TABLE_NAME'   => 'other_table',
                     'REFERENCED_COLUMN_NAME'  => 'id');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($fk));
+                     ->will(static::returnValue($fk));
 
-        $this->result->expects($this->at(1))
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $expectedSql = 'SELECT
                         CONSTRAINT_NAME
@@ -1480,13 +1480,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                     'REFERENCED_TABLE_NAME'   => 'other_table',
                     'REFERENCED_COLUMN_NAME'  => 'id');
 
-        $this->result->expects($this->at(0))
+        $this->result->expects(static::at(0))
                      ->method('fetch')
-                     ->will($this->returnValue($fk));
+                     ->will(static::returnValue($fk));
 
-        $this->result->expects($this->at(1))
+        $this->result->expects(static::at(1))
                      ->method('fetch')
-                     ->will($this->returnValue(null));
+                     ->will(static::returnValue(null));
 
         $expectedSql = 'SELECT
                         CONSTRAINT_NAME

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -599,6 +599,18 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
     }
 
+    public function testDropConstraint()
+    {
+        $table = new \Phinx\Db\Table('table', array(), $this->adapter);
+        $table->addColumn('column2', 'integer')->save();
+
+        $columns = $table->getColumns();
+
+        self::assertTrue($columns[0]->getIdentity());
+        $this->adapter->dropConstraint($table->getName(), 'id');
+        self::assertFalse($columns[0]->getIdentity());
+    }
+
     public function testHasDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('fake_database_name'));

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -613,7 +613,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
                 break;
             }
         }
-        $table->dropContraint('id', $constraintName);
+        $table->dropConstraint('id', $constraintName);
         $emptySet = $this->adapter->getIndexes($table->getName());
 
         $this->assertEmpty($emptySet);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -601,14 +601,22 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testDropConstraint()
     {
-        $table = new \Phinx\Db\Table('table', array(), $this->adapter);
-        $table->addColumn('column2', 'integer')->save();
+        $table = new \Phinx\Db\Table('table', ['identity' => false], $this->adapter);
+        $table->save();
 
-        $columns = $table->getColumns();
+        $tmpSet = $this->adapter->getIndexes($table->getName());
 
-        self::assertTrue($columns[0]->getIdentity());
-        $this->adapter->dropConstraint($table->getName(), 'id');
-        self::assertFalse($columns[0]->getIdentity());
+        $constraintName = '';
+        foreach ($tmpSet as $key => $value) {
+            if (false !== strpos($key, '_pkey')) {
+                $constraintName = $key;
+                break;
+            }
+        }
+        $table->dropContraint('id', $constraintName);
+        $emptySet = $this->adapter->getIndexes($table->getName());
+
+        self::assertEmpty($emptySet);
     }
 
     public function testHasDatabase()

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -115,7 +115,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
     public function testSchemaTableIsCreatedWithPrimaryKey()
     {
         $this->adapter->connect();
-        $table = new \Phinx\Db\Table($this->adapter->getSchemaTableName(), array(), $this->adapter);
+        new \Phinx\Db\Table($this->adapter->getSchemaTableName(), array(), $this->adapter);
         $this->assertTrue($this->adapter->hasIndex($this->adapter->getSchemaTableName(), array('version')));
     }
 
@@ -127,8 +127,8 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testQuoteTableName()
     {
-        $this->assertEquals('"public"."table"', $this->adapter->quoteTableName('table'));
-        $this->assertEquals('"public"."table.table"', $this->adapter->quoteTableName('table.table'));
+        $this->assertEquals('"'.TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE.'"."table"', $this->adapter->quoteTableName('table'));
+        $this->assertEquals('"'.TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE.'"."table.table"', $this->adapter->quoteTableName('table.table'));
     }
 
     public function testQuoteColumnName()
@@ -616,7 +616,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $table->dropContraint('id', $constraintName);
         $emptySet = $this->adapter->getIndexes($table->getName());
 
-        self::assertEmpty($emptySet);
+        $this->assertEmpty($emptySet);
     }
 
     public function testHasDatabase()

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -18,7 +18,9 @@ class ProxyAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $stub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $stub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->adapter = new ProxyAdapter($stub);
     }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -9,7 +9,7 @@ use Phinx\Db\Adapter\SQLiteAdapter;
 class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Phinx\Db\Adapter\MysqlAdapter
+     * @var \Phinx\Db\Adapter\SQLiteAdapter
      */
     private $adapter;
 
@@ -39,7 +39,7 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testConnection()
     {
-        $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
+        self::assertInstanceOf(\PDO::class, $this->adapter->getConnection());
     }
 
     public function testBeginTransaction()
@@ -65,7 +65,6 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
     public function testSchemaTableIsCreatedWithPrimaryKey()
     {
         $this->adapter->connect();
-        $table = new \Phinx\Db\Table($this->adapter->getSchemaTableName(), array(), $this->adapter);
         $this->assertTrue($this->adapter->hasIndex($this->adapter->getSchemaTableName(), array('version')));
     }
 
@@ -109,7 +108,6 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
     public function testCreateTableWithNoOptions()
     {
         $this->markTestIncomplete();
-        //$this->adapter->createTable('ntable', )
     }
 
     public function testCreateTableWithNoPrimaryKey()
@@ -211,11 +209,6 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('email', 'string')
               ->save();
         $this->assertTrue($table->hasColumn('email'));
-
-        // In SQLite it is not possible to dictate order of added columns.
-        // $table->addColumn('realname', 'string', array('after' => 'id'))
-        //       ->save();
-        // $this->assertEquals('realname', $rows[1]['Field']);
     }
 
     public function testAddColumnWithDefaultValue()
@@ -346,7 +339,7 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
                    ->setType('integer');
         $table->changeColumn('column1', $newColumn1);
         $rows = $this->adapter->fetchAll('pragma table_info(t)');
-        $this->assertEquals("0", $rows[1]['dflt_value']);
+        $this->assertEquals('0', $rows[1]['dflt_value']);
     }
 
     public function testChangeColumnDefaultToNull()
@@ -375,28 +368,40 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
     public function testGetColumns()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
-        $table->addColumn('column1', 'string')
-              ->addColumn('column2', 'integer')
-              ->addColumn('column3', 'biginteger')
-              ->addColumn('column4', 'text')
-              ->addColumn('column5', 'float')
-              ->addColumn('column6', 'decimal')
-              ->addColumn('column7', 'datetime')
-              ->addColumn('column8', 'time')
-              ->addColumn('column9', 'timestamp')
-              ->addColumn('column10', 'date')
-              ->addColumn('column11', 'binary')
-              ->addColumn('column12', 'boolean')
-              ->addColumn('column13', 'string', array('limit' => 10))
-              ->addColumn('column15', 'integer', array('limit' => 10))
-              ->addColumn('column16', 'enum', array('values' => array('a', 'b', 'c')));
+        $table->addColumn('column1', 'string', ['null' => true, 'limit' => 255])
+              ->addColumn('column2', 'integer', ['null' => true])
+              ->addColumn('column3', 'biginteger', ['null' => true])
+              ->addColumn('column4', 'text', ['null' => true])
+              ->addColumn('column5', 'float', ['null' => true])
+              ->addColumn('column6', 'decimal', ['null' => true])
+              ->addColumn('column7', 'datetime', ['null' => true])
+              ->addColumn('column8', 'time', ['null' => true])
+              ->addColumn('column9', 'date', ['null' => true])
+              ->addColumn('column10', 'binary', ['null' => true])
+              ->addColumn('column11', 'boolean', ['null' => true])
+              ->addColumn('column12', 'string', ['null' => true, 'limit' => 10])
+              ->addColumn('column13', 'enum', ['null' => true]); // there can be no enum values since there is no enum type in sqlite
+
         $pendingColumns = $table->getPendingColumns();
         $table->save();
         $columns = $this->adapter->getColumns('t');
         $this->assertCount(count($pendingColumns) + 1, $columns);
-        for ($i = 0; $i++; $i < count($pendingColumns)) {
-            $this->assertEquals($pendingColumns[$i], $columns[$i+1]);
+        foreach ($pendingColumns as $key => $columnDefinition) {
+            $this->assertEquals($columnDefinition, $columns[$key+1]);
         }
+    }
+
+    /**
+     * timestamp will be transformed to datetime http://www.sqlite.org/datatype3.html
+     * it still works though
+     */
+    public function testTimestampToDatetimeType() {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('column9', 'timestamp', ['null' => true]);
+        $table->save();
+
+        $columns = $this->adapter->getColumns('t');
+        self::assertEquals('datetime', $columns[1]->getType());
     }
 
     public function testAddIndex()
@@ -679,27 +684,27 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         // load table info
         $columns = $this->adapter->getColumns("table1");
 
-        $this->assertEquals(count($columns), 5);
+        $this->assertCount(5, $columns);
 
         $aa = $columns[1];
         $bb = $columns[2];
         $cc = $columns[3];
         $dd = $columns[4];
 
-        $this->assertEquals("aa", $aa->getName());
+        $this->assertEquals('aa', $aa->getName());
         $this->assertEquals(true, $aa->isNull());
         $this->assertEquals(null, $aa->getDefault());
 
-        $this->assertEquals("bb", $bb->getName());
+        $this->assertEquals('bb', $bb->getName());
         $this->assertEquals(false, $bb->isNull());
         $this->assertEquals(null, $bb->getDefault());
 
-        $this->assertEquals("cc", $cc->getName());
+        $this->assertEquals('cc', $cc->getName());
         $this->assertEquals(true, $cc->isNull());
-        $this->assertEquals("some1", $cc->getDefault());
+        $this->assertEquals('some1', $cc->getDefault());
 
-        $this->assertEquals("dd", $dd->getName());
+        $this->assertEquals('dd', $dd->getName());
         $this->assertEquals(false, $dd->isNull());
-        $this->assertEquals("some2", $dd->getDefault());
+        $this->assertEquals('some2', $dd->getDefault());
     }
 }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -391,6 +391,21 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testDropContraint() {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table
+            ->addColumn('column1', 'string', ['null' => true, 'limit' => 255])
+            ->addColumn('column2', 'integer', ['null' => true])
+            ->save();
+
+        $table->dropContraint('id');
+
+        $columns = $this->adapter->getColumns('t');
+
+        $this->assertFalse($columns[0]->isIdentity());
+    }
+
+
     /**
      * timestamp will be transformed to datetime http://www.sqlite.org/datatype3.html
      * it still works though

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -391,14 +391,14 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testDropContraint() {
+    public function testDropConstraint() {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
         $table
             ->addColumn('column1', 'string', ['null' => true, 'limit' => 255])
             ->addColumn('column2', 'integer', ['null' => true])
             ->save();
 
-        $table->dropContraint('id');
+        $table->dropConstraint('id');
 
         $columns = $this->adapter->getColumns('t');
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -39,7 +39,7 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testConnection()
     {
-        self::assertInstanceOf(\PDO::class, $this->adapter->getConnection());
+        $this->assertInstanceOf(\PDO::class, $this->adapter->getConnection());
     }
 
     public function testBeginTransaction()
@@ -416,7 +416,7 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $table->save();
 
         $columns = $this->adapter->getColumns('t');
-        self::assertEquals('datetime', $columns[1]->getType());
+        $this->assertEquals('datetime', $columns[1]->getType());
     }
 
     public function testAddIndex()

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -39,7 +39,7 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testConnection()
     {
-        $this->assertInstanceOf(\PDO::class, $this->adapter->getConnection());
+        $this->assertInstanceOf('\PDO', $this->adapter->getConnection());
     }
 
     public function testBeginTransaction()

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -26,16 +26,18 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
             'table_suffix' => '_suf',
         );
 
-        $this->mock = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $this->mock = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->mock
-            ->expects($this->any())
+            ->expects(static::any())
             ->method('getOption')
             ->with($this->logicalOr(
                 $this->equalTo('table_prefix'),
                 $this->equalTo('table_suffix')
             ))
-            ->will($this->returnCallback(function ($option) use ($options) {
+            ->will(static::returnCallback(function ($option) use ($options) {
                 return $options[$option];
             }));
 
@@ -44,8 +46,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        unset($this->adapter);
-        unset($this->mock);
+        unset($this->adapter, $this->mock);
     }
 
     public function testGetAdapterTableName()
@@ -57,7 +58,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testHasTable()
     {
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('hasTable')
             ->with($this->equalTo('pre_table_suf'));
 
@@ -69,7 +70,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $table = new Table('table');
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('createTable')
             ->with($this->callback(
                 function ($table) {
@@ -83,7 +84,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testRenameTable()
     {
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('renameTable')
             ->with(
                 $this->equalTo('pre_old_suf'),
@@ -96,7 +97,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testDropTable()
     {
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('dropTable')
             ->with($this->equalTo('pre_table_suf'));
 
@@ -106,7 +107,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testGetColumns()
     {
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getColumns')
             ->with($this->equalTo('pre_table_suf'));
 
@@ -116,7 +117,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testHasColumn()
     {
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('hasColumn')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -132,7 +133,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $column = new Column();
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('addColumn')
             ->with($this->callback(
                 function ($table) {
@@ -147,7 +148,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testRenameColumn()
     {
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('renameColumn')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -163,7 +164,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $newColumn = new Column();
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('changeColumn')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -177,7 +178,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testDropColumn()
     {
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('dropColumn')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -192,7 +193,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $columns = array();
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('hasIndex')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -208,7 +209,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $options = null;
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('dropIndex')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -222,7 +223,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testDropIndexByName()
     {
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('dropIndexByName')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -238,7 +239,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $constraint = null;
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('hasForeignKey')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -255,7 +256,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $foreignKey = new ForeignKey();
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('addForeignKey')
             ->with($this->callback(
                 function ($table) {
@@ -273,7 +274,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $constraint = null;
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('dropForeignKey')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -287,14 +288,14 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testAddTableWithForeignKey()
     {
         $this->mock
-            ->expects($this->any())
+            ->expects(static::any())
             ->method('isValidColumnType')
             ->with($this->callback(
                 function ($column) {
                     return in_array($column->getType(), array('string', 'integer'));
                 }
             ))
-            ->will($this->returnValue(true));
+            ->will(static::returnValue(true));
 
         $table = new Table('table', array(), $this->adapter);
         $table
@@ -303,7 +304,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
             ->addForeignKey('relation', 'target_table', array('id'));
 
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('createTable')
             ->with($this->callback(
                 function ($table) {
@@ -340,7 +341,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $row = array('column1' => 'value3');
         
         $this->mock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('insert')
             ->with($this->callback(
                 function ($table) {

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -31,13 +31,13 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->mock
-            ->expects(static::any())
+            ->expects($this->any())
             ->method('getOption')
             ->with($this->logicalOr(
                 $this->equalTo('table_prefix'),
                 $this->equalTo('table_suffix')
             ))
-            ->will(static::returnCallback(function ($option) use ($options) {
+            ->will($this->returnCallback(function ($option) use ($options) {
                 return $options[$option];
             }));
 
@@ -58,7 +58,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testHasTable()
     {
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('hasTable')
             ->with($this->equalTo('pre_table_suf'));
 
@@ -70,7 +70,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $table = new Table('table');
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('createTable')
             ->with($this->callback(
                 function ($table) {
@@ -84,7 +84,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testRenameTable()
     {
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('renameTable')
             ->with(
                 $this->equalTo('pre_old_suf'),
@@ -97,7 +97,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testDropTable()
     {
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('dropTable')
             ->with($this->equalTo('pre_table_suf'));
 
@@ -107,7 +107,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testGetColumns()
     {
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('getColumns')
             ->with($this->equalTo('pre_table_suf'));
 
@@ -117,7 +117,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testHasColumn()
     {
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('hasColumn')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -133,7 +133,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $column = new Column();
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('addColumn')
             ->with($this->callback(
                 function ($table) {
@@ -148,7 +148,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testRenameColumn()
     {
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('renameColumn')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -164,7 +164,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $newColumn = new Column();
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('changeColumn')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -178,7 +178,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testDropColumn()
     {
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('dropColumn')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -193,7 +193,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $columns = array();
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('hasIndex')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -209,7 +209,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $options = null;
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('dropIndex')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -223,7 +223,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testDropIndexByName()
     {
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('dropIndexByName')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -239,7 +239,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $constraint = null;
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('hasForeignKey')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -256,7 +256,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $foreignKey = new ForeignKey();
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('addForeignKey')
             ->with($this->callback(
                 function ($table) {
@@ -274,7 +274,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $constraint = null;
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('dropForeignKey')
             ->with(
                 $this->equalTo('pre_table_suf'),
@@ -288,14 +288,14 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
     public function testAddTableWithForeignKey()
     {
         $this->mock
-            ->expects(static::any())
+            ->expects($this->any())
             ->method('isValidColumnType')
             ->with($this->callback(
                 function ($column) {
                     return in_array($column->getType(), array('string', 'integer'));
                 }
             ))
-            ->will(static::returnValue(true));
+            ->will($this->returnValue(true));
 
         $table = new Table('table', array(), $this->adapter);
         $table
@@ -304,7 +304,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
             ->addForeignKey('relation', 'target_table', array('id'));
 
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('createTable')
             ->with($this->callback(
                 function ($table) {
@@ -341,7 +341,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
         $row = array('column1' => 'value3');
         
         $this->mock
-            ->expects(static::once())
+            ->expects($this->once())
             ->method('insert')
             ->with($this->callback(
                 function ($table) {

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -256,15 +256,12 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testInsertSaveData()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\SqliteAdapter')
             ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'insert'
-                ]
-            )
             ->getMock();
+
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
+
         $data = [
             [
                 'column1' => 'value1',
@@ -287,11 +284,11 @@ class TableTest extends \PHPUnit_Framework_TestCase
                     ->method('insert')
                     ->with($table, $this->logicalOr($data[0], $data[1], $moreData[0], $moreData[1]));
 
-        $table->save();
+
         $table
             ->insert($data)
             ->insert($moreData)
-            ->saveData();
+            ->save();
     }
 
     public function testRemoveColumn()

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -169,8 +169,16 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testChangeColumn()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'changeColumn'
+                ]
+            )
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('changeColumn');
         $newColumn = new \Phinx\Db\Table\Column();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
@@ -180,8 +188,15 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testChangeColumnWithoutAColumnObject()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'changeColumn'
+                ]
+            )
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('changeColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->changeColumn('test1', 'text', ['null' => false]);
@@ -190,8 +205,15 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testDropForeignKey()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'dropForeignKey'
+                ]
+            )
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('dropForeignKey');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->dropForeignKey('test');
@@ -200,8 +222,15 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testGetColumns()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'getColumns'
+                ]
+            )
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('getColumns');
 
         $table = new \Phinx\Db\Table('table1', [], $adapterStub);
@@ -210,7 +239,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testInsert()
     {
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $data = [
             'column1' => 'value1',
@@ -225,7 +256,14 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testInsertSaveData()
     {
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'insert'
+                ]
+            )
+            ->getMock();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $data = [
             [
@@ -245,7 +283,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $adapterStub->expects($this->exactly(4))
+        $adapterStub->expects(static::exactly(4))
                     ->method('insert')
                     ->with($table, $this->logicalOr($data[0], $data[1], $moreData[0], $moreData[1]));
 
@@ -257,8 +295,15 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testRemoveColumn()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'dropColumn'
+                ]
+            )
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('dropColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->removeColumn('test');
@@ -267,8 +312,15 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testRemoveIndex()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'dropIndex'
+                ]
+            )
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('dropIndex');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->removeIndex(['email']);
@@ -277,8 +329,15 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testRemoveIndexByName()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'dropIndexByName'
+                ]
+            )
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('dropIndexByName');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->removeIndexByName('emailindex');
@@ -287,8 +346,15 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testRenameColumn()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'renameColumn'
+                ]
+            )
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('renameColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->renameColumn('test1', 'test2');
@@ -296,7 +362,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testResetAfterAddingData()
     {
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $columns = ["column1"];
         $data = [["value1"]];

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -178,7 +178,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
             )
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('changeColumn');
         $newColumn = new \Phinx\Db\Table\Column();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
@@ -196,7 +196,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
                 ]
             )
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('changeColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->changeColumn('test1', 'text', ['null' => false]);
@@ -213,7 +213,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
                 ]
             )
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('dropForeignKey');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->dropForeignKey('test');
@@ -230,7 +230,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
                 ]
             )
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('getColumns');
 
         $table = new \Phinx\Db\Table('table1', [], $adapterStub);
@@ -283,13 +283,15 @@ class TableTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $adapterStub->expects(static::exactly(4))
+        $adapterStub->expects($this->exactly(4))
                     ->method('insert')
                     ->with($table, $this->logicalOr($data[0], $data[1], $moreData[0], $moreData[1]));
 
-        $table->insert($data)
-              ->insert($moreData)
-              ->save();
+        $table->save();
+        $table
+            ->insert($data)
+            ->insert($moreData)
+            ->saveData();
     }
 
     public function testRemoveColumn()
@@ -303,7 +305,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
                 ]
             )
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('dropColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->removeColumn('test');
@@ -320,7 +322,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
                 ]
             )
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('dropIndex');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->removeIndex(['email']);
@@ -337,7 +339,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
                 ]
             )
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('dropIndexByName');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->removeIndexByName('emailindex');
@@ -354,7 +356,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
                 ]
             )
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('renameColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->renameColumn('test1', 'test2');

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -106,9 +106,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
             ->disableOriginalConstructor()
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('execute')
-                    ->will(static::returnValue(2));
+                    ->will($this->returnValue(2));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertEquals(2, $migrationStub->execute('SELECT FOO FROM BAR'));
@@ -123,9 +123,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
             ->disableOriginalConstructor()
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('query')
-                    ->will(static::returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
+                    ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertEquals(array(array('0' => 'bar', 'foo' => 'bar')), $migrationStub->query('SELECT FOO FROM BAR'));
@@ -141,9 +141,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('fetchRow')
-                    ->will(static::returnValue(array('0' => 'bar', 'foo' => 'bar')));
+                    ->will($this->returnValue(array('0' => 'bar', 'foo' => 'bar')));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertEquals(array('0' => 'bar', 'foo' => 'bar'), $migrationStub->fetchRow('SELECT FOO FROM BAR'));
@@ -159,9 +159,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('fetchAll')
-                    ->will(static::returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
+                    ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertEquals(array(array('0' => 'bar', 'foo' => 'bar')), $migrationStub->fetchAll('SELECT FOO FROM BAR'));
@@ -177,7 +177,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('insert');
 
         $table = new Table('testdb', [], $adapterStub);
@@ -196,9 +196,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('createDatabase')
-                    ->will(static::returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
+                    ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
 
         $migrationStub->setAdapter($adapterStub);
         $migrationStub->createDatabase('testdb', array());
@@ -214,9 +214,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('dropDatabase')
-                    ->will(static::returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
+                    ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
 
         $migrationStub->setAdapter($adapterStub);
         $migrationStub->dropDatabase('testdb');
@@ -232,9 +232,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('hasTable')
-                    ->will(static::returnValue(true));
+                    ->will($this->returnValue(true));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertTrue($migrationStub->hasTable('test_table'));
@@ -264,7 +264,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
             ->disableOriginalConstructor()
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('dropTable');
 
         $migrationStub->setAdapter($adapterStub);

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -3,7 +3,6 @@
 namespace Test\Phinx\Migration;
 
 use Phinx\Db\Table;
-use Phinx\Db\Adapter\AdapterInterface;
 
 class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
 {
@@ -34,7 +33,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         // test methods
         $this->assertNull($migrationStub->getAdapter());
         $migrationStub->setAdapter($adapterStub);
-        $this->assertInstanceOf(AdapterInterface::class, $migrationStub->getAdapter());
+        $this->assertInstanceOf('\Phinx\Db\Adapter\AdapterInterface', $migrationStub->getAdapter());
     }
 
     public function testSetOutputMethods()
@@ -252,7 +251,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
 
         $migrationStub->setAdapter($adapterStub);
 
-        $this->assertInstanceOf(Table::class, $migrationStub->table('test_table'));
+        $this->assertInstanceOf('\Phinx\Db\Table', $migrationStub->table('test_table'));
     }
 
     public function testDropTableMethod()

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -27,12 +27,14 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         // test methods
         $this->assertNull($migrationStub->getAdapter());
         $migrationStub->setAdapter($adapterStub);
-        $this->assertTrue($migrationStub->getAdapter() instanceof AdapterInterface);
+        $this->assertInstanceOf(AdapterInterface::class, $migrationStub->getAdapter());
     }
 
     public function testSetOutputMethods()
@@ -41,7 +43,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub output
-        $outputStub = $this->getMock('\Symfony\Component\Console\Output\OutputInterface', array(), array(array()));
+        $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         // test methods
         $this->assertNull($migrationStub->getOutput());
@@ -52,7 +56,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testGetInputMethodWithInjectedInput()
     {
         // stub input
-        $inputStub = $this->getMock('\Symfony\Component\Console\Input\InputInterface', array(), array(array()));
+        $inputStub = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, $inputStub, null));
@@ -65,7 +71,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testGetOutputMethodWithInjectedOutput()
     {
         // stub output
-        $outputStub = $this->getMock('\Symfony\Component\Console\Output\OutputInterface', array(), array(array()));
+        $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, null, $outputStub));
@@ -78,7 +86,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testGetName()
     {
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
-        $this->assertFalse(!(strpos($migrationStub->getName(), 'AbstractMigration')));
+        $this->assertNotFalse(strpos($migrationStub->getName(), 'AbstractMigration'));
     }
 
     public function testVersionMethods()
@@ -95,10 +103,12 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('execute')
-                    ->will($this->returnValue(2));
+                    ->will(static::returnValue(2));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertEquals(2, $migrationStub->execute('SELECT FOO FROM BAR'));
@@ -110,10 +120,12 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('query')
-                    ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
+                    ->will(static::returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertEquals(array(array('0' => 'bar', 'foo' => 'bar')), $migrationStub->query('SELECT FOO FROM BAR'));
@@ -125,10 +137,13 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('fetchRow')
-                    ->will($this->returnValue(array('0' => 'bar', 'foo' => 'bar')));
+                    ->will(static::returnValue(array('0' => 'bar', 'foo' => 'bar')));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertEquals(array('0' => 'bar', 'foo' => 'bar'), $migrationStub->fetchRow('SELECT FOO FROM BAR'));
@@ -140,10 +155,13 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('fetchAll')
-                    ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
+                    ->will(static::returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertEquals(array(array('0' => 'bar', 'foo' => 'bar')), $migrationStub->fetchAll('SELECT FOO FROM BAR'));
@@ -155,8 +173,11 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('insert');
 
         $table = new Table('testdb', [], $adapterStub);
@@ -171,10 +192,13 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('createDatabase')
-                    ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
+                    ->will(static::returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
 
         $migrationStub->setAdapter($adapterStub);
         $migrationStub->createDatabase('testdb', array());
@@ -186,10 +210,13 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('dropDatabase')
-                    ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
+                    ->will(static::returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
 
         $migrationStub->setAdapter($adapterStub);
         $migrationStub->dropDatabase('testdb');
@@ -201,10 +228,13 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('hasTable')
-                    ->will($this->returnValue(true));
+                    ->will(static::returnValue(true));
 
         $migrationStub->setAdapter($adapterStub);
         $this->assertTrue($migrationStub->hasTable('test_table'));
@@ -216,10 +246,13 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $migrationStub->setAdapter($adapterStub);
 
-        $this->assertTrue($migrationStub->table('test_table') instanceof Table);
+        $this->assertInstanceOf(Table::class, $migrationStub->table('test_table'));
     }
 
     public function testDropTableMethod()
@@ -228,8 +261,10 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('dropTable');
 
         $migrationStub->setAdapter($adapterStub);

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -106,10 +106,13 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
     public function testCurrentVersion()
     {
-        $stub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $stub->expects($this->any())
+        $stub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $stub->expects(static::any())
              ->method('getVersions')
-             ->will($this->returnValue(array('20110301080000')));
+             ->will(static::returnValue(array('20110301080000')));
 
         $this->environment->setAdapter($stub);
 
@@ -119,16 +122,26 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAMigrationUp()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->will(static::returnArgument(0));
 
         $this->environment->setAdapter($adapterStub);
 
         // up
-        $upMigration = $this->getMock('\Phinx\Migration\AbstractMigration', array('up'), array('20110301080000'));
-        $upMigration->expects($this->once())
+        $upMigration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+            ->setMethods(
+                [
+                    'up'
+                ]
+            )
+            ->setConstructorArgs(['20110301080000'])
+            ->getMock();
+        $upMigration->expects(static::once())
                     ->method('up');
 
         $this->environment->executeMigration($upMigration, MigrationInterface::UP);
@@ -137,16 +150,23 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAMigrationDown()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->will(static::returnArgument(0));
 
         $this->environment->setAdapter($adapterStub);
 
         // down
-        $downMigration = $this->getMock('\Phinx\Migration\AbstractMigration', array('down'), array('20110301080000'));
-        $downMigration->expects($this->once())
+        $downMigration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+            ->setConstructorArgs(['20110301080000'])
+            ->setMethods(['down'])
+            ->getMock();
+
+        $downMigration->expects(static::once())
                       ->method('down');
 
         $this->environment->executeMigration($downMigration, MigrationInterface::DOWN);
@@ -155,22 +175,29 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAMigrationWithTransactions()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adapterStub->expects(static::once())
                     ->method('beginTransaction');
 
-        $adapterStub->expects($this->once())
+        $adapterStub->expects(static::once())
                     ->method('commitTransaction');
 
-        $adapterStub->expects($this->exactly(2))
+        $adapterStub->expects(static::exactly(2))
                     ->method('hasTransactions')
-                    ->will($this->returnValue(true));
+                    ->will(static::returnValue(true));
 
         $this->environment->setAdapter($adapterStub);
 
         // migrate
-        $migration = $this->getMock('\Phinx\Migration\AbstractMigration', array('up'), array('20110301080000'));
-        $migration->expects($this->once())
+        $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+            ->setConstructorArgs(['20110301080000'])
+            ->setMethods(['up'])
+            ->getMock()
+        ;
+
+        $migration->expects(static::once())
                   ->method('up');
 
         $this->environment->executeMigration($migration, MigrationInterface::UP);
@@ -179,16 +206,24 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAChangeMigrationUp()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->will(static::returnArgument(0));
 
         $this->environment->setAdapter($adapterStub);
 
         // migration
-        $migration = $this->getMock('\Phinx\Migration\AbstractMigration', array('change'), array('20130301080000'));
-        $migration->expects($this->once())
+        $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+            ->setConstructorArgs(['20130301080000'])
+            ->setMethods(['change'])
+            ->getMock()
+        ;
+
+        $migration->expects(static::once())
                   ->method('change');
 
         $this->environment->executeMigration($migration, MigrationInterface::UP);
@@ -197,16 +232,23 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAChangeMigrationDown()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $adapterStub->expects(static::once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->will(static::returnArgument(0));
 
         $this->environment->setAdapter($adapterStub);
 
         // migration
-        $migration = $this->getMock('\Phinx\Migration\AbstractMigration', array('change'), array('20130301080000'));
-        $migration->expects($this->once())
+        $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+            ->setConstructorArgs(['20130301080000'])
+            ->setMethods(['change'])
+            ->getMock();
+
+        $migration->expects(static::once())
                   ->method('change');
 
         $this->environment->executeMigration($migration, MigrationInterface::DOWN);
@@ -214,7 +256,11 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
     public function testGettingInputObject()
     {
-        $this->environment->setInput($this->getMock('\Symfony\Component\Console\Input\InputInterface'));
+        $this->environment->setInput(
+            $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+                ->disableOriginalConstructor()
+                ->getMock()
+        );
         $inputObject = $this->environment->getInput();
         $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $inputObject);
     }

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -110,9 +110,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $stub->expects(static::any())
+        $stub->expects($this->any())
              ->method('getVersions')
-             ->will(static::returnValue(array('20110301080000')));
+             ->will($this->returnValue(array('20110301080000')));
 
         $this->environment->setAdapter($stub);
 
@@ -126,9 +126,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will(static::returnArgument(0));
+                    ->will($this->returnArgument(0));
 
         $this->environment->setAdapter($adapterStub);
 
@@ -141,7 +141,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             )
             ->setConstructorArgs(['20110301080000'])
             ->getMock();
-        $upMigration->expects(static::once())
+        $upMigration->expects($this->once())
                     ->method('up');
 
         $this->environment->executeMigration($upMigration, MigrationInterface::UP);
@@ -154,9 +154,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will(static::returnArgument(0));
+                    ->will($this->returnArgument(0));
 
         $this->environment->setAdapter($adapterStub);
 
@@ -166,7 +166,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->setMethods(['down'])
             ->getMock();
 
-        $downMigration->expects(static::once())
+        $downMigration->expects($this->once())
                       ->method('down');
 
         $this->environment->executeMigration($downMigration, MigrationInterface::DOWN);
@@ -178,15 +178,15 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
             ->disableOriginalConstructor()
             ->getMock();
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('beginTransaction');
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('commitTransaction');
 
-        $adapterStub->expects(static::exactly(2))
+        $adapterStub->expects($this->exactly(2))
                     ->method('hasTransactions')
-                    ->will(static::returnValue(true));
+                    ->will($this->returnValue(true));
 
         $this->environment->setAdapter($adapterStub);
 
@@ -197,7 +197,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
-        $migration->expects(static::once())
+        $migration->expects($this->once())
                   ->method('up');
 
         $this->environment->executeMigration($migration, MigrationInterface::UP);
@@ -210,9 +210,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will(static::returnArgument(0));
+                    ->will($this->returnArgument(0));
 
         $this->environment->setAdapter($adapterStub);
 
@@ -223,7 +223,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
-        $migration->expects(static::once())
+        $migration->expects($this->once())
                   ->method('change');
 
         $this->environment->executeMigration($migration, MigrationInterface::UP);
@@ -236,9 +236,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $adapterStub->expects(static::once())
+        $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will(static::returnArgument(0));
+                    ->will($this->returnArgument(0));
 
         $this->environment->setAdapter($adapterStub);
 
@@ -248,7 +248,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
             ->setMethods(['change'])
             ->getMock();
 
-        $migration->expects(static::once())
+        $migration->expects($this->once())
                   ->method('change');
 
         $this->environment->executeMigration($migration, MigrationInterface::DOWN);

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -87,9 +87,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         ;
 
 
-        $envStub->expects(static::once())
+        $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will(static::returnValue(
+                ->will($this->returnValue(
                     array (
                         '20120111235330' =>
                             array (
@@ -128,9 +128,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs(['mockenv', []])
             ->getMock()
         ;
-        $envStub->expects(static::once())
+        $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will(static::returnValue(
+                ->will($this->returnValue(
                     array (
                         '20120111235330' =>
                             array (
@@ -193,9 +193,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
-        $envStub->expects(static::once())
+        $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will(static::returnValue(
+                ->will($this->returnValue(
                     array (
                         '20120103083300' =>
                             array (
@@ -235,9 +235,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
-        $envStub->expects(static::once())
+        $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will(static::returnValue(
+                ->will($this->returnValue(
                     array (
                         '20120103083300' =>
                             array (
@@ -278,9 +278,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
-        $envStub->expects(static::once())
+        $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will(static::returnValue(array(
+                ->will($this->returnValue(array(
                     '20120111235330'=> array(
                         'version' => '20120111235330',
                         'start_time' => '2012-01-16 18:35:40',
@@ -372,9 +372,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             $envStub->expects($this->never())
                     ->method('getVersions');
         } else {
-            $envStub->expects(static::once())
+            $envStub->expects($this->once())
                     ->method('getVersions')
-                    ->will(static::returnValue($availableMigrations));
+                    ->will($this->returnValue($availableMigrations));
         }
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->migrateToDateTime('mockenv', new \DateTime($dateString));
@@ -399,12 +399,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs(['mockenv', []])
             ->getMock()
         ;
-        $envStub->expects(static::any())
+        $envStub->expects($this->any())
             ->method('getVersionLog')
-            ->will(static::returnValue($availableRollbacks));
-        $envStub->expects(static::any())
+            ->will($this->returnValue($availableRollbacks));
+        $envStub->expects($this->any())
                 ->method('getVersions')
-                ->will(static::returnValue(array_keys($availableRollbacks)));
+                ->will($this->returnValue(array_keys($availableRollbacks)));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollbackToDateTime('mockenv', new \DateTime($dateString));
@@ -424,14 +424,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs(['mockenv', []])
             ->getMock()
         ;
-        $envStub->expects(static::any())
+        $envStub->expects($this->any())
                 ->method('getVersionLog')
-                ->will(static::returnValue([
+                ->will($this->returnValue([
                     '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
                 ]));
-        $envStub->expects(static::any())
+        $envStub->expects($this->any())
                 ->method('getVersions')
-                ->will(static::returnValue([20120111235330]));
+                ->will($this->returnValue([20120111235330]));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv');
@@ -447,20 +447,20 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $envStub->expects(static::any())
+        $envStub->expects($this->any())
                 ->method('getVersionLog')
                 ->will(
-                    static::returnValue(
+                    $this->returnValue(
                         [
                             '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
                             '20120116183504' => ['version' => '20120815145812', 'migration' => '', 'breakpoint' => 0],
                         ]
                     )
                 );
-        $envStub->expects(static::any())
+        $envStub->expects($this->any())
                 ->method('getVersions')
                 ->will(
-                    static::returnValue(
+                    $this->returnValue(
                         [
                             20120111235330,
                             20120116183504,

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -81,10 +81,15 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethod()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->once())
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
+
+
+        $envStub->expects(static::once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->will(static::returnValue(
                     array (
                         '20120111235330' =>
                             array (
@@ -119,10 +124,13 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithBreakpointSet()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->once())
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
+        $envStub->expects(static::once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->will(static::returnValue(
                     array (
                         '20120111235330' =>
                             array (
@@ -156,7 +164,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithNoMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
 
         // override the migrations directory to an empty one
         $configArray = $this->getConfigArray();
@@ -177,10 +188,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithMissingMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->once())
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
+
+        $envStub->expects(static::once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->will(static::returnValue(
                     array (
                         '20120103083300' =>
                             array (
@@ -215,10 +230,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithMissingMigrationsAndBreakpointSet()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->once())
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
+
+        $envStub->expects(static::once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->will(static::returnValue(
                     array (
                         '20120103083300' =>
                             array (
@@ -254,10 +273,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithDownMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->once())
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
+
+        $envStub->expects(static::once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(array(
+                ->will(static::returnValue(array(
                     '20120111235330'=> array(
                         'version' => '20120111235330',
                         'start_time' => '2012-01-16 18:35:40',
@@ -340,14 +363,18 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testMigrationsByDate(array $availableMigrations, $dateString, $expectedMigration, $message)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
+
         if (is_null($expectedMigration)) {
             $envStub->expects($this->never())
                     ->method('getVersions');
         } else {
-            $envStub->expects($this->once())
+            $envStub->expects(static::once())
                     ->method('getVersions')
-                    ->will($this->returnValue($availableMigrations));
+                    ->will(static::returnValue($availableMigrations));
         }
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->migrateToDateTime('mockenv', new \DateTime($dateString));
@@ -368,13 +395,16 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbacksByDate(array $availableRollbacks, $dateString, $expectedRollback, $message)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->any())
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
+        $envStub->expects(static::any())
             ->method('getVersionLog')
-            ->will($this->returnValue($availableRollbacks));
-        $envStub->expects($this->any())
+            ->will(static::returnValue($availableRollbacks));
+        $envStub->expects(static::any())
                 ->method('getVersions')
-                ->will($this->returnValue(array_keys($availableRollbacks)));
+                ->will(static::returnValue(array_keys($availableRollbacks)));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollbackToDateTime('mockenv', new \DateTime($dateString));
@@ -390,15 +420,18 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackWithSingleMigrationDoesNotFail()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->any())
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
+        $envStub->expects(static::any())
                 ->method('getVersionLog')
-                ->will($this->returnValue([
+                ->will(static::returnValue([
                     '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
                 ]));
-        $envStub->expects($this->any())
+        $envStub->expects(static::any())
                 ->method('getVersions')
-                ->will($this->returnValue([20120111235330]));
+                ->will(static::returnValue([20120111235330]));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv');
@@ -410,21 +443,24 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackWithTwoMigrationsDoesNotRollbackBothMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->any())
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $envStub->expects(static::any())
                 ->method('getVersionLog')
                 ->will(
-                    $this->returnValue(
+                    static::returnValue(
                         [
                             '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
                             '20120116183504' => ['version' => '20120815145812', 'migration' => '', 'breakpoint' => 0],
                         ]
                     )
                 );
-        $envStub->expects($this->any())
+        $envStub->expects(static::any())
                 ->method('getVersions')
                 ->will(
-                    $this->returnValue(
+                    static::returnValue(
                         [
                             20120111235330,
                             20120116183504,
@@ -660,7 +696,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testExecuteSeedWorksAsExpected()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->seed('mockenv');
         rewind($this->manager->getOutput()->getStream());
@@ -673,7 +712,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testExecuteASingleSeedWorksAsExpected()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->seed('mockenv', 'UserSeeder');
         rewind($this->manager->getOutput()->getStream());
@@ -688,7 +730,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testExecuteANonExistentSeedWorksAsExpected()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock()
+        ;
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->seed('mockenv', 'NonExistentSeeder');
         rewind($this->manager->getOutput()->getStream());


### PR DESCRIPTION
This adds a "dropConstraint" method to the table class:

it will drop the primary keys in MySQL and SQLite and in pgSQL it invokes the drop foreign key with the contraint parameter which is basically the same behaviour. I did not want to automate it like I did with mysql or sqlite since in pSQL everything is a constraint :) so only dropping things based on your naming convention does not cover all cases.

The reason I did not name it "dropPrimaryKey" is because pgSQL does not have primary keys and primary keys are only special cases of constraints.

I ran and added unittests for SQLite / MySQL / psql.

I updated the unittests to use the mockbuilder and not getMock for all libraries 
and DRY the SQLiteadapter.

This was blocking my development so please provide me feedback if you want to merge it or i have to maintain it myself.