### PR TITLE
Missing function in AdapterWrapper

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -536,4 +536,12 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     {
         return $this->getAdapter()->castToBool($value);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection()
+    {
+        return $this->getAdapter()->getConnection();
+    }
 }


### PR DESCRIPTION
Due to errors encountered while using getConnection() from migration, I added the missing function in the AdapterWrapper