### PR TITLE
Update yml file to surround parameters with quotes

### DIFF
--- a/phinx.yml
+++ b/phinx.yml
@@ -1,6 +1,6 @@
 paths:
-    migrations: %%PHINX_CONFIG_DIR%%/db/migrations
-    seeds: %%PHINX_CONFIG_DIR%%/db/seeds
+    migrations: '%%PHINX_CONFIG_DIR%%/db/migrations'
+    seeds: '%%PHINX_CONFIG_DIR%%/db/seeds'
 
 environments:
     default_migration_table: phinxlog


### PR DESCRIPTION
Hi, getting a php non fatal error being shown in error_get_last() due to a symfony deprecation.

    Not quoting the scalar "%%PHINX_CONFIG_DIR%%/database/migrations" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.

Info about this error: http://symfony.com/blog/new-in-symfony-3-1-yaml-deprecations#deprecated-starting-scalars-with-characters