### PR TITLE
Sqlite create column with notnull without default

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -407,7 +407,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
             $writeName = $selectName;
             if ($selectName === $columnName) {
-                if ($column['notnull'] === '0' && !$newColumn->isNull() && empty ($newColumn->getDefault())) {
+                if ($column['notnull'] === '0' && !$newColumn->isNull() && trim($newColumn->getDefault()) !== false) {
                     // it is necessary to check when changing NULL column to NOT NULL without DEFAULT options that
                     // there should be no existing rows with null values. Sqlite will SILENTLY IGNORE these rows when we would
                     // insert select them to the new table

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1043,7 +1043,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         $default = $column->getDefault();
 
-        $def .= ($column->isNull() || is_null($default)) ? ' NULL' : ' NOT NULL';
+        $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
         $def .= $this->getDefaultValueDefinition($default);
         $def .= ($column->isIdentity()) ? ' PRIMARY KEY AUTOINCREMENT' : '';
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -76,7 +76,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             }
 
             try {
-                $db = new \PDO($dsn);
+                $db = new \PDO($dsn, null, null, array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION));
             } catch (\PDOException $exception) {
                 throw new \InvalidArgumentException(sprintf(
                     'There was a problem connecting to the database: %s',
@@ -353,7 +353,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             ));
         }
 
-        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName));
+        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $this->quoteTableName($tableName), $this->quoteTableName($tmpTableName)));
 
         $sql = str_replace(
             $this->quoteColumnName($columnName),
@@ -365,10 +365,10 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         $sql = sprintf(
             'INSERT INTO %s(%s) SELECT %s FROM %s',
-            $tableName,
+            $this->quoteTableName($tableName),
             implode(', ', $writeColumns),
             implode(', ', $selectColumns),
-            $tmpTableName
+            $this->quoteTableName($tmpTableName)
         );
 
         $this->execute($sql);
@@ -415,7 +415,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             ));
         }
 
-        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName));
+        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $this->quoteTableName($tableName), $this->quoteTableName($tmpTableName)));
 
         $sql = preg_replace(
             sprintf("/%s[^,]+([,)])/", $this->quoteColumnName($columnName)),
@@ -427,11 +427,11 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $this->execute($sql);
 
         $sql = sprintf(
-            'INSERT INTO %s(%s) SELECT %s FROM %s',
-            $tableName,
+            'INSERT INTO %s (%s) SELECT %s FROM %s',
+            $this->quoteTableName($tableName),
             implode(', ', $writeColumns),
             implode(', ', $selectColumns),
-            $tmpTableName
+            $this->quoteTableName($tmpTableName)
         );
 
         $this->execute($sql);
@@ -478,7 +478,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             ));
         }
 
-        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName));
+        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $this->quoteTableName($tableName), $this->quoteTableName($tmpTableName)));
 
         $sql = preg_replace(
             sprintf("/%s\s%s[^,)]*(,\s|\))/", preg_quote($this->quoteColumnName($columnName)), preg_quote($columnType)),
@@ -494,10 +494,10 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         $sql = sprintf(
             'INSERT INTO %s(%s) SELECT %s FROM %s',
-            $tableName,
+            $this->quoteTableName($tableName),
             implode(', ', $columns),
             implode(', ', $columns),
-            $tmpTableName
+            $this->quoteTableName($tmpTableName)
         );
 
         $this->execute($sql);
@@ -723,13 +723,13 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $columns[] = $this->quoteColumnName($column['name']);
         }
 
-        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $this->quoteTableName($table->getName()), $tmpTableName));
+        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $this->quoteTableName($table->getName()), $this->quoteTableName($tmpTableName)));
 
         $sql = substr($sql, 0, -1) . ',' . $this->getForeignKeySqlDefinition($foreignKey) . ')';
         $this->execute($sql);
 
         $sql = sprintf(
-            'INSERT INTO %s(%s) SELECT %s FROM %s',
+            'INSERT INTO %s (%s) SELECT %s FROM %s',
             $this->quoteTableName($table->getName()),
             implode(', ', $columns),
             implode(', ', $columns),
@@ -782,7 +782,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             ));
         }
 
-        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $this->quoteTableName($tableName), $tmpTableName));
+        $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $this->quoteTableName($tableName), $this->quoteTableName($tmpTableName)));
 
         foreach ($columns as $columnName) {
             $search = sprintf(
@@ -796,10 +796,10 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         $sql = sprintf(
             'INSERT INTO %s(%s) SELECT %s FROM %s',
-            $tableName,
+            $this->quoteTableName($tableName),
             implode(', ', $columns),
             implode(', ', $columns),
-            $tmpTableName
+            $this->quoteTableName($tmpTableName)
         );
 
         $this->execute($sql);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -92,6 +92,18 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
     }
 
+    /**
+     * @expectedException \PDOException
+     * @expectedExceptionMessage SQLSTATE[HY000]: General error: 1 duplicate column name: realname
+     */
+    public function testCreateTableWithInvalidSyntaxThrowsException()
+    {
+        $table = new \Phinx\Db\Table('ntable', array(), $this->adapter);
+        $table->addColumn('realname', 'string')
+              ->addColumn('realname', 'integer')
+              ->save();
+    }
+
     public function testCreateTableCustomIdColumn()
     {
         $table = new \Phinx\Db\Table('ntable', array('id' => 'custom_id'), $this->adapter);
@@ -514,7 +526,9 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
     public function testDropForeignKey()
     {
         $refTable = new \Phinx\Db\Table('ref_table', array(), $this->adapter);
-        $refTable->addColumn('field1', 'string')->save();
+        $refTable->addColumn('field1', 'string')
+            ->addIndex(array('field1'), array('unique' => true)) // referenced key must be unique or primary key
+            ->save();
 
         $table = new \Phinx\Db\Table('table', array(), $this->adapter);
         $table->addColumn('ref_table_id', 'integer')->addColumn('ref_table_field', 'string')->save();


### PR DESCRIPTION
Fix for issue #265 - Allow table creating with SqliteAdapter to have NOT NULL columns without DEFAULT keyword.

no need to worry about ALTER COLUMN as
```
alter table person add column age integer not null;
```
will result with anyway

> SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL

but this has one sideeffect - when user tries to `$table->changeColumn(...)`:
* change NULL column to NOT NULL 
* and does not provide DEFAULT options
* and existing table has rows with null value in this column

Phinx would recreate table with NOT NULL column and `insert select` all data from old table to new. During this Sqlite SILENTLY ignores all values. I tried to do `INSERT OR FAIL ...` but this will just ignore problematic rows. so data loss occurs (Tested on Windows PhP 5.6.x).

My PR will check before first DDL if dataloss could occur and if there are rows with null values then Exception will be thrown