### PR TITLE
SQLite - Revert back to RegEx for dropping enum columns (#1086)

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -491,32 +491,21 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             ));
         }
 
-        // rename existing table to a temp table
         $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName));
 
-        $originalBuildTableCommandIncludingColumnToRemove = $sql;
-
-        // isolate and rebuild column definitions sans the column we no longer want
-        $columnDefinitionsSubstring = preg_replace([
-                '/^CREATE\sTABLE\s`[^`]+`\s\(/i',
-                '/\);?\s*$/'
-            ],
-            '',
-            $originalBuildTableCommandIncludingColumnToRemove
+        $sql = preg_replace(
+            sprintf("/%s\s%s.*(,\s(?!')|\)$)/U", preg_quote($this->quoteColumnName($columnName)), preg_quote($columnType)),
+            "",
+            $sql
         );
 
-        $columnDefinitions = preg_split('/,\s*(?=`)/i', $columnDefinitionsSubstring);
-        $columnDefinitionsWithoutTheUnwantedColumn = array_filter($columnDefinitions, function ($definition) use ($columnName, $columnType) {
-            return (strpos($definition, $this->quoteColumnName($columnName).' '.$columnType) !== 0);
-        });
+        if (substr($sql, -2) === ', ') {
+            $sql = substr($sql, 0, -2) . ')';
+        }
 
-        // rebuild the table creation command, without the unwanted column
-        $rebuildTableCommand = "CREATE TABLE `{$tableName}` (".implode(', ', $columnDefinitionsWithoutTheUnwantedColumn).')';
+        $this->execute($sql);
 
-        // rebuild the table
-        $this->execute($rebuildTableCommand);
-
-        $dataMigrationFromTempTableToNewTable = sprintf(
+        $sql = sprintf(
             'INSERT INTO %s(%s) SELECT %s FROM %s',
             $tableName,
             implode(', ', $columns),
@@ -524,7 +513,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $tmpTableName
         );
 
-        $this->execute($dataMigrationFromTempTableToNewTable);
+        $this->execute($sql);
         $this->execute(sprintf('DROP TABLE %s', $this->quoteTableName($tmpTableName)));
         $this->endCommandTimer();
     }


### PR DESCRIPTION
Related to https://github.com/cakephp/phinx/pull/1093 - this PR modifies the original RegEx that was used for dropping columns.
The issue was that ENUMs weren't properly caught by the RegEx and thus produced invalid SQL when re-creating the table. This regex should fix that.