### PR TITLE
Add support for PostgreSQL citext column type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
     - travis_retry composer update --no-interaction --prefer-source --prefer-stable ${COMPOSER_FLAGS}
     - mysql -e 'create database phinx_testing;'
     - psql -c 'create database phinx_testing;' -U postgres
+    - psql -c 'create extension if not exists citext;' -U postgres
 
 script:
     - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -788,6 +788,14 @@ collation set collation that differs from table defaults *(only applies to MySQL
 encoding  set character set that differs from table defaults *(only applies to MySQL)*
 ========= ===========
 
+For the ``text`` column only:
+
+============== ===========
+Option         Description
+============== ===========
+case_sensitive set case-sensitivity via the ``citext`` extension *(only applies to PostgreSQL)*
+============== ===========
+
 For foreign key definitions:
 
 ====== ===========

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -102,6 +102,11 @@ class Column
     protected $timezone = false;
 
     /**
+     * @var boolean
+     */
+    protected $caseSensitive = true;
+
+    /**
      * @var array
      */
     protected $properties = array();
@@ -449,6 +454,39 @@ class Column
     }
 
     /**
+     * Sets whether the field should be case-sensitive.
+     * Used for text columns only!
+     *
+     * @param bool $caseSensitive
+     * @return Column
+     */
+    public function setCaseSensitive($caseSensitive)
+    {
+        $this->caseSensitive = (bool) $caseSensitive;
+        return $this;
+    }
+
+    /**
+     * Gets whether field is case-sensitive.
+     *
+     * @return boolean
+     */
+    public function getCaseSensitive()
+    {
+        return $this->caseSensitive;
+    }
+
+    /**
+     * Should the column be case-sensitive?
+     *
+     * @return boolean
+     */
+    public function isCaseSensitive()
+    {
+        return $this->getCaseSensitive();
+    }
+
+    /**
      * Sets field properties.
      *
      * @param array $properties
@@ -586,6 +624,7 @@ class Column
             'values',
             'collation',
             'encoding',
+            'caseSensitive',
         );
     }
 
@@ -598,6 +637,7 @@ class Column
     {
         return array(
             'length' => 'limit',
+            'case_sensitive' => 'caseSensitive',
         );
     }
 


### PR DESCRIPTION
This pull request is meant to add support for the [`citext`](https://www.postgresql.org/docs/9.2/static/citext.html) data type (generally available under `postgresql-contrib-*` packages).

I'm migrating my own project to Phinx (eventually CakePHP) and the lack of `citext` support caused me to hit a roadblock in the process. I believe my changes follow the guidelines found in the repository, but if not please do let me know.

I verified that all PostgresAdapter tests passed on a local PostgreSQL 9.6 server and I attempted the `docker-compose` route as well, but I got the following:
```
$ docker-compose run phinx
Starting phinx_postgres_1 ... 
Starting phinx_mysql_1 ... done
This version of PHPUnit is supported on PHP 5.6, PHP 7.0, and PHP 7.1.
You are using PHP 5.4.16 (/usr/bin/php).
```

In essence the only difference in the testing process after this change is having to run `CREATE EXTENSION citext` after the database creation and before the testing of tables starts, for which I added commands into both the `PostgresAdapterTest` class as well as the `.travis.yml` file.