### PR TITLE
Update docs to reflect actual behavior of [primary_key => false]

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -423,8 +423,9 @@ Finally calling ``save()`` commits the changes to the database.
     table.
 
 The ``id`` option sets the name of the automatically created identity field, while the ``primary_key``
-option selects the field or fields used for primary key. The ``primary_key`` option always defaults to
-the value of ``id``. Both can be disabled by setting them to false.
+option selects the field or fields used for primary key. ``id`` will always override the ``primary_key``
+option unless it's set to false. If you don't need a primary key set ``id`` to false without
+specifying a ``primary_key``, and no primary key will be created.
 
 To specify an alternate primary key, you can specify the ``primary_key`` option
 when accessing the Table object. Let's disable the automatic ``id`` column and


### PR DESCRIPTION
According to [the docs](https://github.com/cakephp/phinx/blob/26ac87ba6562e83689d34e3460ccc1d8014008d3/docs/migrations.rst#creating-a-table): *(emphasis mine)*

>The `id` option sets the name of the automatically created identity field, while the `primary_key` option selects the field or fields used for primary key. **The `primary_key` option always defaults to the value of `id`. Both can be disabled by setting them to false.**

This is misleading for two reasons.

First, the `primary_key` is currently only accounted for when `id` is set false, otherwise it's being set to the same value as `id`.  `primary_key` is not "inheriting" the value, that'd mean that there should be an `isset()` check before `$options['primary_key'] = $options['id']`.

Second, trying to run `vendor/bin/phinx migrate` with a migration that contains the `primary_key` option set to false, as in the example below:
```php
$this->table('mytable', ['id' => false, 'primary_key' => false])
    ->addColumn('thing', 'char', ['length' => 7, 'null' => true])
    ->create();
```
Causes the following error to be displayed & the migration to fail:
```
  [PDOException]                                                              
  SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near ")"        
  LINE 1: ...TER (7) NULL, CONSTRAINT mytable_pkey PRIMARY KEY ());CREATE ...  
                                                                ^              
```

With this pull request I'm updating the documentation to match what the code is currently doing.