### PR TITLE
Force exception onto PDO

### DIFF
--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -329,6 +329,7 @@ class Environment
                 throw new \RuntimeException('The specified connection is not a PDO instance');
             }
 
+            $this->options['connection']->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $this->options['adapter'] = $this->options['connection']->getAttribute(\PDO::ATTR_DRIVER_NAME);
         }
         if (!isset($this->options['adapter'])) {

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -9,7 +9,7 @@ use Phinx\Migration\MigrationInterface;
 
 class PDOMock extends \PDO
 {
-    private $attributes = [];
+    public $attributes = [];
 
     public function __construct()
     {
@@ -17,7 +17,7 @@ class PDOMock extends \PDO
 
     public function getAttribute($attribute)
     {
-        return array_key_exists($attribute, $this->attributes) ? $this->attributes[$attribute] : 'pdomock';
+        return isset($this->attributes[$attribute]) ? $this->attributes[$attribute] : 'pdomock';
     }
 
     public function setAttribute($attribute, $value)
@@ -89,7 +89,8 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', array(array('foo' => 'bar')));
         AdapterFactory::instance()->registerAdapter('pdomock', $adapter);
         $this->environment->setOptions(array('connection' => $pdoMock));
-        $this->assertEquals(\PDO::ERRMODE_EXCEPTION, $pdoMock->getAttribute(\PDO::ATTR_ERRMODE));
+        $options = $this->environment->getAdapter()->getOptions();
+        $this->assertEquals(\PDO::ERRMODE_EXCEPTION, $options['connection']->getAttribute(\PDO::ATTR_ERRMODE));
     }
 
     /**

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -17,6 +17,11 @@ class PDOMock extends \PDO
     {
         return 'pdomock';
     }
+
+    public function setAttribute($attribute, $value)
+    {
+        return null;
+    }
 }
 
 class EnvironmentTest extends \PHPUnit_Framework_TestCase

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -9,18 +9,20 @@ use Phinx\Migration\MigrationInterface;
 
 class PDOMock extends \PDO
 {
+    private $attributes = [];
+
     public function __construct()
     {
     }
 
     public function getAttribute($attribute)
     {
-        return 'pdomock';
+        return array_key_exists($attribute, $this->attributes) ? $this->attributes[$attribute] : 'pdomock';
     }
 
     public function setAttribute($attribute, $value)
     {
-        return null;
+        $this->attributes[$attribute] = $value;
     }
 }
 
@@ -80,6 +82,15 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->environment->setOptions(array('connection' => new PDOMock()));
         $options = $this->environment->getAdapter()->getOptions();
         $this->assertEquals('pdomock', $options['adapter']);
+    }
+
+    public function testSetPdoAttributeToErrmodeException() {
+        $pdoMock = new PDOMock();
+        $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', array(array('foo' => 'bar')));
+        AdapterFactory::instance()->registerAdapter('pdomock', $adapter);
+        $this->environment->setOptions(array('connection' => $pdoMock));
+        $options = $this->environment->getAdapter()->getOptions();
+        $this->assertEquals(\PDO::ERRMODE_EXCEPTION, $pdoMock->getAttribute(\PDO::ATTR_ERRMODE));
     }
 
     /**

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -89,7 +89,6 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', array(array('foo' => 'bar')));
         AdapterFactory::instance()->registerAdapter('pdomock', $adapter);
         $this->environment->setOptions(array('connection' => $pdoMock));
-        $options = $this->environment->getAdapter()->getOptions();
         $this->assertEquals(\PDO::ERRMODE_EXCEPTION, $pdoMock->getAttribute(\PDO::ATTR_ERRMODE));
     }
 


### PR DESCRIPTION
## Problem

If someone uses an unconfigured PDO instance as a connection migration won't stop if an error is encountered (by default pdo is set to PDO::ERRMODE_SILENT)

## Solution

Add a PDO attribute to throw an exception on failed queries.