### PR TITLE
Docker Development Kickstart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,20 @@ Great, so you want to contribute. Let's get started:
 
 1. Open a pull request on the Github project page. Ensure the code is being merged into `master`.
 
+## Getting Started with docker
+
+If you do not wish to install MySQL and Postgres locally to run unit tests
+can use [docker-compose](https://docs.docker.com/compose/) which will start 
+both database, install all development dependencies and run all unit tests.
+
+To get started, just run `docker-compose run phinx`. It will download all 
+images, install all dependencies, hook them up and run all unit tests
+(note: SQLServer tests are not supported, yet).
+
+You can also use `docker-compose run phinx install` to update/reinstall
+php composer packages manually. If you wish to drop into a shell, just run
+`docker-compose run phinx bash`, which will drop you right into a shell.
+
 ## Documentation
 
 The Phinx documentation is stored in the **docs** directory using the [RestructedText](http://docutils.sourceforge.net/rst.html)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "2"
+services:
+    phinx:
+        build:
+            dockerfile: docker/Dockerfile
+            context: .
+        volumes:
+            - .:/app
+        links:
+            - mysql:mysql
+            - postgres:postgres
+    mysql:
+        image: mysql:5.5
+        environment:
+            - MYSQL_DATABASE=phinx_testing
+            - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+    postgres:
+        image: postgres:9.2
+        environment:
+            - POSTGRES_DB=phinx_testing
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:7
+
+RUN yum install -y php php-cli php-pdo php-mbstring php-intl php-pdo \
+	php-pgsql php-mysqlnd php-xml git && \
+	curl -sS https://getcomposer.org/installer | php && \
+	mv composer.phar /usr/local/bin/composer
+
+COPY docker/entrypoint.bash /usr/local/bin/entrypoint.bash
+COPY composer.json /vendor_preinstalled/
+
+RUN cd /vendor_preinstalled/ && \
+	composer update --no-interaction --prefer-source --prefer-stable \
+		--prefer-lowest
+
+WORKDIR /app/
+ENTRYPOINT ["/bin/bash", "/usr/local/bin/entrypoint.bash"];
+CMD ["phpunit"]
+

--- a/docker/entrypoint.bash
+++ b/docker/entrypoint.bash
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+VENDOR_DIR=/app/vendor/
+
+function prepareConfig {
+	cat phpunit.xml.dist |
+	sed 's/localhost/mysql/' | sed 's/127.0.0.1/postgres/' > phpunit.xml.docker
+	trap shutdown EXIT
+}
+
+function printHelp {
+	echo "Available commands: {install, phpunit, bash}"
+	echo
+	echo " - install: install all dependencies using composer freshly"
+	echo " - quick-install: copy all dependencies from the docker image"
+	echo " - phpunit: run unit tests"
+	echo " - bash: drop into shell"
+	exit 1
+}
+
+function installCommand  {
+	prepareConfig
+	echo "Installing dependencies using composer:"
+	composer update --no-interaction --prefer-source --prefer-stable \
+		--prefer-lowest
+	echo "done installing dependencies"
+}
+
+function quickInstallCommand {
+	echo "Installing vendor dir from docker image"
+	rm -rf $VENDOR_DIR 2> /dev/null || true
+	cp -r /vendor_preinstalled/vendor/ $VENDOR_DIR
+	echo "Done installing vendor dir"
+}
+
+function phpunitCommand  {
+	prepareConfig
+	if [ ! -d $VENDOR_DIR ]; then
+		quickInstallCommand
+	fi
+
+	php vendor/bin/phpunit --config phpunit.xml.docker
+}
+
+function bashCommand {
+	prepareConfig
+	bash
+}
+
+function shutdown {
+	rm phpunit.xml.docker 2> /dev/null || true
+}
+
+key="$1"
+
+case $key in
+	quick-install)
+		quickInstallCommand
+		;;
+
+	install)
+		installCommand
+		;;
+
+	phpunit)
+		phpunitCommand
+		;;
+
+	bash)
+		bashCommand
+		;;
+	*)
+		printHelp
+esac
+


### PR DESCRIPTION
When I was trying to contribute to phinx, I found it rather difficult to setup the testing environment for running the unit tests.

This is why I have decided to create [docker](https://www.docker.com) and [docker-compose](https://docs.docker.com/compose/) files to help you kickstart a development environment. 

The advantage of using docker for developing is that running `docker-compose run phinx` will bring up a freshly created MySQL 5.5 and Postgres 9.2 database (the versions can be easily adjusted in `docker-compose.yml`), and a PHP 5.4 container running the unit tests. The PHP 5.4 container uses CentOS 7. I chose CentOS 7 since it still supports (and maintains PHP 5.4, unlike the official docker image) and I chose PHP 5.4 because it is the oldest PHP version supported by phinx.

So, what this does is: it will download & install all depencies (mysql, postgres, sqlite-lib, php, git and a few others), download all php composer packages (using --prefer-stable --prefer-source --prefer-lowest), and then run the tests, just with one command.

Besides being able to easily test it against every database, the database containers are volatile which means once they are removed (docker-compose down), they loose all data (this is helpful if you manage to corrupt the database because recreating it is really easy). They also isolate your other database (security warning: docker does not provide secure isolation to the host os, which means that there might be zero-days, so do not run any untrusted code inside docker. It will, however, save you from an accidental  `DROP DATABASE myOtherDatabase`). 

## Things to do (can be done in another merge): ##

- [ ] **Create an image for the Dockerfile** (this will decrease the start time for the first start dramatically since there is no "build" step -- this should only be done by the maintainers but creating the image can be fully automated & I am happy to assist)
- [ ] **Add support for Microsoft SQL** (since Microsoft added Linux support, it should be possible to run MSSQL tests on Mac, Linux, and Windows from Docker. Furthermore the linux build should run identically to the Windows build -- if it does not, it is considered a bug by Microsoft).