### PR TITLE
add seeds into config and enabled seeds config array to be loaded when seed:run executed

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -422,4 +422,12 @@ class Config implements ConfigInterface
     {
         unset($this->values[$id]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSeeds()
+    {
+        return (array_key_exists("seeds",$this->values))?$this->values['seeds']:[];
+    }
 }

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -102,6 +102,13 @@ interface ConfigInterface extends \ArrayAccess
      */
     public function getSeedPaths();
 
+    /**
+     * Gets seed classes to load seeds config array
+     *
+     * @return string[]
+     */
+    public function getSeeds();
+
      /**
      * Get the template file name.
      *

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -105,6 +105,10 @@ EOT
 
         $start = microtime(true);
 
+        if(empty($seedSet) && count($this->getConfig()->getSeeds())) {
+            $seedSet = $this->getConfig()->getSeeds();
+        }
+
         if (empty($seedSet)) {
             // run all the seed(ers)
             $this->getManager()->seed($environment);


### PR DESCRIPTION
i need to run seed using predefine sequence, so i add seeds into config:
```
    'seeds' => [
        GenderSeeder::class,
        LinkSeeder::class,
        LinkVisibilitySeeder::class,
    ]
```
when execute seed:run, if no seed parameter from command line, then use config['seeds'] array, if not then execute all in seed folder.