### PR TITLE
Apply default collation on tables as per documentation

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -30,7 +30,6 @@ namespace Phinx\Db\Adapter;
 
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
-use Phinx\Migration\MigrationInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -84,6 +83,10 @@ abstract class AbstractAdapter implements AdapterInterface
     public function setOptions(array $options)
     {
         $this->options = $options;
+
+        if (isset($options['default_migration_table'])) {
+        	$this->setSchemaTableName($options['default_migration_table']);
+        }
 
         return $this;
     }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -205,7 +205,12 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             'engine' => 'InnoDB',
             'collation' => 'utf8_general_ci'
         );
-        $options = array_merge($defaultOptions, $table->getOptions());
+
+        $options = array_merge(
+            $defaultOptions,
+            array_intersect_key($this->getOptions(), $defaultOptions),
+            $table->getOptions()
+        );
 
         // Add the default primary key
         $columns = $table->getPendingColumns();


### PR DESCRIPTION
As per the documentation on [environment configuration](http://docs.phinx.org/en/latest/configuration.html#environments), there should be an option named `collation`. This configuration option doesn't do anything when you set it.

This change will set the default collation of newly created tables in this order:

1. The `collation` option provided in the array of options
2. The `collation` option provided in the environment configuration
3. `utf8_general_ci`