### PR TITLE
Change adapter in migration

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -337,13 +337,13 @@ class Config implements ConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function getDatabases()
+    public function getAvailableAdapters()
     {
         if (isset($this->values, $this->values['databases'])) {
             $adapter_factory = AdapterFactory::instance();
             $default_env = $this->getDefaultEnvironment();
             $default_database = $this->getEnvironment($default_env);
-            $databases = [];
+            $adapter_list = [];
             foreach ($this->values['databases'] as $key => $options) {
                 $options = array_merge($default_database, $options);
                 $adapter = $adapter_factory->getAdapter($options['adapter'], $options);
@@ -357,10 +357,10 @@ class Config implements ConfigInterface
                     $adapter = $adapter_factory->getWrapper('prefix', $adapter);
                 }
 
-                $databases[$key] = $adapter;
+                $adapter_list[$key] = $adapter;
             }
 
-            return $databases;
+            return $adapter_list;
         }
 
         return null;
@@ -369,12 +369,12 @@ class Config implements ConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function getDatabase($name)
+    public function getAvailableAdapter($name)
     {
-        $databases = $this->getDatabases();
+        $adapters = $this->getAvailableAdapters();
 
-        if (isset($databases[$name])) {
-            return $databases[$name];
+        if (isset($adapters[$name])) {
+            return $adapters[$name];
         }
 
         return null;
@@ -383,9 +383,9 @@ class Config implements ConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function hasDatabase($name)
+    public function hasAdapter($name)
     {
-        return (null !== $this->getDatabase($name));
+        return (null !== $this->getAvailableAdapter($name));
 
     }
     

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -61,7 +61,7 @@ class Config implements ConfigInterface
     protected $configFilePath;
 
     /**
-     * @var AdapterInterface[]
+     * @var AdapterInterface[]|null
      */
     protected $availableAdapters;
 

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -29,6 +29,7 @@
 namespace Phinx\Config;
 
 use Phinx\Db\Adapter\AdapterFactory;
+use Phinx\Db\Adapter\AdapterInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -58,6 +59,10 @@ class Config implements ConfigInterface
      * @var string
      */
     protected $configFilePath;
+    /**
+     * @var AdapterInterface[]
+     */
+    protected $availableAdapters;
 
     /**
      * {@inheritdoc}
@@ -339,11 +344,15 @@ class Config implements ConfigInterface
      */
     public function getAvailableAdapters()
     {
+        if ($this->availableAdapters !== null) {
+            return $this->availableAdapters;
+        }
+
+        $this->availableAdapters = [];
         if (isset($this->values, $this->values['databases'])) {
             $adapter_factory = AdapterFactory::instance();
             $default_env = $this->getDefaultEnvironment();
             $default_database = $this->getEnvironment($default_env);
-            $adapter_list = [];
             foreach ($this->values['databases'] as $key => $options) {
                 $options = array_merge($default_database, $options);
                 $adapter = $adapter_factory->getAdapter($options['adapter'], $options);
@@ -357,13 +366,12 @@ class Config implements ConfigInterface
                     $adapter = $adapter_factory->getWrapper('prefix', $adapter);
                 }
 
-                $adapter_list[$key] = $adapter;
+                $this->availableAdapters[$key] = $adapter;
             }
 
-            return $adapter_list;
         }
 
-        return null;
+        return $this->availableAdapters;
     }
 
     /**

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -28,6 +28,8 @@
  */
 namespace Phinx\Config;
 
+use Phinx\Db\Adapter\AdapterInterface;
+
 /**
  * Phinx configuration interface.
  *
@@ -129,6 +131,23 @@ interface ConfigInterface extends \ArrayAccess
      * @return boolean
      */
     public function isVersionOrderCreationTime();
+
+    /**
+     * @return AdapterInterface[]|null
+     */
+    public function getDatabases();
+
+    /**
+     * @param string $alias
+     * @return AdapterInterface|null
+     */
+    public function getDatabase($alias);
+
+    /**
+     * @param string $alias
+     * @return bool
+     */
+    public function hasDatabase($alias);
 
     /**
      * Gets the base class name for migrations.

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -133,7 +133,7 @@ interface ConfigInterface extends \ArrayAccess
     public function isVersionOrderCreationTime();
 
     /**
-     * @return AdapterInterface[]
+     * @return AdapterInterface[]|null
      */
     public function getAvailableAdapters();
 

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -135,19 +135,19 @@ interface ConfigInterface extends \ArrayAccess
     /**
      * @return AdapterInterface[]|null
      */
-    public function getDatabases();
+    public function getAvailableAdapters();
 
     /**
      * @param string $alias
      * @return AdapterInterface|null
      */
-    public function getDatabase($alias);
+    public function getAvailableAdapter($alias);
 
     /**
      * @param string $alias
      * @return bool
      */
-    public function hasDatabase($alias);
+    public function hasAdapter($alias);
 
     /**
      * Gets the base class name for migrations.

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -133,7 +133,7 @@ interface ConfigInterface extends \ArrayAccess
     public function isVersionOrderCreationTime();
 
     /**
-     * @return AdapterInterface[]|null
+     * @return AdapterInterface[]
      */
     public function getAvailableAdapters();
 

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -65,15 +65,20 @@ abstract class AbstractMigration implements MigrationInterface
      */
     protected $input;
 
+    /** @var Manager */
+    protected $manager;
+
     /**
      * Class Constructor.
      *
+     * @param Manager $manager
      * @param int $version Migration Version
      * @param InputInterface|null $input
      * @param OutputInterface|null $output
      */
-    final public function __construct($version, InputInterface $input = null, OutputInterface $output = null)
+    final public function __construct(Manager $manager, $version, InputInterface $input = null, OutputInterface $output = null)
     {
+        $this->manager = $manager;
         $this->version = $version;
         if (!is_null($input)){
             $this->setInput($input);
@@ -120,9 +125,42 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * {@inheritdoc}
      */
+    public function setAdapterByAlias($alias)
+    {
+        $config = $this->getManager()
+            ->getConfig();
+        if ($config->hasDatabase($alias) === false) {
+            throw new \InvalidArgumentException('Missing database configuration for "' . $alias . '"');
+        }
+
+        $this->setAdapter($config->getDatabase($alias));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getAdapter()
     {
         return $this->adapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setManager(Manager $manager)
+    {
+        $this->manager = $manager;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManager()
+    {
+        return $this->manager;
     }
 
     /**

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -73,18 +73,16 @@ abstract class AbstractMigration implements MigrationInterface
      *
      * @param Manager $manager
      * @param int $version Migration Version
-     * @param InputInterface|null $input
-     * @param OutputInterface|null $output
      */
-    final public function __construct(Manager $manager, $version, InputInterface $input = null, OutputInterface $output = null)
+    final public function __construct(Manager $manager, $version)
     {
         $this->manager = $manager;
         $this->version = $version;
-        if (!is_null($input)){
-            $this->setInput($input);
+        if ($manager->getInput()) {
+            $this->setInput($manager->getInput());
         }
-        if (!is_null($output)){
-            $this->setOutput($output);
+        if ($manager->getOutput()) {
+            $this->setOutput($manager->getOutput());
         }
 
         $this->init();

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -129,11 +129,11 @@ abstract class AbstractMigration implements MigrationInterface
     {
         $config = $this->getManager()
             ->getConfig();
-        if ($config->hasDatabase($alias) === false) {
-            throw new \InvalidArgumentException('Missing database configuration for "' . $alias . '"');
+        if ($config->hasAdapter($alias) === false) {
+            throw new \InvalidArgumentException('Missing adapter configuration for "' . $alias . '"');
         }
 
-        $this->setAdapter($config->getDatabase($alias));
+        $this->setAdapter($config->getAvailableAdapter($alias));
 
         return $this;
     }

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -117,6 +117,7 @@ abstract class AbstractMigration implements MigrationInterface
     public function setAdapter(AdapterInterface $adapter)
     {
         $this->adapter = $adapter;
+
         return $this;
     }
 
@@ -150,6 +151,7 @@ abstract class AbstractMigration implements MigrationInterface
     public function setManager(Manager $manager)
     {
         $this->manager = $manager;
+
         return $this;
     }
 
@@ -167,6 +169,7 @@ abstract class AbstractMigration implements MigrationInterface
     public function setInput(InputInterface $input)
     {
         $this->input = $input;
+
         return $this;
     }
 
@@ -184,6 +187,7 @@ abstract class AbstractMigration implements MigrationInterface
     public function setOutput(OutputInterface $output)
     {
         $this->output = $output;
+
         return $this;
     }
 
@@ -209,6 +213,7 @@ abstract class AbstractMigration implements MigrationInterface
     public function setVersion($version)
     {
         $this->version = $version;
+
         return $this;
     }
 

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -675,7 +675,7 @@ class Manager
                     }
 
                     // instantiate it
-                    $migration = new $class($version, $this->getInput(), $this->getOutput());
+                    $migration = new $class($this, $version, $this->getInput(), $this->getOutput());
 
                     if (!($migration instanceof AbstractMigration)) {
                         throw new \InvalidArgumentException(sprintf(

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -675,7 +675,7 @@ class Manager
                     }
 
                     // instantiate it
-                    $migration = new $class($this, $version, $this->getInput(), $this->getOutput());
+                    $migration = new $class($this, $version);
 
                     if (!($migration instanceof AbstractMigration)) {
                         throw new \InvalidArgumentException(sprintf(

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -78,11 +78,34 @@ interface MigrationInterface
     public function setAdapter(AdapterInterface $adapter);
 
     /**
+     * Sets the database adapter by alias
+     *
+     * @param string $alias
+     * @return MigrationInterface
+     */
+    public function setAdapterByAlias($alias);
+
+    /**
      * Gets the database adapter.
      *
      * @return AdapterInterface
      */
     public function getAdapter();
+
+    /**
+     * Sets the migration manager.
+     *
+     * @param Manager $manager Migration manager
+     * @return MigrationInterface
+     */
+    public function setManager(Manager $manager);
+
+    /**
+     * Gets the migration manager.
+     *
+     * @return Manager
+     */
+    public function getManager();
 
     /**
      * Sets the input object to be used in migration object

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Migration;
 
+use Phinx\Config\Config;
 use Phinx\Db\Table;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Migration\Manager;
@@ -17,7 +18,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->config = [];
+        $this->config = new Config([]);
         $this->input = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
             ->setConstructorArgs([[]])
             ->getMock();

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -27,6 +27,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $this->manager = $this->getMockBuilder('\Phinx\Migration\Manager')
             ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->setMethods(null)
             ->getMock();
     }
 
@@ -60,13 +61,21 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($migrationStub->getAdapter() instanceof AdapterInterface);
     }
 
-    public function testGetInputAndGetOutputMethods()
+    public function testGetInputMethodWithManagerInput()
     {
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // test methods
         $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $migrationStub->getInput());
+    }
+
+    public function testGetOutputMethodWithManagerOutput()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
+
+        // test methods
         $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $migrationStub->getOutput());
     }
 

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -60,34 +60,13 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($migrationStub->getAdapter() instanceof AdapterInterface);
     }
 
-    public function testSetOutputMethods()
+    public function testGetInputAndGetOutputMethods()
     {
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // test methods
-        $this->assertNull($migrationStub->getOutput());
-        $migrationStub->setOutput($this->output);
-        $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $migrationStub->getOutput());
-    }
-
-    public function testGetInputMethodWithInjectedInput()
-    {
-        // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0, $this->input, null));
-
-        // test methods
-        $this->assertNotNull($migrationStub->getInput());
         $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $migrationStub->getInput());
-    }
-
-    public function testGetOutputMethodWithInjectedOutput()
-    {
-        // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0, null, $this->output));
-
-        // test methods
-        $this->assertNotNull($migrationStub->getOutput());
         $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $migrationStub->getOutput());
     }
 

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -4,27 +4,49 @@ namespace Test\Phinx\Migration;
 
 use Phinx\Db\Table;
 use Phinx\Db\Adapter\AdapterInterface;
+use Phinx\Migration\Manager;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\StreamOutput;
 
 class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
 {
+    private $config;
+    private $input;
+    private $output;
+    private $manager;
+
+    protected function setUp()
+    {
+        $this->config = [];
+        $this->input = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $this->output = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $this->manager = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+    }
+
     public function testUp()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
         $this->assertNull($migrationStub->up());
     }
 
     public function testDown()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
         $this->assertNull($migrationStub->down());
     }
 
     public function testAdapterMethods()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -40,28 +62,18 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testSetOutputMethods()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
-
-        // stub output
-        $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
-            ->setConstructorArgs([[]])
-            ->getMock();
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // test methods
         $this->assertNull($migrationStub->getOutput());
-        $migrationStub->setOutput($outputStub);
+        $migrationStub->setOutput($this->output);
         $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $migrationStub->getOutput());
     }
 
     public function testGetInputMethodWithInjectedInput()
     {
-        // stub input
-        $inputStub = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
-            ->setConstructorArgs([[]])
-            ->getMock();
-
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, $inputStub, null));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0, $this->input, null));
 
         // test methods
         $this->assertNotNull($migrationStub->getInput());
@@ -70,13 +82,8 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
 
     public function testGetOutputMethodWithInjectedOutput()
     {
-        // stub output
-        $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
-            ->setConstructorArgs([[]])
-            ->getMock();
-
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, null, $outputStub));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0, null, $this->output));
 
         // test methods
         $this->assertNotNull($migrationStub->getOutput());
@@ -85,13 +92,13 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
 
     public function testGetName()
     {
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
         $this->assertFalse(!(strpos($migrationStub->getName(), 'AbstractMigration')));
     }
 
     public function testVersionMethods()
     {
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(20120103080000));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 20120103080000));
         $this->assertEquals(20120103080000, $migrationStub->getVersion());
         $migrationStub->setVersion(20120915093312);
         $this->assertEquals(20120915093312, $migrationStub->getVersion());
@@ -100,7 +107,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testExecute()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -117,7 +124,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testQuery()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -134,7 +141,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testFetchRow()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -151,7 +158,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testFetchAll()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -168,7 +175,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testInsert()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -186,7 +193,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testCreateDatabase()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -203,7 +210,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testDropDatabase()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -220,7 +227,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testHasTable()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -237,7 +244,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testTableMethod()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -251,7 +258,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testDropTableMethod()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array($this->manager, 0));
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Migration\Manager;
 
+use Phinx\Config\Config;
 use Phinx\Db\Adapter\AdapterFactory;
 use Phinx\Db\Adapter\PdoAdapter;
 use Phinx\Migration\Manager\Environment;
@@ -33,7 +34,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->environment = new Environment('test', array());
-        $this->config = [];
+        $this->config = new Config([]);
         $this->input = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
             ->setConstructorArgs([[]])
             ->getMock();

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -25,10 +25,24 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
      * @var \Phinx\Migration\Manager\Environment
      */
     private $environment;
+    private $config;
+    private $input;
+    private $output;
+    private $manager;
 
     public function setUp()
     {
         $this->environment = new Environment('test', array());
+        $this->config = [];
+        $this->input = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $this->output = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $this->manager = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
     }
 
     public function testConstructorWorksAsExpected()
@@ -132,7 +146,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
         // up
         $upMigration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20110301080000'])
+            ->setConstructorArgs([$this->manager, '20110301080000'])
             ->setMethods(['up'])
             ->getMock();
         $upMigration->expects($this->once())
@@ -155,7 +169,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
         // down
         $downMigration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20110301080000'])
+            ->setConstructorArgs([$this->manager, '20110301080000'])
             ->setMethods(['down'])
             ->getMock();
         $downMigration->expects($this->once())
@@ -184,7 +198,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
         // migrate
         $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20110301080000'])
+            ->setConstructorArgs([$this->manager, '20110301080000'])
             ->setMethods(['up'])
             ->getMock();
         $migration->expects($this->once())
@@ -207,7 +221,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
         // migration
         $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20130301080000'])
+            ->setConstructorArgs([$this->manager, '20130301080000'])
             ->setMethods(['change'])
             ->getMock();
         $migration->expects($this->once())
@@ -230,7 +244,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
         // migration
         $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20130301080000'])
+            ->setConstructorArgs([$this->manager, '20130301080000'])
             ->setMethods(['change'])
             ->getMock();
         $migration->expects($this->once())
@@ -241,9 +255,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
     public function testGettingInputObject()
     {
-        $mock = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
-            ->getMock();
-        $this->environment->setInput($mock);
+        $this->environment->setInput($this->input);
         $inputObject = $this->environment->getInput();
         $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $inputObject);
     }


### PR DESCRIPTION
This PR implements a new `setAdapterByAlias($alias)` method in the `AbstractMigration` class. This allows to change the used adapter during the migration process.

To keep the adapter selection handy, I've also created a configuration extensions to provide a list of databases which may be choosen by an alias.

Specific test for the new configuration section and `setAdapterByAlias` method will be pushed asap.