### PR TITLE
Add tests for connection and table name configuration.

### DIFF
--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -25,18 +25,39 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $options['foo']);
     }
 
+    public function testOptionsSetConnection()
+    {
+        $this->assertNull($this->adapter->getConnection());
+
+        $connection = $this
+            ->getMockBuilder('\PDO')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->adapter->setOptions(['connection' => $connection]);
+
+        $this->assertSame($connection, $this->adapter->getConnection());
+    }
+
+    public function testOptionsSetSchemaTableName()
+    {
+        $this->assertEquals('phinxlog', $this->adapter->getSchemaTableName());
+        $this->adapter->setOptions(['default_migration_table' => 'schema_table_test']);
+        $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());
+    }
+
     public function testSchemaTableName()
     {
+        $this->assertEquals('phinxlog', $this->adapter->getSchemaTableName());
         $this->adapter->setSchemaTableName('schema_table_test');
         $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());
     }
-    
+
     /**
      * @dataProvider getVersionLogDataProvider
      */
     public function testGetVersionLog($versionOrder, $expectedOrderBy)
     {
-        $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', 
+        $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter',
             array(array('version_order' => $versionOrder)), '', true, true, true,
             array('fetchAll', 'getSchemaTableName'));
 
@@ -87,14 +108,14 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
-    
+
     /**
      * @expectedException RuntimeException
      * @expectedExceptionMessage Invalid version_order configuration option
      */
     public function testGetVersionLogInvalidVersionOrderKO()
     {
-        $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', 
+        $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter',
             array(array('version_order' => 'invalid')));
 
         $adapter->getVersionLog();

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -4,6 +4,13 @@ namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\PdoAdapter;
 
+class PdoAdapterTestPDOMock extends \PDO
+{
+    public function __construct()
+    {
+    }
+}
+
 class PdoAdapterTest extends \PHPUnit_Framework_TestCase
 {
     private $adapter;
@@ -29,10 +36,7 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertNull($this->adapter->getConnection());
 
-        $connection = $this
-            ->getMockBuilder('\PDO')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $connection = new PdoAdapterTestPDOMock();
         $this->adapter->setOptions(['connection' => $connection]);
 
         $this->assertSame($connection, $this->adapter->getConnection());


### PR DESCRIPTION
Adds tests for #1173, #1171, #1167.

Should this maybe be moved to, or have additional integration tests on `EnvironmentTest` class level? `EnvironmentTest::testGetAdapterWithExistingPdoInstance()` seems to have a hint of testing that could have covered #1170, but actually doesn't touch the underlying adapter to check whether it received the expected connection.

Edit: Didn't noticed the whitespace removal... I blame JetBrains.