### PR TITLE
change glob to adapter the .phar files

### DIFF
--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -213,6 +213,13 @@ class Util
      */
     public static function glob($path)
     {
-        return glob($path, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
+        $directory = new \DirectoryIterator($path);
+        $files = [];
+        foreach ($directory as $file) {
+            if($file->isFile() && $file->getExtension() === 'php'){
+                $files[] = $file->getPath() . DIRECTORY_SEPARATOR . $file->getFilename();
+            }
+        }
+        return $files;
     }
 }


### PR DESCRIPTION
When generating .phar file the glob function did not find the migrations, changing to DirectiryIterator it is possible to find the migrations.
