### PR TITLE
Better reversible migrations

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -66,6 +66,11 @@ abstract class AbstractMigration implements MigrationInterface
     protected $input;
 
     /**
+     * @var bool
+     */
+    protected $goingUp;
+
+    /**
      * Class Constructor.
      *
      * @param int $version Migration Version
@@ -182,6 +187,23 @@ abstract class AbstractMigration implements MigrationInterface
     public function getVersion()
     {
         return $this->version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setGoingUp($goingUp)
+    {
+        $this->goingUp = $goingUp;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGoingUp()
+    {
+        return $this->goingUp;
     }
 
     /**

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -105,6 +105,10 @@ class Environment
 
         // Run the migration
         if (method_exists($migration, MigrationInterface::CHANGE)) {
+
+            // notify reversible migrations of current direction
+            $migration->setGoingUp($direction === MigrationInterface::UP);
+
             if ($direction === MigrationInterface::DOWN) {
                 // Create an instance of the ProxyAdapter so we can record all
                 // of the migration commands for reverse playback

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -103,11 +103,11 @@ class Environment
             $this->getAdapter()->beginTransaction();
         }
 
+        // notify migrations of current direction
+        $migration->setGoingUp($direction === MigrationInterface::UP);
+
         // Run the migration
         if (method_exists($migration, MigrationInterface::CHANGE)) {
-
-            // notify reversible migrations of current direction
-            $migration->setGoingUp($direction === MigrationInterface::UP);
 
             if ($direction === MigrationInterface::DOWN) {
                 // Create an instance of the ProxyAdapter so we can record all

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -137,6 +137,21 @@ interface MigrationInterface
     public function getVersion();
 
     /**
+     * Sets the current migration direction.
+     *
+     * @param bool $goingUp Direction is up
+     * @return MigrationInterface
+     */
+    public function setGoingUp($goingUp);
+
+    /**
+     * Gets the current migration direction.
+     *
+     * @return bool
+     */
+    public function getGoingUp();
+
+    /**
      * Executes a SQL statement and returns the number of affected rows.
      *
      * @param string $sql SQL

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5469,6 +5469,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($adapter->hasTable('user_logins'));
         $this->assertTrue($adapter->hasColumn('users', 'biography'));
         $this->assertTrue($adapter->hasForeignKey('user_logins', array('user_id')));
+        $this->assertTrue($adapter->hasTable('change_direction_test'));
+        $this->assertTrue($adapter->hasColumn('change_direction_test', 'subthing'));
+        $this->assertEquals(
+            count($adapter->fetchAll('SELECT * FROM change_direction_test WHERE subthing IS NOT NULL')),
+            2
+        );
 
         // revert all changes to the first
         $this->manager->rollback('production', '20121213232502');
@@ -5479,6 +5485,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($adapter->hasTable('user_logins'));
         $this->assertTrue($adapter->hasColumn('users', 'bio'));
         $this->assertFalse($adapter->hasForeignKey('user_logins', array('user_id')));
+        $this->assertFalse($adapter->hasTable('change_direction_test'));
     }
 
     public function testReversibleMigrationsWorkAsExpectedWithNamespace()

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20170824134305_direction_aware_reversible_up.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20170824134305_direction_aware_reversible_up.php
@@ -1,0 +1,33 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class DirectionAwareReversibleUp extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('change_direction_test')
+            ->addColumn('thing', 'string', [
+                'limit' => 12,
+            ])
+            ->create();
+
+        if ($this->goingUp)
+        {
+            $this->insert('change_direction_test', [
+                [
+                    'thing' => 'one',
+                ],
+                [
+                    'thing' => 'two',
+                ],
+                [
+                    'thing' => 'fox_socks',
+                ],
+                [
+                    'thing' => 'mouse_box',
+                ],
+            ]);
+        }
+    }
+}

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20170831121929_direction_aware_reversible_down.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20170831121929_direction_aware_reversible_down.php
@@ -1,0 +1,29 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class DirectionAwareReversibleDown extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('change_direction_test')
+            ->addColumn('subthing', 'string', [
+                'limit' => 12,
+                'null' => true,
+            ])
+            ->update();
+
+        if ($this->goingUp)
+        {
+            $this->execute("UPDATE change_direction_test
+                SET subthing = SUBSTRING(thing, LOCATE('_', thing) + 1),
+                    thing = LEFT(thing, LOCATE('_', thing) - 1)
+                WHERE thing LIKE '%\\\\_%'");
+        }
+        else
+        {
+            $this->execute("UPDATE change_direction_test
+                SET thing = CONCAT_WS('_', thing, subthing)");
+        }
+    }
+}


### PR DESCRIPTION
Enables otherwise irreversible migrations to become reversible, and makes
it possible to use a single migration where previously two were required.

Pursuant to https://github.com/cakephp/phinx/pull/1151