### PR TITLE
Fatal: hasOption() on null

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -246,6 +246,6 @@ abstract class AbstractAdapter implements AdapterInterface
     {
         $input = $this->getInput();
 
-        return $input->hasOption('dry-run') ? $input->getOption('dry-run') : false;
+        return ($input && $input->hasOption('dry-run')) ? $input->getOption('dry-run') : false;
     }
 }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTestExecChecks.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTestExecChecks.php
@@ -11,6 +11,27 @@ class PdoAdapterTestPDOMock extends \PDO
     }
 }
 
+/**
+ * A mock PDO that stores its last exec()'d SQL that can be retrieved for queries.
+ * 
+ * This exists as $this->getMockForAbstractClass('\PDO') fails under PHP5.4 and
+ * an older PHPUnit; a PDO instance cannot be serialised.
+ */
+class PdoAdapterTestPDOMockWithExecChecks extends PdoAdapterTestPDOMock
+{
+    private $sql;
+    
+    public function exec($sql)
+    {
+        $this->sql = $sql;
+    }
+
+    public function getExecutedSqlForTest()
+    {
+        return $this->sql;
+    }
+}
+
 class PdoAdapterTest extends \PHPUnit_Framework_TestCase
 {
     private $adapter;
@@ -131,5 +152,19 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
         );
 
         $adapter->getVersionLog();
+    }
+
+    /**
+     * Tests that execute() can be called on the adapter, and that the SQL is passed through to the PDO.
+     */
+    public function testExecuteCanBeCalled()
+    {
+        $pdo = new PdoAdapterTestPDOMockWithExecChecks();
+
+        $this->adapter->setConnection($pdo);
+
+        $this->adapter->execute('SELECT 1');
+
+        $this->assertSame('SELECT 1', $pdo->getExecutedSqlForTest());
     }
 }


### PR DESCRIPTION
Hi. Not sure if I'm missing something, but we've encountered an issue when instantiating a migration environment.

Sample code:

```php
<?php

require __DIR__ . '/vendor/autoload.php';

$manager = new \Phinx\Migration\Manager(
    \Phinx\Config\Config::fromPhp(__DIR__ . '/test-config.php'),
    new \Symfony\Component\Console\Input\ArrayInput([]),
    new \Symfony\Component\Console\Output\NullOutput()
);

class TestSeed extends \Phinx\Seed\AbstractSeed { }

$manager->executeSeed('development', new TestSeed());
```

Where our test configuration is:
```php
<?php

return [
    'environments' => [
        'development' => [
            'name' => 'devdb',
            'connection' => new PDO('sqlite::memory:'),
        ]
    ]
];
```

We encounter this error:
```
Fatal error: Uncaught Error: Call to a member function hasOption() on null in phinx/src/Phinx/Db/Adapter/AbstractAdapter.php on line 248

Error: Call to a member function hasOption() on null in phinx/src/Phinx/Db/Adapter/AbstractAdapter.php on line 248

Call Stack:
    0.0002     371912   1. {main}() phinx/pop.php:0
    0.0030     996640   2. Phinx\Migration\Manager->executeSeed() phinx/pop.php:13
    0.0032    1035552   3. Phinx\Migration\Manager\Environment->executeSeed() phinx/src/Phinx/Migration/Manager.php:396
    0.0032    1035552   4. Phinx\Migration\Manager\Environment->getAdapter() phinx/src/Phinx/Migration/Manager/Environment.php:148
    0.0033    1049152   5. Phinx\Db\Adapter\AdapterFactory->getAdapter() phinx/src/Phinx/Migration/Manager/Environment.php:344
    0.0044    1349128   6. Phinx\Db\Adapter\AbstractAdapter->__construct() phinx/src/Phinx/Db/Adapter/AdapterFactory.php:131
    0.0044    1349128   7. Phinx\Db\Adapter\PdoAdapter->setOptions() phinx/src/Phinx/Db/Adapter/AbstractAdapter.php:71
    0.0044    1349128   8. Phinx\Db\Adapter\PdoAdapter->setConnection() phinx/src/Phinx/Db/Adapter/PdoAdapter.php:56
    0.0045    1349128   9. Phinx\Db\Adapter\AbstractAdapter->createSchemaTable() phinx/src/Phinx/Db/Adapter/PdoAdapter.php:74
    0.0050    1452504  10. Phinx\Db\Table->save() phinx/src/Phinx/Db/Adapter/AbstractAdapter.php:218
    0.0050    1452504  11. Phinx\Db\Table->create() phinx/src/Phinx/Db/Table.php:697
    0.0050    1452504  12. Phinx\Db\Adapter\SQLiteAdapter->createTable() phinx/src/Phinx/Db/Table.php:609
    0.0051    1452760  13. Phinx\Db\Adapter\PdoAdapter->execute() phinx/src/Phinx/Db/Adapter/SQLiteAdapter.php:228
    0.0051    1452760  14. Phinx\Db\Adapter\AbstractAdapter->isDryRunEnabled() phinx/src/Phinx/Db/Adapter/PdoAdapter.php:126
```

Our script runs an empty seed to prove the problem, but I suspect this would happen with any DB operation against the manager. I think the problem is around initialising a connection, which is too early for an environment to be aware of a console input.

We've worked around this in our project by reverting to v0.8.1, but I'm posting this quick-fix PR in case it is any use.

Thanks! :)