### PR TITLE
Fix chainability for the setColumns call

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -201,6 +201,7 @@ class Table
     public function setColumns($columns)
     {
         $this->setPendingColumns($columns);
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Table->setColumns() was not returning $this despite the documentation and thus was not chainable.

It's fixed :-)