### PR TITLE
Apply default collation on tables as per documentation (new #1165)

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -206,7 +206,12 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             'engine' => 'InnoDB',
             'collation' => 'utf8_general_ci'
         ];
-        $options = array_merge($defaultOptions, $table->getOptions());
+
+        $options = array_merge(
+            $defaultOptions,
+            array_intersect_key($this->getOptions(), $defaultOptions),
+            $table->getOptions()
+        );
 
         // Add the default primary key
         $columns = $table->getPendingColumns();


### PR DESCRIPTION
_Closed and re-opened from #1165 as I put new commits into my own master branch - use this one instead please_

As per the documentation on [environment configuration](http://docs.phinx.org/en/latest/configuration.html#environments), there should be an option named `collation`. This configuration option doesn't do anything when you set it.

This change will set the default collation of newly created tables in this order:

1. The `collation` option provided in the array of options
2. The `collation` option provided in the environment configuration
3. `utf8_general_ci`