### PR TITLE
When execute command `seed:run`, insert all data to a table in a bulk.

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -288,6 +288,15 @@ interface AdapterInterface
     public function insert(Table $table, $row);
 
     /**
+     * Inserts data into a table in a bulk.
+     *
+     * @param Table $table where to insert data
+     * @param array $rows
+     * @return void
+     */
+    public function bulkinsert(Table $table, $rows);
+
+    /**
      * Quotes a table name for use in a query.
      *
      * @param string $tableName Table Name

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -186,6 +186,14 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
+    public function bulkinsert(Table $table, $rows)
+    {
+        $this->getAdapter()->bulkinsert($table, $rows);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function fetchRow($sql)
     {
         return $this->getAdapter()->fetchRow($sql);

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -182,6 +182,7 @@ abstract class PdoAdapter extends AbstractAdapter
         $keys = array_keys($current);
         $sql .= "(". implode(', ', array_map(array($this, 'quoteColumnName'), $keys)) . ") VALUES";
 
+        $vals = array();
         foreach ($rows as $row) {
             foreach($row as $v) {
                 $vals[] = $v;

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -182,9 +182,11 @@ abstract class PdoAdapter extends AbstractAdapter
         $keys = array_keys($current);
         $sql .= "(". implode(', ', array_map(array($this, 'quoteColumnName'), $keys)) . ") VALUES";
 
-        $objTmp = (object) array('aFlat' => array());
-        array_walk_recursive($rows, create_function('&$v, $k, &$t', '$t->flat[] = $v;'), $objTmp);
-        $vals = $objTmp->flat;
+        foreach ($rows as $row) {
+            foreach($row as $v) {
+                $vals[] = $v;
+            }
+        }
 
         $count_keys = count($keys);
         $query = "(" . implode(', ', array_fill(0, $count_keys, '?')) . ")";

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -249,6 +249,17 @@ class TablePrefixAdapter extends AdapterWrapper
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function bulkinsert(Table $table, $rows)
+    {
+        $adapterTable = clone $table;
+        $adapterTableName = $this->getAdapterTableName($table->getName());
+        $adapterTable->setName($adapterTableName);
+        parent::bulkinsert($adapterTable, $rows);
+    }
+
+    /**
      * Gets the table prefix.
      *
      * @return string

--- a/src/Phinx/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Phinx/Db/Adapter/TimedOutputAdapter.php
@@ -115,6 +115,19 @@ class TimedOutputAdapter extends AdapterWrapper
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
+     */
+    public function bulkinsert(Table $table, $rows)
+    {
+        $end = $this->startCommandTimer();
+        $this->writeCommand('bulkinsert', [$table->getName()]);
+        parent::bulkinsert($table, $rows);
+        $end();
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function createTable(Table $table)
     {

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -75,6 +75,11 @@ class Table
     protected $data = array();
 
     /**
+     * @var boolean
+     */
+    protected $bulk = false;
+
+    /**
      * Class Constuctor.
      *
      * @param string $name Table Name
@@ -302,6 +307,39 @@ class Table
     }
 
     /**
+     * Sets flag to be inserted in bulk.
+     *
+     * @return Table
+     */
+    public function bulk()
+    {
+        $this->setBulk(true);
+        return $this;
+    }
+
+    /**
+     * Sets flag to be inserted in bulk.
+     *
+     * @param boolean $bulk bulk flag
+     * @return Table
+     */
+    public function setBulk($bulk)
+    {
+        $this->bulk = $bulk;
+        return $this;
+    }
+
+    /**
+     * Gets flag to be inserted in bulk.
+     *
+     * @return boolean
+     */
+    public function getBulk()
+    {
+        return $this->bulk;
+    }
+
+    /**
      * Resets all of the pending table changes.
      *
      * @return void
@@ -312,6 +350,7 @@ class Table
         $this->setIndexes(array());
         $this->setForeignKeys(array());
         $this->setData(array());
+        $this->setBulk(false);
     }
 
     /**
@@ -647,8 +686,12 @@ class Table
      */
     public function saveData()
     {
-        foreach ($this->getData() as $row) {
-            $this->getAdapter()->insert($this, $row);
+        if ($this->getBulk()) {
+            $this->getAdapter()->bulkinsert($this, $this->getData());
+        } else {
+            foreach ($this->getData() as $row) {
+                $this->getAdapter()->insert($this, $row);
+            }
         }
     }
 

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -75,11 +75,6 @@ class Table
     protected $data = array();
 
     /**
-     * @var boolean
-     */
-    protected $bulk = false;
-
-    /**
      * Class Constuctor.
      *
      * @param string $name Table Name
@@ -307,39 +302,6 @@ class Table
     }
 
     /**
-     * Sets flag to be inserted in bulk.
-     *
-     * @return Table
-     */
-    public function bulk()
-    {
-        $this->setBulk(true);
-        return $this;
-    }
-
-    /**
-     * Sets flag to be inserted in bulk.
-     *
-     * @param boolean $bulk bulk flag
-     * @return Table
-     */
-    public function setBulk($bulk)
-    {
-        $this->bulk = $bulk;
-        return $this;
-    }
-
-    /**
-     * Gets flag to be inserted in bulk.
-     *
-     * @return boolean
-     */
-    public function getBulk()
-    {
-        return $this->bulk;
-    }
-
-    /**
      * Resets all of the pending table changes.
      *
      * @return void
@@ -350,7 +312,6 @@ class Table
         $this->setIndexes(array());
         $this->setForeignKeys(array());
         $this->setData(array());
-        $this->setBulk(false);
     }
 
     /**
@@ -686,7 +647,23 @@ class Table
      */
     public function saveData()
     {
-        if ($this->getBulk()) {
+        $rows = $this->getData();
+        if (empty($rows)) {
+            return;
+        }
+
+        $bulk = true;
+        $row = current($rows);
+        $c = array_keys($row);
+        foreach($this->getData() as $row) {
+            $k = array_keys($row);
+            if ($k != $c) {
+                $bulk = false;
+                break;
+            }
+        }
+
+        if ($bulk) {
             $this->getAdapter()->bulkinsert($this, $this->getData());
         } else {
             foreach ($this->getData() as $row) {

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1082,6 +1082,42 @@ public function testRenameColumn()
         $this->assertTrue($tableQuoted->hasColumn('value'));
     }
 
+    public function testBulkInsertData()
+    {
+        $data = array(
+            array(
+                'column1' => 'value1',
+                'column2' => 1,
+            ),
+            array(
+                'column1' => 'value2',
+                'column2' => 2,
+            ),
+            array(
+                'column1' => 'value3',
+                'column2' => 3,
+            )
+        );
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->addColumn('column1', 'string')
+            ->addColumn('column2', 'integer')
+            ->addColumn('column3', 'string', array('default' => 'test'))
+            ->insert($data);
+        $this->adapter->createTable($table);
+        $this->adapter->bulkinsert($table, $table->getData());
+        $table->reset();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+        $this->assertEquals('value1', $rows[0]['column1']);
+        $this->assertEquals('value2', $rows[1]['column1']);
+        $this->assertEquals('value3', $rows[2]['column1']);
+        $this->assertEquals(1, $rows[0]['column2']);
+        $this->assertEquals(2, $rows[1]['column2']);
+        $this->assertEquals(3, $rows[2]['column2']);
+        $this->assertEquals('test', $rows[0]['column3']);
+        $this->assertEquals('test', $rows[2]['column3']);
+    }
+
     public function testInsertData()
     {
         $data = array(

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -374,7 +374,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->hasColumn('t', 'columnOne'));
         $this->assertTrue($this->adapter->hasColumn('t', 'columnTwo'));
     }
-    
+
     public function testRenamingANonExistentColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
@@ -935,6 +935,32 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
                 $this->assertTrue($column->isTimezone(), 'column: ' . $column->getName());
             }
         }
+    }
+
+    public function testBulkInsertData()
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->addColumn('column2', 'integer')
+              ->insert(array(
+                  array(
+                      'column1' => 'value1',
+                      'column2' => 1
+                  ),
+                  array(
+                      'column1' => 'value2',
+                      'column2' => 2
+                  )
+              ));
+        $this->adapter->createTable($table);
+        $this->adapter->bulkinsert($table, $table->getData());
+        $table->reset();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+        $this->assertEquals('value1', $rows[0]['column1']);
+        $this->assertEquals('value2', $rows[1]['column1']);
+        $this->assertEquals(1, $rows[0]['column2']);
+        $this->assertEquals(2, $rows[1]['column2']);
     }
 
     public function testInsertData()

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -666,6 +666,41 @@ class SqlServerAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($foreign->hasForeignKey('user'));
     }
 
+    public function testBulkInsertData()
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->addColumn('column2', 'integer')
+              ->insert(array(
+                  array(
+                      'column1' => 'value1',
+                      'column2' => 1,
+                  ),
+                  array(
+                      'column1' => 'value2',
+                      'column2' => 2,
+                  )
+              ))
+              ->insert(
+                  array(
+                      'column1' => 'value3',
+                      'column2' => 3,
+                  )
+              );
+        $this->adapter->createTable($table);
+        $this->adapter->bulkinsert($table, $table->getData());
+        $table->reset();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+
+        $this->assertEquals('value1', $rows[0]['column1']);
+        $this->assertEquals('value2', $rows[1]['column1']);
+        $this->assertEquals('value3', $rows[2]['column1']);
+        $this->assertEquals(1, $rows[0]['column2']);
+        $this->assertEquals(2, $rows[1]['column2']);
+        $this->assertEquals(3, $rows[2]['column2']);
+    }
+
     public function testInsertData()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -341,7 +341,7 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->mock
             ->expects($this->once())
-            ->method('insert')
+            ->method('bulkinsert')
             ->with($this->callback(
                 function ($table) {
                     return $table->getName() == 'pre_table_suf';

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -257,9 +257,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $adapterStub->expects($this->exactly(4))
-                    ->method('insert')
-                    ->with($table, $this->logicalOr($data[0], $data[1], $moreData[0], $moreData[1]));
+        $adapterStub->expects($this->exactly(1))
+                    ->method('bulkinsert')
+                    ->with($table, array($data[0], $data[1], $moreData[0], $moreData[1]));
 
         $table->insert($data)
               ->insert($moreData)

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -175,7 +175,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([[]])
             ->getMock();
         $adapterStub->expects($this->once())
-                    ->method('insert');
+                    ->method('bulkinsert');
 
         $table = new Table('testdb', [], $adapterStub);
 


### PR DESCRIPTION
When execute command `seed:run`, insert all data to a table in a bulk.
It take much time to insert data to a table one by one until now.

An example is shown below:
```
$table = $this->table('users');
$table->bulk()
      ->insert($data)
      ->save();
```

It became more than triple as fast by Bulk Insert when inserting 1,000 records.
It is very effective when many data samples are required.

However, it is assumed that the keys of data to be set are unified. 
The method `bulk()` are not available in the following example:

```
$data = array(
    array(
        'column1' => 'value1',
        'column2' => 1,
    ),
    array(
        'column1' => 'value2',
        'column3' => 'foo',
    ),
    array(
        'column1' => 'value3',
        'column2' => 3,
        'column3' => 'foo',
    )
);

$table = $this->table('users');
$table->bulk()
  ->insert($data)
  ->save();
```

The function of dynamically checking the key of the set data is not added,  
because it will cause performance degradation.