### PR TITLE
Fix phpstan error by adding method to interface as annotation.

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -40,6 +40,7 @@ use Phinx\Migration\MigrationInterface;
  * Adapter Interface.
  *
  * @author Rob Morgan <robbym@gmail.com>
+ * @method \PDO getConnection()
  */
 interface AdapterInterface
 {


### PR DESCRIPTION
After https://github.com/cakephp/phinx/pull/1190 broke the build, this attempts to get phpstan green again.