### PR TITLE
Correct `Migration->query($sql)` Example

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -183,7 +183,8 @@ Queries can be executed with the ``execute()`` and ``query()`` methods. The
                 $count = $this->execute('DELETE FROM users'); // returns the number of affected rows
 
                 // query()
-                $rows = $this->query('SELECT * FROM users'); // returns the result as an array
+                $stmt = $this->query('SELECT * FROM users'); // returns PDOStatement
+                $rows = $stmt->fetchAll(); // returns the result as an array
             }
 
             /**


### PR DESCRIPTION
The Description in the preceding documentation says `query()` will return a PDO Statement, but the sample code and comment implies it will return an array instead.