### PR TITLE
Fix issue with dropColumn command in SQLite (#1086)

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -205,6 +205,9 @@ abstract class PdoAdapter implements AdapterInterface
     {
         $this->connection = $connection;
 
+        // ensure connection throws exceptions on errors (SQL syntax errors, etc)
+        $this->connection->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
         // Create the schema table if it doesn't already exist
         if (!$this->hasSchemaTable()) {
             $this->createSchemaTable();

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -205,9 +205,6 @@ abstract class PdoAdapter implements AdapterInterface
     {
         $this->connection = $connection;
 
-        // ensure connection throws exceptions on errors (SQL syntax errors, etc)
-        $this->connection->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-
         // Create the schema table if it doesn't already exist
         if (!$this->hasSchemaTable()) {
             $this->createSchemaTable();

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -379,11 +379,12 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider columnCreationArgumentProvider
      */
-    public function testDropColumn($columnName, $extraColumnCreationArgs)
+    public function testDropColumn($columnCreationArgs)
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
-        $table->addColumn($columnName, ...$extraColumnCreationArgs)
-              ->save();
+        $columnName = $columnCreationArgs[0];
+        call_user_func_array([$table, 'addColumn'], $columnCreationArgs);
+        $table->save();
         $this->assertTrue($this->adapter->hasColumn('t', $columnName));
 
         $this->adapter->dropColumn('t', $columnName);
@@ -394,8 +395,8 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
     public function columnCreationArgumentProvider()
     {
         return [
-            [ 'column1', ['string'] ],
-            [ 'profile_colour', ['enum', ['values' => ['blue', 'red', 'white']]] ]
+            [ ['column1', 'string'] ],
+            [ ['profile_colour', 'enum', ['values' => ['blue', 'red', 'white']]] ]
         ];
     }
 

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -11,6 +11,7 @@ class PDOMock extends \PDO
 {
     public function __construct()
     {
+        parent::__construct('sqlite::memory:');
     }
 
     public function getAttribute($attribute)

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -11,7 +11,7 @@ class PDOMock extends \PDO
 {
     public function __construct()
     {
-        parent::__construct('sqlite::memory:');
+
     }
 
     public function getAttribute($attribute)


### PR DESCRIPTION
Fix for the regex issue found (#1086) in `Phinx\Db\Adapter\SQLiteAdapter::dropColumn()` which resulted in malformed SQL being executed.  Note that included in this fix is a call to set the PDO error mode to throw exceptions in the event of error (malformed SQL being executed, etc) as I believe this will make such errors much more visible in the future (there were some failing unit tests that were covered up and marked as passing because of the exact same problem...malformed SQL being executed but no exceptions being thrown and no error codes checked for).  This was done in the `Phinx\Db\Adapter\PdoAdapter::setConnection()` method, so it will apply to all adapter classes derived from it.  I wanted to call this to attention as I'm not 100% certain this omission wasn't by design.  Let me know if any issues are found, will get them fixed ASAP.  Appreciate the time/effort put into Phinx thus far, I've found it very useful!