### PR TITLE
[RuntimeException] Adapter "dblib" has not been registered

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -67,6 +67,7 @@ class AdapterFactory
         'pgsql'  => 'Phinx\Db\Adapter\PostgresAdapter',
         'sqlite' => 'Phinx\Db\Adapter\SQLiteAdapter',
         'sqlsrv' => 'Phinx\Db\Adapter\SqlServerAdapter',
+		'dblib'  => 'Phinx\Db\Adapter\SqlServerAdapter',
     );
 
     /**


### PR DESCRIPTION
[RuntimeException] Adapter "dblib" has not been registered. This run time error occur when user command  phinx operation via linux