### PR TITLE
fix : use the default_migration_table yml directive if present

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -30,7 +30,6 @@ namespace Phinx\Db\Adapter;
 
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
-use Phinx\Migration\MigrationInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -84,6 +83,10 @@ abstract class AbstractAdapter implements AdapterInterface
     public function setOptions(array $options)
     {
         $this->options = $options;
+
+        if (isset($options['default_migration_table'])) {
+        	$this->setSchemaTableName($options['default_migration_table']);
+        }
 
         return $this;
     }


### PR DESCRIPTION
When phinx.yml defines a custom default_migration_table value, this value is not used. "phinxlog" is still used.

 .... setSchemaTableName() is never used in the whole project ....

The problem was already present in <0.9 versions but not for PDOAdapter, like if this default_migration_table directive was only available for PDOAdapters. I am using PDOAdapter subclasses so I didn't notice it before. Since 0.9.0 version it is blocking even when using pdo adapters.