### PR TITLE
Add direction parameter to migration change method

### DIFF
--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -114,7 +114,7 @@ class Environment
                     ->getWrapper('proxy', $this->getAdapter());
                 $migration->setAdapter($proxyAdapter);
                 /** @noinspection PhpUndefinedMethodInspection */
-                $migration->change();
+                $migration->change($direction);
                 $proxyAdapter->executeInvertedCommands();
                 $migration->setAdapter($this->getAdapter());
             } else {


### PR DESCRIPTION
Enables otherwise irreversible migrations to become reversible. e.g. inside a `change()`:

```php
$this->table('foo', ['id' => false])
    # more columns
    ->create();
if ($direction === MigrationInterface::UP) {
    # some change to new table/data that requires no down() counterpart, e.g. custom compound primary key.
}
```