### PR TITLE
Fix testing under docker 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,10 +63,10 @@ Great, so you want to contribute. Let's get started:
 ## Getting Started with docker
 
 If you do not wish to install MySQL and Postgres locally to run unit tests
-can use [docker-compose](https://docs.docker.com/compose/) which will start 
+can use [docker-compose](https://docs.docker.com/compose/) which will start
 both database, install all development dependencies and run all unit tests.
 
-To get started, just run `dco run --rm phinx`. It will download all 
+To get started, just run `docker-compose run --rm phinx`. It will download all
 images, build&start development container create `phpunit.xml` configuration and switch you to that container. So just install dependencies with `composer install` and run unittests with `vendor/bin/phpunit`.
 
 ## Documentation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.4
+FROM php:7
 
 # system dependecies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Current dockerized testing experience is this:

We should bump dockerized version to 7.0 as it's a minimal possible version from dev-dependencies.

PHP 5.4 and above will be caught by `travis`.

````
root@74dd8a8e4d55:/src# composer install                
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for symfony/config v3.3.6 -> satisfiable by symfony/config[v3.3.6].
    - symfony/config v3.3.6 requires php >=5.5.9 -> your PHP version (5.4.45) does not satisfy that requirement.
...
  Problem 18
    - phpdocumentor/reflection-docblock 3.2.2 requires php >=5.5 -> your PHP version (5.4.45) does not satisfy that requirement.
    - phpspec/prophecy v1.7.0 requires phpdocumentor/reflection-docblock ^2.0|^3.0.2 -> satisfiable by phpdocumentor/reflection-docblock[3.2.2].
    - Installation request for phpspec/prophecy v1.7.0 -> satisfiable by phpspec/prophecy[v1.7.0].
```