### PR TITLE
Added full support of different schemas for Postgres.

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -211,7 +211,7 @@ abstract class AbstractAdapter implements AdapterInterface
     {
         try {
             $options = [
-                'id' => false,
+                'id'  => false,
                 'primary_key' => 'version'
             ];
 

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -211,7 +211,7 @@ abstract class AbstractAdapter implements AdapterInterface
     {
         try {
             $options = [
-                'id'  => false,
+                'id' => false,
                 'primary_key' => 'version'
             ];
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1088,13 +1088,10 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         $parts = $this->getSchemaName($tableName);
 
         $constraintName = $foreignKey->getConstraint() ?: ($parts['table'] . '_' . implode('_', $foreignKey->getColumns()) . '_fkey');
-        $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName)
-            . ' FOREIGN KEY ("'
-            . implode('", "', $foreignKey->getColumns())
-            . '")'
-            . " REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable()->getName())} (\""
-            . implode('", "', $foreignKey->getReferencedColumns())
-            . '")';
+        $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName) .
+' FOREIGN KEY ("' . implode('", "', $foreignKey->getColumns()) . '")' .
+" REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable()->getName())} (\"" .
+implode('", "', $foreignKey->getReferencedColumns()) . '")';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }
@@ -1128,7 +1125,8 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function createSchema($schemaName = 'public')
     {
-        $sql = sprintf('CREATE SCHEMA %s;', $this->quoteSchemaName($schemaName)); // from postgres 9.3 we can use "CREATE SCHEMA IF NOT EXISTS schema_name"
+        // from postgres 9.3 we can use "CREATE SCHEMA IF NOT EXISTS schema_name"
+        $sql = sprintf('CREATE SCHEMA %s;', $this->quoteSchemaName($schemaName));
         $this->execute($sql);
     }
 
@@ -1229,7 +1227,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     }
 
     /**
-     * @param string $tableName
+     * @param string $tableName Table name
      * @return array
      */
     private function getSchemaName($tableName)

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -167,7 +167,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
-        $parts  = $this->getSchemaName($tableName);
+        $parts = $this->getSchemaName($tableName);
         $result = $this->getConnection()->query(
             sprintf(
                 'SELECT *
@@ -188,7 +188,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function createTable(Table $table, array $columns = [], array $indexes = [])
     {
         $options = $table->getOptions();
-        $parts   = $this->getSchemaName($table->getName());
+        $parts = $this->getSchemaName($table->getName());
 
          // Add the default primary key
         if (!isset($options['id']) || (isset($options['id']) && $options['id'] === true)) {
@@ -380,7 +380,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function hasColumn($tableName, $columnName)
     {
         $parts = $this->getSchemaName($tableName);
-        $sql   = sprintf(
+        $sql = sprintf(
             "SELECT count(*)
             FROM information_schema.columns
             WHERE table_schema = %s AND table_name = %s AND column_name = %s",
@@ -419,7 +419,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     protected function getRenameColumnInstructions($tableName, $columnName, $newColumnName)
     {
         $parts = $this->getSchemaName($tableName);
-        $sql   = sprintf(
+        $sql = sprintf(
             "SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END AS column_exists
              FROM information_schema.columns
              WHERE table_schema = %s AND table_name = %s AND column_name = %s",
@@ -537,7 +537,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         $parts = $this->getSchemaName($tableName);
 
         $indexes = [];
-        $sql     = sprintf(
+        $sql = sprintf(
             "SELECT
                 i.relname AS index_name,
                 a.attname AS column_name
@@ -695,9 +695,9 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getForeignKeys($tableName)
     {
-        $parts       = $this->getSchemaName($tableName);
+        $parts = $this->getSchemaName($tableName);
         $foreignKeys = [];
-        $rows        = $this->fetchAll(sprintf(
+        $rows = $this->fetchAll(sprintf(
             "SELECT
                     tc.constraint_name,
                     tc.table_name, kcu.column_name,
@@ -1090,10 +1090,14 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     {
         $parts = $this->getSchemaName($tableName);
 
-        $constraintName = $foreignKey->getConstraint() ?: $parts['table'] . '_' . implode('_', $foreignKey->getColumns());
-
-        $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName) . ' FOREIGN KEY ("' . implode('", "', $foreignKey->getColumns()) . '")';
-        $def .= " REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable()->getName())} (\"" . implode('", "', $foreignKey->getReferencedColumns()) . '")';
+        $constraintName = $foreignKey->getConstraint() ?: ($parts['table'] . '_' . implode('_', $foreignKey->getColumns()) . '_fkey');
+        $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName)
+            . ' FOREIGN KEY ("'
+            . implode('", "', $foreignKey->getColumns())
+            . '")'
+            . " REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable()->getName())} (\""
+            . implode('", "', $foreignKey->getReferencedColumns())
+            . '")';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }
@@ -1228,20 +1232,20 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     }
 
     /**
-     * @param  string $tableName
+     * @param string $tableName
      * @return array
      */
     private function getSchemaName($tableName)
     {
         $schema = $this->getGlobalSchemaName();
-        $table  = $tableName;
+        $table = $tableName;
         if (false !== strpos($tableName, '.')) {
             list($schema, $table) = explode('.', $tableName);
         }
 
         return [
             'schema' => $schema,
-            'table'  => $table,
+            'table' => $table,
         ];
     }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -310,9 +310,9 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function getColumns($tableName)
     {
-        $parts   = $this->getSchemaName($tableName);
+        $parts = $this->getSchemaName($tableName);
         $columns = [];
-        $sql     = sprintf(
+        $sql = sprintf(
             "SELECT column_name, data_type, udt_name, is_identity, is_nullable,
              column_default, character_maximum_length, numeric_precision, numeric_scale,
              datetime_precision
@@ -761,10 +761,10 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $rows = $this->fetchAll(sprintf(
                 "SELECT CONSTRAINT_NAME
                 FROM information_schema.KEY_COLUMN_USAGE
-                WHERE TABLE_SCHEMA = '%s'
+                WHERE TABLE_SCHEMA = %s
                 AND TABLE_NAME IS NOT NULL
-                AND TABLE_NAME = '%s'
-                AND COLUMN_NAME = '%s'
+                AND TABLE_NAME = %s
+                AND COLUMN_NAME = %s
                 ORDER BY POSITION_IN_UNIQUE_CONSTRAINT",
                 $this->getConnection()->quote($parts['schema']),
                 $this->getConnection()->quote($parts['table']),
@@ -1063,9 +1063,6 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $indexName = $index->getName();
         } else {
             $columnNames = $index->getColumns();
-            if (is_string($columnNames)) {
-                $columnNames = [$columnNames];
-            }
             $indexName = sprintf('%s_%s', $parts['table'], implode('_', $columnNames));
         }
         $def = sprintf(

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1089,9 +1089,9 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
 
         $constraintName = $foreignKey->getConstraint() ?: ($parts['table'] . '_' . implode('_', $foreignKey->getColumns()) . '_fkey');
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName) .
-' FOREIGN KEY ("' . implode('", "', $foreignKey->getColumns()) . '")' .
-" REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable()->getName())} (\"" .
-implode('", "', $foreignKey->getReferencedColumns()) . '")';
+        ' FOREIGN KEY ("' . implode('", "', $foreignKey->getColumns()) . '")' .
+        " REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable()->getName())} (\"" .
+        implode('", "', $foreignKey->getReferencedColumns()) . '")';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -46,11 +46,11 @@ class PostgresAdapterTest extends TestCase
         }
 
         $options = [
-            'host'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_HOST,
-            'name'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE,
-            'user'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_USERNAME,
-            'pass'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_PASSWORD,
-            'port'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_PORT,
+            'host' => TESTS_PHINX_DB_ADAPTER_POSTGRES_HOST,
+            'name' => TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE,
+            'user' => TESTS_PHINX_DB_ADAPTER_POSTGRES_USERNAME,
+            'pass' => TESTS_PHINX_DB_ADAPTER_POSTGRES_PASSWORD,
+            'port' => TESTS_PHINX_DB_ADAPTER_POSTGRES_PORT,
             'schema' => TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE_SCHEMA
         ];
         $this->adapter = new PostgresAdapter($options, new ArrayInput([]), new NullOutput());
@@ -205,8 +205,8 @@ class PostgresAdapterTest extends TestCase
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = [
-            'id'            => false,
-            'primary_key'   => ['user_id', 'tag_id']
+            'id' => false,
+            'primary_key' => ['user_id', 'tag_id']
         ];
         $table = new \Phinx\Db\Table('table1', $options, $this->adapter);
         $table->addColumn('user_id', 'integer')
@@ -222,7 +222,7 @@ class PostgresAdapterTest extends TestCase
         $this->adapter->createSchema('schema1');
 
         $options = [
-            'id'          => false,
+            'id' => false,
             'primary_key' => ['user_id', 'tag_id']
         ];
         $table = new \Phinx\Db\Table('schema1.table1', $options, $this->adapter);
@@ -723,7 +723,7 @@ class PostgresAdapterTest extends TestCase
         $columns = $this->adapter->getColumns('tschema.t');
         $this->assertCount(count($pendingColumns) + 1, $columns);
         for ($i = 0; $i++; $i < count($pendingColumns)) {
-            $this->assertEquals($pendingColumns[$i], $columns[$i+1]);
+            $this->assertEquals($pendingColumns[$i], $columns[$i + 1]);
         }
 
         $this->adapter->dropSchema('tschema');
@@ -1293,13 +1293,21 @@ class PostgresAdapterTest extends TestCase
     {
         $this->adapter->createSchema('schema_users');
 
-        $userId    = 'user';
+        $userId = 'user';
         $sessionId = 'session';
 
-        $local = new \Phinx\Db\Table('schema_users.users', ['primary_key' => $userId, 'id' => $userId], $this->adapter);
+        $local = new \Phinx\Db\Table(
+            'schema_users.users',
+            ['primary_key' => $userId, 'id' => $userId],
+            $this->adapter
+        );
         $local->create();
 
-        $foreign = new \Phinx\Db\Table('schema_users.sessions', ['primary_key' => $sessionId, 'id' => $sessionId], $this->adapter);
+        $foreign = new \Phinx\Db\Table(
+            'schema_users.sessions',
+            ['primary_key' => $sessionId, 'id' => $sessionId],
+            $this->adapter
+        );
         $foreign->addColumn('user', 'integer')
             ->addForeignKey('user', 'schema_users.users', $userId)
             ->create();
@@ -1314,13 +1322,21 @@ class PostgresAdapterTest extends TestCase
         $this->adapter->createSchema('schema_users');
         $this->adapter->createSchema('schema_sessions');
 
-        $userId    = 'user';
+        $userId = 'user';
         $sessionId = 'session';
 
-        $local = new \Phinx\Db\Table('schema_users.users', ['primary_key' => $userId, 'id' => $userId], $this->adapter);
+        $local = new \Phinx\Db\Table(
+            'schema_users.users',
+            ['primary_key' => $userId, 'id' => $userId],
+            $this->adapter
+        );
         $local->create();
 
-        $foreign = new \Phinx\Db\Table('schema_sessions.sessions', ['primary_key' => $sessionId, 'id' => $sessionId], $this->adapter);
+        $foreign = new \Phinx\Db\Table(
+            'schema_sessions.sessions',
+            ['primary_key' => $sessionId, 'id' => $sessionId],
+            $this->adapter
+        );
         $foreign->addColumn('user', 'integer')
             ->addForeignKey('user', 'schema_users.users', $userId)
             ->create();
@@ -1499,7 +1515,7 @@ class PostgresAdapterTest extends TestCase
     {
         $this->adapter->createSchema('schema1');
 
-        $table  = new \Phinx\Db\Table('schema1.table1', [], $this->adapter);
+        $table = new \Phinx\Db\Table('schema1.table1', [], $this->adapter);
         $table->addColumn('column1', 'string')
             ->addColumn('column2', 'integer')
             ->insert([

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -46,11 +46,11 @@ class PostgresAdapterTest extends TestCase
         }
 
         $options = [
-            'host' => TESTS_PHINX_DB_ADAPTER_POSTGRES_HOST,
-            'name' => TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE,
-            'user' => TESTS_PHINX_DB_ADAPTER_POSTGRES_USERNAME,
-            'pass' => TESTS_PHINX_DB_ADAPTER_POSTGRES_PASSWORD,
-            'port' => TESTS_PHINX_DB_ADAPTER_POSTGRES_PORT,
+            'host'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_HOST,
+            'name'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE,
+            'user'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_USERNAME,
+            'pass'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_PASSWORD,
+            'port'   => TESTS_PHINX_DB_ADAPTER_POSTGRES_PORT,
             'schema' => TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE_SCHEMA
         ];
         $this->adapter = new PostgresAdapter($options, new ArrayInput([]), new NullOutput());
@@ -139,7 +139,7 @@ class PostgresAdapterTest extends TestCase
     public function testQuoteTableName()
     {
         $this->assertEquals('"public"."table"', $this->adapter->quoteTableName('table'));
-        $this->assertEquals('"public"."table.table"', $this->adapter->quoteTableName('table.table'));
+        $this->assertEquals('"table"."table"', $this->adapter->quoteTableName('table.table'));
     }
 
     public function testQuoteColumnName()
@@ -188,15 +188,15 @@ class PostgresAdapterTest extends TestCase
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = [
-            'id' => false,
-            'primary_key' => ['user_id', 'tag_id']
+            'id'            => false,
+            'primary_key'   => ['user_id', 'tag_id']
         ];
         $table = new \Phinx\Db\Table('table1', $options, $this->adapter);
         $table->addColumn('user_id', 'integer')
               ->addColumn('tag_id', 'integer')
               ->save();
         $this->assertTrue($this->adapter->hasIndex('table1', ['user_id', 'tag_id']));
-        $this->assertTrue($this->adapter->hasIndex('table1', ['tag_id', 'USER_ID']));
+        $this->assertTrue($this->adapter->hasIndex('table1', ['tag_id', 'user_id']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_email']));
     }
 
@@ -1179,7 +1179,7 @@ class PostgresAdapterTest extends TestCase
             ->save();
 
         $expectedOutput = <<<'OUTPUT'
-CREATE TABLE "public"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT 'test', CONSTRAINT table1_pkey PRIMARY KEY ("id"));
+CREATE TABLE "public"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT 'test', CONSTRAINT "table1_pkey" PRIMARY KEY ("id"));
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
         $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query');

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1092,7 +1092,7 @@ class PostgresAdapterTest extends TestCase
         $rows = $this->adapter->fetchAll(
             sprintf(
                 "SELECT description FROM pg_description JOIN pg_class ON pg_description.objoid = " .
-"pg_class.oid WHERE relname = '%s'",
+                "pg_class.oid WHERE relname = '%s'",
                 'ntable'
             )
         );
@@ -1565,8 +1565,8 @@ class PostgresAdapterTest extends TestCase
             ->save();
 
         $expectedOutput = 'CREATE TABLE "public"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) ' .
-'NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
-'"table1_pkey" PRIMARY KEY ("id"));';
+        'NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
+        '"table1_pkey" PRIMARY KEY ("id"));';
         $actualOutput = $consoleOutput->fetch();
         $this->assertContains(
             $expectedOutput,
@@ -1591,8 +1591,8 @@ class PostgresAdapterTest extends TestCase
             ->save();
 
         $expectedOutput = 'CREATE TABLE "schema1"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) ' .
-'NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
-'"table1_pkey" PRIMARY KEY ("id"));';
+        'NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
+        '"table1_pkey" PRIMARY KEY ("id"));';
         $actualOutput = $consoleOutput->fetch();
         $this->assertContains(
             $expectedOutput,

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -419,7 +419,11 @@ class PostgresAdapterTest extends TestCase
         $columns = $this->adapter->getColumns('citable');
         foreach ($columns as $column) {
             if ($column->getName() === 'insensitive') {
-                $this->assertEquals('citext', (string)$column->getType(), 'column: ' . $column->getName());
+                $this->assertEquals(
+                    'citext',
+                    (string)$column->getType(),
+                    'column: ' . $column->getName()
+                );
             }
         }
     }
@@ -1085,10 +1089,13 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
 
-        $rows = $this->adapter->fetchAll(sprintf(
-            "SELECT description FROM pg_description JOIN pg_class ON pg_description.objoid = pg_class.oid WHERE relname = '%s'",
-            'ntable'
-        ));
+        $rows = $this->adapter->fetchAll(
+            sprintf(
+                "SELECT description FROM pg_description JOIN pg_class ON pg_description.objoid = " .
+"pg_class.oid WHERE relname = '%s'",
+                'ntable'
+            )
+        );
 
         $this->assertEquals($tableComment, $rows[0]['description'], 'Dont set table comment correctly');
     }
@@ -1096,8 +1103,11 @@ class PostgresAdapterTest extends TestCase
     public function testCanAddColumnComment()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
-        $table->addColumn('field1', 'string', ['comment' => $comment = 'Comments from column "field1"'])
-              ->save();
+        $table->addColumn(
+            'field1',
+            'string',
+            ['comment' => $comment = 'Comments from column "field1"']
+        )->save();
 
         $row = $this->adapter->fetchRow(
             'SELECT
@@ -1146,8 +1156,11 @@ class PostgresAdapterTest extends TestCase
         $table->addColumn('field1', 'string', ['comment' => 'Comments from column "field1"'])
               ->save();
 
-        $table->changeColumn('field1', 'string', ['comment' => $comment = 'New Comments from column "field1"'])
-              ->save();
+        $table->changeColumn(
+            'field1',
+            'string',
+            ['comment' => $comment = 'New Comments from column "field1"']
+        )->save();
 
         $row = $this->adapter->fetchRow(
             'SELECT
@@ -1270,7 +1283,11 @@ class PostgresAdapterTest extends TestCase
         $local = new \Phinx\Db\Table('users', ['primary_key' => $userId, 'id' => $userId], $this->adapter);
         $local->create();
 
-        $foreign = new \Phinx\Db\Table('sessions', ['primary_key' => $sessionId, 'id' => $sessionId], $this->adapter);
+        $foreign = new \Phinx\Db\Table(
+            'sessions',
+            ['primary_key' => $sessionId, 'id' => $sessionId],
+            $this->adapter
+        );
         $foreign->addColumn('user', 'integer')
                 ->addForeignKey('user', 'users', $userId)
                 ->create();
@@ -1342,8 +1359,10 @@ class PostgresAdapterTest extends TestCase
         $table
             ->addColumn('timestamp_tz', 'timestamp', ['timezone' => true])
             ->addColumn('time_tz', 'time', ['timezone' => true])
-            ->addColumn('date_notz', 'date', ['timezone' => true]) /* date columns cannot have timestamp */
-            ->addColumn('time_notz', 'timestamp') /* default for timezone option is false */
+            /* date columns cannot have timestamp */
+            ->addColumn('date_notz', 'date', ['timezone' => true])
+            /* default for timezone option is false */
+            ->addColumn('time_notz', 'timestamp')
             ->save();
 
         $this->assertTrue($this->adapter->hasColumn('tztable', 'timestamp_tz'));
@@ -1369,8 +1388,10 @@ class PostgresAdapterTest extends TestCase
         $table
             ->addColumn('timestamp_tz', 'timestamp', ['timezone' => true])
             ->addColumn('time_tz', 'time', ['timezone' => true])
-            ->addColumn('date_notz', 'date', ['timezone' => true]) /* date columns cannot have timestamp */
-            ->addColumn('time_notz', 'timestamp') /* default for timezone option is false */
+            /* date columns cannot have timestamp */
+            ->addColumn('date_notz', 'date', ['timezone' => true])
+            /* default for timezone option is false */
+            ->addColumn('time_notz', 'timestamp')
             ->save();
 
         $this->assertTrue($this->adapter->hasColumn('tzschema.tztable', 'timestamp_tz'));
@@ -1543,11 +1564,15 @@ class PostgresAdapterTest extends TestCase
             ->addColumn('column3', 'string', ['default' => 'test'])
             ->save();
 
-        $expectedOutput = <<<'OUTPUT'
-CREATE TABLE "public"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT 'test', CONSTRAINT "table1_pkey" PRIMARY KEY ("id"));
-OUTPUT;
+        $expectedOutput = 'CREATE TABLE "public"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) ' .
+'NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
+'"table1_pkey" PRIMARY KEY ("id"));';
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query');
+        $this->assertContains(
+            $expectedOutput,
+            $actualOutput,
+            'Passing the --dry-run option does not dump create table query'
+        );
     }
 
     public function testDumpCreateTableWithSchema()
@@ -1565,11 +1590,15 @@ OUTPUT;
             ->addColumn('column3', 'string', ['default' => 'test'])
             ->save();
 
-        $expectedOutput = <<<'OUTPUT'
-CREATE TABLE "schema1"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT 'test', CONSTRAINT "table1_pkey" PRIMARY KEY ("id"));
-OUTPUT;
+        $expectedOutput = 'CREATE TABLE "schema1"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) ' .
+'NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
+'"table1_pkey" PRIMARY KEY ("id"));';
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query');
+        $this->assertContains(
+            $expectedOutput,
+            $actualOutput,
+            'Passing the --dry-run option does not dump create table query'
+        );
     }
 
     /**
@@ -1608,7 +1637,11 @@ INSERT INTO "public"."table1" ("string_col") VALUES (null);
 INSERT INTO "public"."table1" ("int_col") VALUES (23);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the insert to the output');
+        $this->assertContains(
+            $expectedOutput,
+            $actualOutput,
+            'Passing the --dry-run option doesn\'t dump the insert to the output'
+        );
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         self::assertTrue($countQuery->execute());
@@ -1649,7 +1682,11 @@ OUTPUT;
 INSERT INTO "public"."table1" ("string_col", "int_col") VALUES ('test_data1', 23), (null, 42);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the bulkinsert to the output');
+        $this->assertContains(
+            $expectedOutput,
+            $actualOutput,
+            'Passing the --dry-run option doesn\'t dump the bulkinsert to the output'
+        );
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         self::assertTrue($countQuery->execute());


### PR DESCRIPTION
Added full support of different schemas for Postgres (#828). Use-case:
```php
$this->getAdapter()->createSchema('schema1');

if (!$this->hasTable('schema1.example1')) {
    $table = $this->table('schema1.example1');
    $table
        ->addColumn('column1', 'integer')
        ->save();
}

$this->getAdapter()->createSchema('schema2');

if (!$this->hasTable('schema2.example2')) {
    $table = $this->table('schema2.example2');
    $table
        ->addColumn('column2', 'integer')
        ->save();

    $table
        ->addForeignKey('column2', 'schema1.example1', 'id')
        ->save();
}
```

Instead of now:
```php
$this->getAdapter()->createSchema('schema1');
$this->getAdapter()->setOptions(array_replace($this->getAdapter()->getOptions(), ['schema' => 'schema1']));

if (!$this->hasTable('example1')) {
    $table = $this->table('example1');
    $table
        ->addColumn('column1', 'integer')
        ->save();
}

$this->getAdapter()->createSchema('schema2');
$this->getAdapter()->setOptions(array_replace($this->getAdapter()->getOptions(), ['schema' => 'schema2']));

if (!$this->hasTable('example2')) {
    $table = $this->table('example2');
    $table
        ->addColumn('column2', 'integer')
        ->save();

    $this->execute('ALTER TABLE schema2.example2 ADD CONSTRAINT example2_column2_fkey FOREIGN KEY (column2) REFERENCES schema1.example1(id)');
}

$this->getAdapter()->setOptions(array_replace($this->getAdapter()->getOptions(), ['schema' => 'public']));
```