### PR TITLE
add optional limit parameter for mysql datetime, time and timestamp types

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -794,14 +794,13 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'decimal');
                 break;
             case static::PHINX_TYPE_DATETIME:
-                return array('name' => 'datetime');
-                break;
             case static::PHINX_TYPE_TIMESTAMP:
-                return array('name' => 'timestamp');
-                break;
             case static::PHINX_TYPE_TIME:
-                return array('name' => 'time');
-                break;
+                $def = array('name' => $type);
+                if ($limit && $limit > 0) {
+                    $def['limit'] = $limit <= 6 ? $limit : 6;
+                }
+                return $def;
             case static::PHINX_TYPE_DATE:
                 return array('name' => 'date');
                 break;

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -447,7 +447,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('utf8mb4_unicode_ci', $rows[2]['Collation']);
     }
 
-public function testRenameColumn()
+    public function testRenameColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
         $table->addColumn('column1', 'string')
@@ -619,6 +619,36 @@ public function testRenameColumn()
         $this->assertEquals($limit, $sqlType['limit']);
     }
 
+    /**
+     * @dataProvider provideTimeTypes
+     */
+    public function testDatetimeColumn($type, $options = array())
+    {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('column1', $type, $options)
+            ->save();
+        $columns = $table->getColumns();
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals($type, $sqlType['name']);
+        if (isset($options['limit'])) {
+            $this->assertEquals($options['limit'], $sqlType['limit']);
+        } else {
+            $this->assertFalse(isset($sqlType['limit']));
+        }
+    }
+
+    public function provideTimeTypes()
+    {
+        return array(
+            array('datetime'),
+            array('datetime', array('limit' => 6)),
+            array('time'),
+            array('time', array('limit' => 6)),
+            array('timestamp'),
+            array('timestamp', array('limit' => 6)),
+        );
+    }
+
     public function testDropColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
@@ -639,20 +669,23 @@ public function testRenameColumn()
               ->addColumn('column5', 'float')
               ->addColumn('column6', 'decimal')
               ->addColumn('column7', 'datetime')
-              ->addColumn('column8', 'time')
-              ->addColumn('column9', 'timestamp')
-              ->addColumn('column10', 'date')
-              ->addColumn('column11', 'binary')
-              ->addColumn('column12', 'boolean')
-              ->addColumn('column13', 'string', array('limit' => 10))
-              ->addColumn('column15', 'integer', array('limit' => 10))
-              ->addColumn('column16', 'geometry')
-              ->addColumn('column17', 'point')
-              ->addColumn('column18', 'linestring')
-              ->addColumn('column19', 'polygon')
-              ->addColumn('column20', 'uuid')
-              ->addColumn('column21', 'set', array('values' => "one, two"))
-              ->addColumn('column22', 'enum', array('values' => array('three', 'four')));
+              ->addColumn('column8', 'datetime', array('limit' => 6))
+              ->addColumn('column9', 'time')
+              ->addColumn('column10', 'time', array('limit' => 6))
+              ->addColumn('column11', 'timestamp')
+              ->addColumn('column12', 'timestamp', array('limit' => 6))
+              ->addColumn('column13', 'date')
+              ->addColumn('column14', 'binary')
+              ->addColumn('column15', 'boolean')
+              ->addColumn('column16', 'string', array('limit' => 10))
+              ->addColumn('column17', 'integer', array('limit' => 10))
+              ->addColumn('column18', 'geometry')
+              ->addColumn('column19', 'point')
+              ->addColumn('column20', 'linestring')
+              ->addColumn('column21', 'polygon')
+              ->addColumn('column22', 'uuid')
+              ->addColumn('column23', 'set', array('values' => "one, two"))
+              ->addColumn('column24', 'enum', array('values' => array('three', 'four')));
         $pendingColumns = $table->getPendingColumns();
         $table->save();
         $columns = $this->adapter->getColumns('t');
@@ -686,20 +719,23 @@ public function testRenameColumn()
               ->addColumn('column5', 'float')
               ->addColumn('column6', 'decimal')
               ->addColumn('column7', 'datetime')
-              ->addColumn('column8', 'time')
-              ->addColumn('column9', 'timestamp')
-              ->addColumn('column10', 'date')
-              ->addColumn('column11', 'binary')
-              ->addColumn('column12', 'boolean')
-              ->addColumn('column13', 'string', array('limit' => 10))
-              ->addColumn('column15', 'integer', array('limit' => 10))
-              ->addColumn('column16', 'geometry')
-              ->addColumn('column17', 'point')
-              ->addColumn('column18', 'linestring')
-              ->addColumn('column19', 'polygon')
-              ->addColumn('column20', 'uuid')
-              ->addColumn('column21', 'set', array('values' => "one, two"))
-              ->addColumn('column22', 'enum', array('values' => array('three', 'four')));
+              ->addColumn('column8', 'datetime', array('limit' => 6))
+              ->addColumn('column9', 'time')
+              ->addColumn('column10', 'time', array('limit' => 6))
+              ->addColumn('column11', 'timestamp')
+              ->addColumn('column12', 'timestamp', array('limit' => 6))
+              ->addColumn('column13', 'date')
+              ->addColumn('column14', 'binary')
+              ->addColumn('column15', 'boolean')
+              ->addColumn('column16', 'string', array('limit' => 10))
+              ->addColumn('column17', 'integer', array('limit' => 10))
+              ->addColumn('column18', 'geometry')
+              ->addColumn('column19', 'point')
+              ->addColumn('column20', 'linestring')
+              ->addColumn('column21', 'polygon')
+              ->addColumn('column22', 'uuid')
+              ->addColumn('column23', 'set', array('values' => "one, two"))
+              ->addColumn('column24', 'enum', array('values' => array('three', 'four')));
         $pendingColumns = $table->getPendingColumns();
         $table->save();
         $columns = $this->adapter->getColumns('group');

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -942,12 +942,18 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_DECIMAL));
         $this->assertEquals(array('name' => 'datetime'),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_DATETIME));
+        $this->assertEquals(array('name' => 'datetime', 'limit' => 6),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_DATETIME, 6));
         $this->assertEquals(array('name' => 'timestamp'),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_TIMESTAMP));
+        $this->assertEquals(array('name' => 'timestamp', 'limit' => 6),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_TIMESTAMP, 6));
         $this->assertEquals(array('name' => 'date'),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_DATE));
         $this->assertEquals(array('name' => 'time'),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_TIME));
+        $this->assertEquals(array('name' => 'time', 'limit' => 6),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_TIME, 6));
         $this->assertEquals(array('name' => 'blob'),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB));
         $this->assertEquals(array('name' => 'tinyint', 'limit' => 1),
@@ -1050,6 +1056,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                             $this->adapter->getPhinxType('decimal(8,2)'));
         $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_TEXT, 'limit' => 1024, 'precision' => null),
                             $this->adapter->getPhinxType('text(1024)'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_DATETIME, 'limit' => 6, 'precision' => null),
+                            $this->adapter->getPhinxType('datetime(6)'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_TIME, 'limit' => 6, 'precision' => null),
+                            $this->adapter->getPhinxType('time(6)'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_TIMESTAMP, 'limit' => 6, 'precision' => null),
+                            $this->adapter->getPhinxType('timestamp(6)'));
     }
 
 


### PR DESCRIPTION
From Mysql 5.7 and MariaDB 5.3 the DATETIME, TIME and TIMESTAMP types support fractional seconds with a precision from 0 to 6. This PR makes it possible to create tables with those columns.

As mentioned in #904 and #1003