### PR TITLE
Fill up column values from schema

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -350,6 +350,10 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 $column->setIdentity(true);
             }
 
+            if (isset($phinxType['values'])) {
+                $column->setValues($phinxType['values']);
+            }
+
             $columns[] = $column;
         }
 
@@ -841,6 +845,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function getPhinxType($sqlTypeDef)
     {
+        $matches = array();
         if (!preg_match('/^([\w]+)(\(([\d]+)*(,([\d]+))*\))*(.+)*$/', $sqlTypeDef, $matches)) {
             throw new \RuntimeException('Column type ' . $sqlTypeDef . ' is not supported');
         } else {
@@ -926,13 +931,20 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                     break;
             }
 
+            // Call this to check if parsed type is supported.
             $this->getSqlType($type, $limit);
 
-            return array(
+            $phinxType = array(
                 'name' => $type,
                 'limit' => $limit,
                 'precision' => $precision
             );
+
+            if (static::PHINX_TYPE_ENUM == $type) {
+                $phinxType['values'] = explode("','", trim($matches[6], "()'"));
+            }
+
+            return $phinxType;
         }
     }
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\StreamOutput;
+use Phinx\Db\Adapter\AdapterInterface;
 
 class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
 {
@@ -1060,6 +1061,21 @@ public function testRenameColumn()
               ->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
         $this->assertEquals("enum('one','two')", $rows[1]['Type']);
+    }
+
+    public function testEnumColumnValuesFilledUpFromSchema()
+    {
+        // Creating column with values
+        (new \Phinx\Db\Table('table1', array(), $this->adapter))
+            ->addColumn('enum_column', 'enum', array('values' => array('one', 'two')))
+            ->save();
+
+        // Reading them back
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $columns = $table->getColumns();
+        $enumColumn = end($columns);
+        $this->assertEquals(AdapterInterface::PHINX_TYPE_ENUM, $enumColumn->getType());
+        $this->assertEquals(array('one', 'two'), $enumColumn->getValues());
     }
 
     public function testHasColumn()


### PR DESCRIPTION
When we create enum's in DB we should be able to read their's values back in migrations too.