### PR TITLE
Postgresql can't have limit on bigint, same as integer and smallint

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -954,7 +954,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                     strtoupper($sqlType['type']),
                     $sqlType['srid']
                 );
-            } elseif (!in_array($sqlType['name'], array('integer', 'smallint'))) {
+            } elseif (!in_array($sqlType['name'], array('integer', 'smallint', 'bigint'))) {
                 if ($column->getLimit() || isset($sqlType['limit'])) {
                     $buffer[] = sprintf('(%s)', $column->getLimit() ? $column->getLimit() : $sqlType['limit']);
                 }


### PR DESCRIPTION

    Have I implemented my feature for as many database adapters as possible? No, it is to correct a bug on postgresql
    Does my new feature improve Phinx's performance or keep it consistent? No change
    Does my feature fit within the database migration space? ???
    Is the code entirely my own and free from any commercial licensing? Yes
    Am I happy to release my code under the MIT license? Yes
    Is my code formatted using the PSR-2 coding standard? Yes
