### PR TITLE
allow symfony dotenv external parameters style in config

### DIFF
--- a/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
+++ b/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
@@ -24,9 +24,9 @@ class ConfigDefaultEnvironmentTest extends AbstractConfigTest
     {
         $_SERVER['PHINX_DBHOST'] = 'localhost';
         $_SERVER['PHINX_DBNAME'] = 'productionapp';
-        $_SERVER['PHINX_DBUSER'] = 'root';
-        $_SERVER['PHINX_DBPASS'] = 'ds6xhj1';
         $_SERVER['PHINX_DBPORT'] = '1234';
+        $_SERVER['DB_PASS'] = 'ds6xhj1';
+        $_SERVER['DB_USER'] = 'root';
         $path = __DIR__ . '/_files';
         $config = Config::fromYaml($path . '/external_variables.yml');
         $env = $config->getEnvironment($config->getDefaultEnvironment());

--- a/tests/Phinx/Config/_files/external_variables.yml
+++ b/tests/Phinx/Config/_files/external_variables.yml
@@ -1,13 +1,13 @@
 paths:
-    migrations: %%PHINX_CONFIG_DIR%%/migrations
+    migrations: '%%PHINX_CONFIG_DIR%%/migrations'
         
 environments:
     default_migration_table: phinxlog
     default_database: production
     production:
         adapter: mysql
-        host: %%PHINX_DBHOST%%
-        name: %%PHINX_DBNAME%%
-        user: %%PHINX_DBUSER%%
-        pass: %%PHINX_DBPASS%%
-        port: %%PHINX_DBPORT%%
+        host: '%%PHINX_DBHOST%%'
+        name: '%%PHINX_DBNAME%%'
+        user: '%env(DB_USER)%'
+        pass: '%env(DB_PASS)%'
+        port: '%%PHINX_DBPORT%%'


### PR DESCRIPTION
http://symfony.com/doc/current/configuration/external_parameters.html

This PR leaves the current `%%PROOPH_VARIABLE%%` syntax in place but also allows for `%env(NEW_VARIABLE)%`

