### PR TITLE
doc: fix $this->query return type

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -180,10 +180,12 @@ Queries can be executed with the ``execute()`` and ``query()`` methods. The
             public function up()
             {
                 // execute()
-                $count = $this->execute('DELETE FROM users'); // returns the number of affected rows
+                // returns the number of affected rows
+                $count = $this->execute('DELETE FROM users');
 
                 // query()
-                $rows = $this->query('SELECT * FROM users'); // returns the result as an array
+                // returns the result as PDOStatement which you can iterate with foreach
+                $rows = $this->query('SELECT * FROM users');
             }
 
             /**


### PR DESCRIPTION
`$this->query` does not return array. altho it returns PDOStatement which is Iterable like array.

for example `print_r($rows)` will just print you:
```
PDOStatement Object
(
    [queryString] => SELECT * FROM users
)
```