### PR TITLE
[SQLite] Fix invalid changeColumn regex causing deletions

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -431,7 +431,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName));
 
         $sql = preg_replace(
-            sprintf("/%s(?:\/\*.*?\*\/|\([^)]+\)|'[^']+'|[^,])+([,)])/", $this->quoteColumnName($columnName)),
+            sprintf("/%s(?:\/\*.*?\*\/|\([^)]+\)|'[^']*?'|[^,])+([,)])/", $this->quoteColumnName($columnName)),
             sprintf('%s %s$1', $this->quoteColumnName($newColumn->getName()), $this->getColumnSqlDefinition($newColumn)),
             $sql,
             1


### PR DESCRIPTION
This fixes an issue in the SQLiteAdapter that causes columns to be destroyed when removing a default value of `''` from a string column.
See comment here: https://github.com/cakephp/phinx/pull/1093#issuecomment-312373192

Unfortunately, there are no existing tests for this specific functionality that prove what I've changed hasn't broken anything.