### PR TITLE
Fix FQCN in doc blocks

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -74,7 +74,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param  string $configFilePath Path to the Yaml File
      * @throws \RuntimeException
-     * @return Config
+     * @return \Phinx\Config\Config
      */
     public static function fromYaml($configFilePath)
     {
@@ -96,7 +96,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param  string $configFilePath Path to the JSON File
      * @throws \RuntimeException
-     * @return Config
+     * @return \Phinx\Config\Config
      */
     public static function fromJson($configFilePath)
     {
@@ -116,7 +116,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param  string $configFilePath Path to the PHP File
      * @throws \RuntimeException
-     * @return Config
+     * @return \Phinx\Config\Config
      */
     public static function fromPhp($configFilePath)
     {

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -57,17 +57,17 @@ abstract class AbstractCommand extends Command
     const DEFAULT_SEED_TEMPLATE = '/../../Seed/Seed.template.php.dist';
 
     /**
-     * @var ConfigInterface
+     * @var \Phinx\Config\ConfigInterface
      */
     protected $config;
 
     /**
-     * @var AdapterInterface
+     * @var \Phinx\Db\Adapter\AdapterInterface
      */
     protected $adapter;
 
     /**
-     * @var Manager
+     * @var \Phinx\Migration\Manager
      */
     protected $manager;
 
@@ -83,8 +83,8 @@ abstract class AbstractCommand extends Command
     /**
      * Bootstrap Phinx.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return void
      */
     public function bootstrap(InputInterface $input, OutputInterface $output)
@@ -120,8 +120,8 @@ abstract class AbstractCommand extends Command
     /**
      * Sets the config.
      *
-     * @param  ConfigInterface $config
-     * @return AbstractCommand
+     * @param  \Phinx\Config\ConfigInterface $config
+     * @return \Phinx\Console\Command\AbstractCommand
      */
     public function setConfig(ConfigInterface $config)
     {
@@ -133,7 +133,7 @@ abstract class AbstractCommand extends Command
     /**
      * Gets the config.
      *
-     * @return ConfigInterface
+     * @return \Phinx\Config\ConfigInterface
      */
     public function getConfig()
     {
@@ -143,8 +143,8 @@ abstract class AbstractCommand extends Command
     /**
      * Sets the database adapter.
      *
-     * @param AdapterInterface $adapter
-     * @return AbstractCommand
+     * @param \Phinx\Db\Adapter\AdapterInterface $adapter
+     * @return \Phinx\Console\Command\AbstractCommand
      */
     public function setAdapter(AdapterInterface $adapter)
     {
@@ -156,7 +156,7 @@ abstract class AbstractCommand extends Command
     /**
      * Gets the database adapter.
      *
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter()
     {
@@ -166,8 +166,8 @@ abstract class AbstractCommand extends Command
     /**
      * Sets the migration manager.
      *
-     * @param Manager $manager
-     * @return AbstractCommand
+     * @param \Phinx\Migration\Manager $manager
+     * @return \Phinx\Console\Command\AbstractCommand
      */
     public function setManager(Manager $manager)
     {
@@ -179,7 +179,7 @@ abstract class AbstractCommand extends Command
     /**
      * Gets the migration manager.
      *
-     * @return Manager
+     * @return \Phinx\Migration\Manager
      */
     public function getManager()
     {
@@ -189,7 +189,7 @@ abstract class AbstractCommand extends Command
     /**
      * Returns config file path
      *
-     * @param InputInterface $input
+     * @param \Symfony\Component\Console\Input\InputInterface $input
      * @return string
      */
     protected function locateConfigFile(InputInterface $input)
@@ -229,8 +229,8 @@ abstract class AbstractCommand extends Command
     /**
      * Parse the config file and load it into the config object
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \InvalidArgumentException
      * @return void
      */
@@ -280,8 +280,8 @@ abstract class AbstractCommand extends Command
     /**
      * Load the migrations manager and inject the config
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      */
     protected function loadManager(InputInterface $input, OutputInterface $output)
     {

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -64,8 +64,8 @@ EOT
     /**
      * Toggle the breakpoint.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -76,7 +76,7 @@ class Create extends AbstractCommand
      * Get the confirmation question asking if the user wants to create the
      * migrations directory.
      *
-     * @return ConfirmationQuestion
+     * @return \Symfony\Component\Console\Question\ConfirmationQuestion
      */
     protected function getCreateMigrationDirectoryQuestion()
     {
@@ -87,7 +87,7 @@ class Create extends AbstractCommand
      * Get the question that allows the user to select which migration path to use.
      *
      * @param string[] $paths
-     * @return ChoiceQuestion
+     * @return \Symfony\Component\Console\Question\ChoiceQuestion
      */
     protected function getSelectMigrationPathQuestion(array $paths)
     {
@@ -97,8 +97,8 @@ class Create extends AbstractCommand
     /**
      * Returns the migration path to create the migration in.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return mixed
      * @throws \Exception
      */
@@ -143,8 +143,8 @@ class Create extends AbstractCommand
     /**
      * Create the new migration.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      * @return void

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -53,8 +53,8 @@ class Init extends Command
     /**
      * Initializes the application.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      * @return void

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -64,8 +64,8 @@ EOT
     /**
      * Migrate the database.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return integer integer 0 on success, or an error code.
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -74,8 +74,8 @@ EOT
     /**
      * Rollback the migration.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -61,7 +61,7 @@ class SeedCreate extends AbstractCommand
      * Get the confirmation question asking if the user wants to create the
      * seeds directory.
      *
-     * @return ConfirmationQuestion
+     * @return \Symfony\Component\Console\Question\ConfirmationQuestion
      */
     protected function getCreateSeedDirectoryQuestion()
     {
@@ -72,7 +72,7 @@ class SeedCreate extends AbstractCommand
      * Get the question that allows the user to select which seed path to use.
      *
      * @param string[] $paths
-     * @return ChoiceQuestion
+     * @return \Symfony\Component\Console\Question\ChoiceQuestion
      */
     protected function getSelectSeedPathQuestion(array $paths)
     {
@@ -82,8 +82,8 @@ class SeedCreate extends AbstractCommand
     /**
      * Returns the seed path to create the seeder in.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return mixed
      * @throws \Exception
      */
@@ -128,8 +128,8 @@ class SeedCreate extends AbstractCommand
     /**
      * Create the new seeder.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      * @return void

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -62,8 +62,8 @@ EOT
     /**
      * Run database seeders.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -61,8 +61,8 @@ EOT
     /**
      * Show the migration status.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return integer 0 if all migrations are up, or an error code
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -64,8 +64,8 @@ EOT
     /**
      * Verify configuration file
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      * @return void

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -67,8 +67,8 @@ class PhinxApplication extends Application
     /**
      * Runs the current application.
      *
-     * @param InputInterface $input An Input instance
-     * @param OutputInterface $output An Output instance
+     * @param \Symfony\Component\Console\Input\InputInterface $input An Input instance
+     * @param \Symfony\Component\Console\Output\OutputInterface $output An Output instance
      * @return integer 0 if everything went fine, or an error code
      */
     public function doRun(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -45,12 +45,12 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $options = [];
 
     /**
-     * @var InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface
      */
     protected $input;
 
     /**
-     * @var OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
 
@@ -63,8 +63,8 @@ abstract class AbstractAdapter implements AdapterInterface
      * Class Constructor.
      *
      * @param array $options Options
-     * @param InputInterface $input Input Interface
-     * @param OutputInterface  $output Output Interface
+     * @param \Symfony\Component\Console\Input\InputInterface $input Input Interface
+     * @param \Symfony\Component\Console\Output\OutputInterface  $output Output Interface
      */
     public function __construct(array $options, InputInterface $input = null, OutputInterface $output = null)
     {

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -40,14 +40,14 @@ use Phinx\Db\Adapter\AdapterInterface;
 class AdapterFactory
 {
     /**
-     * @var AdapterFactory
+     * @var \Phinx\Db\Adapter\AdapterFactory
      */
     protected static $instance;
 
     /**
      * Get the factory singleton instance.
      *
-     * @return AdapterFactory
+     * @return \Phinx\Db\Adapter\AdapterFactory
      */
     public static function instance()
     {
@@ -126,7 +126,7 @@ class AdapterFactory
      *
      * @param  string $name
      * @param  array  $options
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter($name, array $options)
     {
@@ -179,8 +179,8 @@ class AdapterFactory
      * Get a wrapper instance by name.
      *
      * @param  string $name
-     * @param  AdapterInterface $adapter
-     * @return AdapterInterface
+     * @param  \Phinx\Db\Adapter\AdapterInterface $adapter
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getWrapper($name, AdapterInterface $adapter)
     {

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -98,7 +98,7 @@ interface AdapterInterface
      * Set adapter configuration options.
      *
      * @param  array $options
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setOptions(array $options);
 
@@ -128,50 +128,50 @@ interface AdapterInterface
     /**
      * Sets the console input.
      *
-     * @param InputInterface $input Input
-     * @return AdapterInterface
+     * @param \Symfony\Component\Console\Input\InputInterface $input Input
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setInput(InputInterface $input);
 
     /**
      * Gets the console input.
      *
-     * @return InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface
      */
     public function getInput();
 
     /**
      * Sets the console output.
      *
-     * @param OutputInterface $output Output
-     * @return AdapterInterface
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setOutput(OutputInterface $output);
 
     /**
      * Gets the console output.
      *
-     * @return OutputInterface
+     * @return \Symfony\Component\Console\Output\OutputInterface
      */
     public function getOutput();
 
     /**
      * Records a migration being run.
      *
-     * @param MigrationInterface $migration Migration
+     * @param \Phinx\Migration\MigrationInterface $migration Migration
      * @param string $direction Direction
      * @param int $startTime Start Time
      * @param int $endTime End Time
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime);
 
     /**
      * Toggle a migration breakpoint.
      *
-     * @param MigrationInterface $migration
+     * @param \Phinx\Migration\MigrationInterface $migration
      *
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function toggleBreakpoint(MigrationInterface $migration);
 
@@ -282,7 +282,7 @@ interface AdapterInterface
     /**
      * Inserts data into a table.
      *
-     * @param Table $table where to insert data
+     * @param \Phinx\Db\Table $table where to insert data
      * @param array $row
      * @return void
      */
@@ -291,7 +291,7 @@ interface AdapterInterface
     /**
      * Inserts data into a table in a bulk.
      *
-     * @param Table $table where to insert data
+     * @param \Phinx\Db\Table $table where to insert data
      * @param array $rows
      * @return void
      */
@@ -324,7 +324,7 @@ interface AdapterInterface
     /**
      * Creates the specified database table.
      *
-     * @param Table $table Table
+     * @param \Phinx\Db\Table $table Table
      * @return void
      */
     public function createTable(Table $table);
@@ -358,7 +358,7 @@ interface AdapterInterface
      * Returns table columns
      *
      * @param string $tableName Table Name
-     * @return Column[]
+     * @return \Phinx\Db\Table\Column[]
      */
     public function getColumns($tableName);
 
@@ -374,8 +374,8 @@ interface AdapterInterface
     /**
      * Adds the specified column to a database table.
      *
-     * @param Table  $table  Table
-     * @param Column $column Column
+     * @param \Phinx\Db\Table  $table  Table
+     * @param \Phinx\Db\Table\Column $column Column
      * @return void
      */
     public function addColumn(Table $table, Column $column);
@@ -395,8 +395,8 @@ interface AdapterInterface
      *
      * @param string $tableName  Table Name
      * @param string $columnName Column Name
-     * @param Column $newColumn  New Column
-     * @return Table
+     * @param \Phinx\Db\Table\Column $newColumn  New Column
+     * @return \Phinx\Db\Table
      */
     public function changeColumn($tableName, $columnName, Column $newColumn);
 
@@ -430,8 +430,8 @@ interface AdapterInterface
     /**
      * Adds the specified index to a database table.
      *
-     * @param Table $table Table
-     * @param Index $index Index
+     * @param \Phinx\Db\Table $table Table
+     * @param \Phinx\Db\Table\Index $index Index
      * @return void
      */
     public function addIndex(Table $table, Index $index);
@@ -467,8 +467,8 @@ interface AdapterInterface
     /**
      * Adds the specified foreign key to a database table.
      *
-     * @param Table      $table
-     * @param ForeignKey $foreignKey
+     * @param \Phinx\Db\Table      $table
+     * @param \Phinx\Db\Table\ForeignKey $foreignKey
      * @return void
      */
     public function addForeignKey(Table $table, ForeignKey $foreignKey);
@@ -493,7 +493,7 @@ interface AdapterInterface
     /**
      * Checks that the given column is of a supported type.
      *
-     * @param  Column $column
+     * @param  \Phinx\Db\Table\Column $column
      * @return bool
      */
     public function isValidColumnType(Column $column);

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -47,7 +47,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
 {
     /**
-     * @var AdapterInterface
+     * @var \Phinx\Db\Adapter\AdapterInterface
      */
     protected $adapter;
 

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1007,7 +1007,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the MySQL Column Definition for a Column object.
      *
-     * @param Column $column Column
+     * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
     protected function getColumnSqlDefinition(Column $column)
@@ -1045,7 +1045,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the MySQL Index Definition for an Index object.
      *
-     * @param Index $index Index
+     * @param \Phinx\Db\Table\Index $index Index
      * @return string
      */
     protected function getIndexSqlDefinition(Index $index)
@@ -1078,7 +1078,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the MySQL Foreign Key Definition for an ForeignKey object.
      *
-     * @param ForeignKey $foreignKey
+     * @param \Phinx\Db\Table\ForeignKey $foreignKey
      * @return string
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey)

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -63,7 +63,7 @@ abstract class PdoAdapter extends AbstractAdapter
      * Sets the database connection.
      *
      * @param \PDO $connection Connection
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setConnection(\PDO $connection)
     {

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -904,7 +904,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the PostgreSQL Column Definition for a Column object.
      *
-     * @param Column $column Column
+     * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
     protected function getColumnSqlDefinition(Column $column)
@@ -956,7 +956,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the PostgreSQL Column Comment Defininition for a column object.
      *
-     * @param Column $column Column
+     * @param \Phinx\Db\Table\Column $column Column
      * @param string $tableName Table name
      * @return string
      */
@@ -978,7 +978,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the PostgreSQL Index Definition for an Index object.
      *
-     * @param Index  $index Index
+     * @param \Phinx\Db\Table\Index  $index Index
      * @param string $tableName Table name
      * @return string
      */
@@ -1007,7 +1007,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the MySQL Foreign Key Definition for an ForeignKey object.
      *
-     * @param ForeignKey $foreignKey
+     * @param \Phinx\Db\Table\ForeignKey $foreignKey
      * @param string     $tableName  Table name
      * @return string
      */

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -187,7 +187,7 @@ class ProxyAdapter extends AdapterWrapper
      * Sets an array of recorded commands.
      *
      * @param array $commands Commands
-     * @return ProxyAdapter
+     * @return \Phinx\Db\Adapter\ProxyAdapter
      */
     public function setCommands($commands)
     {
@@ -209,7 +209,7 @@ class ProxyAdapter extends AdapterWrapper
     /**
      * Gets an array of the recorded commands in reverse.
      *
-     * @throws IrreversibleMigrationException if a command cannot be reversed.
+     * @throws \Phinx\Migration\IrreversibleMigrationException if a command cannot be reversed.
      * @return array
      */
     public function getInvertedCommands()

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -990,7 +990,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the SQLite Column Definition for a Column object.
      *
-     * @param Column $column Column
+     * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
     protected function getColumnSqlDefinition(Column $column)
@@ -1027,7 +1027,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the comment Definition for a Column object.
      *
-     * @param Column $column Column
+     * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
     protected function getCommentDefinition(Column $column)
@@ -1042,8 +1042,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the SQLite Index Definition for an Index object.
      *
-     * @param Table $table Table
-     * @param Index $index Index
+     * @param \Phinx\Db\Table $table Table
+     * @param \Phinx\Db\Table\Index $index Index
      * @return string
      */
     protected function getIndexSqlDefinition(Table $table, Index $index)
@@ -1078,7 +1078,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the SQLite Foreign Key Definition for an ForeignKey object.
      *
-     * @param ForeignKey $foreignKey
+     * @param \Phinx\Db\Table\ForeignKey $foreignKey
      * @return string
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey)

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -290,7 +290,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
     /**
      * Gets the SqlServer Column Comment Defininition for a column object.
      *
-     * @param Column $column    Column
+     * @param \Phinx\Db\Table\Column $column    Column
      * @param string $tableName Table name
      *
      * @return string
@@ -1032,7 +1032,7 @@ SQL;
     /**
      * Gets the SqlServer Column Definition for a Column object.
      *
-     * @param Column $column Column
+     * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
     protected function getColumnSqlDefinition(Column $column, $create = true)
@@ -1078,7 +1078,7 @@ SQL;
     /**
      * Gets the SqlServer Index Definition for an Index object.
      *
-     * @param Index $index Index
+     * @param \Phinx\Db\Table\Index $index Index
      * @return string
      */
     protected function getIndexSqlDefinition(Index $index, $tableName)
@@ -1106,7 +1106,7 @@ SQL;
     /**
      * Gets the SqlServer Foreign Key Definition for an ForeignKey object.
      *
-     * @param ForeignKey $foreignKey
+     * @param \Phinx\Db\Table\ForeignKey $foreignKey
      * @return string
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, $tableName)
@@ -1142,7 +1142,7 @@ SQL;
      * @param string $direction Direction
      * @param int $startTime Start Time
      * @param int $endTime End Time
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function migrated(\Phinx\Migration\MigrationInterface $migration, $direction, $startTime, $endTime)
     {

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -918,7 +918,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * Returns Phinx type by SQL type
      *
-     * @param $sqlTypeDef
+     * @param string $sqlType SQL Type definition
      * @throws \RuntimeException
      * @internal param string $sqlType SQL type
      * @returns string Phinx type

--- a/src/Phinx/Db/Adapter/WrapperInterface.php
+++ b/src/Phinx/Db/Adapter/WrapperInterface.php
@@ -38,15 +38,15 @@ interface WrapperInterface
     /**
      * Class constructor, must always wrap another adapter.
      *
-     * @param  AdapterInterface $adapter
+     * @param  \Phinx\Db\Adapter\AdapterInterface $adapter
      */
     public function __construct(AdapterInterface $adapter);
 
     /**
      * Sets the database adapter to proxy commands to.
      *
-     * @param  AdapterInterface $adapter
-     * @return AdapterInterface
+     * @param  \Phinx\Db\Adapter\AdapterInterface $adapter
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setAdapter(AdapterInterface $adapter);
 
@@ -54,7 +54,7 @@ interface WrapperInterface
      * Gets the database adapter.
      *
      * @throws \RuntimeException if the adapter has not been set
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter();
 }

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -50,7 +50,7 @@ class Table
     protected $options = [];
 
     /**
-     * @var AdapterInterface
+     * @var \Phinx\Db\Adapter\AdapterInterface
      */
     protected $adapter;
 
@@ -65,7 +65,7 @@ class Table
     protected $indexes = [];
 
     /**
-     * @var ForeignKey[]
+     * @var \Phinx\Db\Table\ForeignKey[]
      */
     protected $foreignKeys = [];
 
@@ -79,7 +79,7 @@ class Table
      *
      * @param string $name Table Name
      * @param array $options Options
-     * @param AdapterInterface $adapter Database Adapter
+     * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
      */
     public function __construct($name, $options = [], AdapterInterface $adapter = null)
     {
@@ -95,7 +95,7 @@ class Table
      * Sets the table name.
      *
      * @param string $name Table Name
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function setName($name)
     {
@@ -118,7 +118,7 @@ class Table
      * Sets the table options.
      *
      * @param array $options
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function setOptions($options)
     {
@@ -140,8 +140,8 @@ class Table
     /**
      * Sets the database adapter.
      *
-     * @param AdapterInterface $adapter Database Adapter
-     * @return Table
+     * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
+     * @return \Phinx\Db\Table
      */
     public function setAdapter(AdapterInterface $adapter)
     {
@@ -153,7 +153,7 @@ class Table
     /**
      * Gets the database adapter.
      *
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter()
     {
@@ -184,7 +184,7 @@ class Table
      * Renames the database table.
      *
      * @param string $newTableName New Table Name
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function rename($newTableName)
     {
@@ -200,7 +200,7 @@ class Table
      *
      * @deprecated
      * @param array $columns Columns
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function setColumns($columns)
     {
@@ -212,7 +212,7 @@ class Table
     /**
      * Gets an array of the table columns.
      *
-     * @return Column[]
+     * @return \Phinx\Db\Table\Column[]
      */
     public function getColumns()
     {
@@ -223,7 +223,7 @@ class Table
      * Sets an array of columns waiting to be committed.
      *
      * @param array $columns Columns
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function setPendingColumns($columns)
     {
@@ -235,7 +235,7 @@ class Table
     /**
      * Gets an array of columns waiting to be committed.
      *
-     * @return Column[]
+     * @return \Phinx\Db\Table\Column[]
      */
     public function getPendingColumns()
     {
@@ -246,7 +246,7 @@ class Table
      * Sets an array of columns waiting to be indexed.
      *
      * @param array $indexes Indexes
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function setIndexes($indexes)
     {
@@ -268,8 +268,8 @@ class Table
     /**
      * Sets an array of foreign keys waiting to be commited.
      *
-     * @param ForeignKey[] $foreignKeys foreign keys
-     * @return Table
+     * @param \Phinx\Db\Table\ForeignKey[] $foreignKeys foreign keys
+     * @return \Phinx\Db\Table
      */
     public function setForeignKeys($foreignKeys)
     {
@@ -281,7 +281,7 @@ class Table
     /**
      * Gets an array of foreign keys waiting to be commited.
      *
-     * @return array|ForeignKey[]
+     * @return array|\Phinx\Db\Table\ForeignKey[]
      */
     public function getForeignKeys()
     {
@@ -292,7 +292,7 @@ class Table
      * Sets an array of data to be inserted.
      *
      * @param array $data Data
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function setData($data)
     {
@@ -332,12 +332,12 @@ class Table
      *
      * Valid options can be: limit, default, null, precision or scale.
      *
-     * @param string|Column $columnName Column Name
+     * @param string|\Phinx\Db\Table\Column $columnName Column Name
      * @param string $type Column Type
      * @param array $options Column Options
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function addColumn($columnName, $type = null, $options = [])
     {
@@ -374,7 +374,7 @@ class Table
      * Remove a table column.
      *
      * @param string $columnName Column Name
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function removeColumn($columnName)
     {
@@ -388,7 +388,7 @@ class Table
      *
      * @param string $oldName Old Column Name
      * @param string $newName New Column Name
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function renameColumn($oldName, $newName)
     {
@@ -401,9 +401,9 @@ class Table
      * Change a table column type.
      *
      * @param string        $columnName    Column Name
-     * @param string|Column $newColumnType New Column Type
+     * @param string|\Phinx\Db\Table\Column $newColumnType New Column Type
      * @param array         $options       Options
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function changeColumn($columnName, $newColumnType, $options = [])
     {
@@ -442,9 +442,9 @@ class Table
      *
      * In $options you can specific unique = true/false or name (index name).
      *
-     * @param string|array|Index $columns Table Column(s)
+     * @param string|array|\Phinx\Db\Table\Index $columns Table Column(s)
      * @param array $options Index Options
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function addIndex($columns, $options = [])
     {
@@ -469,7 +469,7 @@ class Table
      * Removes the given index from a table.
      *
      * @param array $columns Columns
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function removeIndex($columns)
     {
@@ -482,7 +482,7 @@ class Table
      * Removes the given index identified by its name from a table.
      *
      * @param string $name Index name
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function removeIndexByName($name)
     {
@@ -510,10 +510,10 @@ class Table
      * on_update, constraint = constraint name.
      *
      * @param string|array $columns Columns
-     * @param string|Table $referencedTable   Referenced Table
+     * @param string|\Phinx\Db\Table $referencedTable   Referenced Table
      * @param string|array $referencedColumns Referenced Columns
      * @param array $options Options
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function addForeignKey($columns, $referencedTable, $referencedColumns = ['id'], $options = [])
     {
@@ -539,7 +539,7 @@ class Table
      *
      * @param string|array $columns    Column(s)
      * @param null|string  $constraint Constraint names
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function dropForeignKey($columns, $constraint = null)
     {
@@ -573,7 +573,7 @@ class Table
      * @param string $createdAtColumnName
      * @param string $updatedAtColumnName
      *
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function addTimestamps($createdAtColumnName = 'created_at', $updatedAtColumnName = 'updated_at')
     {
@@ -601,7 +601,7 @@ class Table
      *              )
      *              or array("col1" => "value1", "col2" => "anotherValue1")
      *
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function insert($data)
     {

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -594,7 +594,7 @@ class Table
     /**
      * Insert data into the table.
      *
-     * @param $data array of data in the form:
+     * @param array $data array of data in the form:
      *              array(
      *                  array("col1" => "value1", "col2" => "anotherValue1"),
      *                  array("col2" => "value2", "col2" => "anotherValue2"),

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -125,7 +125,7 @@ class Column
      * Sets the column name.
      *
      * @param string $name
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setName($name)
     {
@@ -148,7 +148,7 @@ class Column
      * Sets the column type.
      *
      * @param string $type
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setType($type)
     {
@@ -171,7 +171,7 @@ class Column
      * Sets the column limit.
      *
      * @param int $limit
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setLimit($limit)
     {
@@ -194,7 +194,7 @@ class Column
      * Sets whether the column allows nulls.
      *
      * @param bool $null
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setNull($null)
     {
@@ -227,7 +227,7 @@ class Column
      * Sets the default column value.
      *
      * @param mixed $default
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setDefault($default)
     {
@@ -250,7 +250,7 @@ class Column
      * Sets whether or not the column is an identity column.
      *
      * @param bool $identity
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setIdentity($identity)
     {
@@ -283,7 +283,7 @@ class Column
      * Sets the name of the column to add this column after.
      *
      * @param string $after After
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setAfter($after)
     {
@@ -306,7 +306,7 @@ class Column
      * Sets the 'ON UPDATE' mysql column function.
      *
      * @param  string $update On Update function
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setUpdate($update)
     {
@@ -329,7 +329,7 @@ class Column
      * Sets the column precision for decimal.
      *
      * @param int $precision
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setPrecision($precision)
     {
@@ -352,7 +352,7 @@ class Column
      * Sets the column scale for decimal.
      *
      * @param int $scale
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setScale($scale)
     {
@@ -375,7 +375,7 @@ class Column
      * Sets the column comment.
      *
      * @param string $comment
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setComment($comment)
     {
@@ -398,7 +398,7 @@ class Column
      * Sets whether field should be signed.
      *
      * @param bool $signed
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setSigned($signed)
     {
@@ -432,7 +432,7 @@ class Column
      * Used for date/time columns only!
      *
      * @param bool $timezone
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setTimezone($timezone)
     {
@@ -466,7 +466,7 @@ class Column
      *
      * @param array $properties
      *
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setProperties($properties)
     {
@@ -490,7 +490,7 @@ class Column
      *
      * @param mixed (array|string) $values
      *
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setValues($values)
     {
@@ -622,7 +622,7 @@ class Column
      * Utility method that maps an array of column options to this objects methods.
      *
      * @param array $options Options
-     * @return Column
+     * @return \Phinx\Db\Table\Column
      */
     public function setOptions($options)
     {

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -44,7 +44,7 @@ class ForeignKey
     protected $columns = [];
 
     /**
-     * @var Table
+     * @var \Phinx\Db\Table
      */
     protected $referencedTable;
 
@@ -72,7 +72,7 @@ class ForeignKey
      * Sets the foreign key columns.
      *
      * @param array|string $columns
-     * @return ForeignKey
+     * @return \Phinx\Db\Table\ForeignKey
      */
     public function setColumns($columns)
     {
@@ -94,8 +94,8 @@ class ForeignKey
     /**
      * Sets the foreign key referenced table.
      *
-     * @param Table $table
-     * @return ForeignKey
+     * @param \Phinx\Db\Table $table
+     * @return \Phinx\Db\Table\ForeignKey
      */
     public function setReferencedTable(Table $table)
     {
@@ -107,7 +107,7 @@ class ForeignKey
     /**
      * Gets the foreign key referenced table.
      *
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function getReferencedTable()
     {
@@ -118,7 +118,7 @@ class ForeignKey
      * Sets the foreign key referenced columns.
      *
      * @param array $referencedColumns
-     * @return ForeignKey
+     * @return \Phinx\Db\Table\ForeignKey
      */
     public function setReferencedColumns(array $referencedColumns)
     {
@@ -141,7 +141,7 @@ class ForeignKey
      * Sets ON DELETE action for the foreign key.
      *
      * @param string $onDelete
-     * @return ForeignKey
+     * @return \Phinx\Db\Table\ForeignKey
      */
     public function setOnDelete($onDelete)
     {
@@ -174,7 +174,7 @@ class ForeignKey
      * Sets ON UPDATE action for the foreign key.
      *
      * @param string $onUpdate
-     * @return ForeignKey
+     * @return \Phinx\Db\Table\ForeignKey
      */
     public function setOnUpdate($onUpdate)
     {
@@ -187,7 +187,7 @@ class ForeignKey
      * Sets constraint for the foreign key.
      *
      * @param string $constraint
-     * @return ForeignKey
+     * @return \Phinx\Db\Table\ForeignKey
      */
     public function setConstraint($constraint)
     {
@@ -212,7 +212,7 @@ class ForeignKey
      * @param array $options Options
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     * @return ForeignKey
+     * @return \Phinx\Db\Table\ForeignKey
      */
     public function setOptions($options)
     {

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -69,7 +69,7 @@ class Index
      * Sets the index columns.
      *
      * @param array $columns
-     * @return Index
+     * @return \Phinx\Db\Table\Index
      */
     public function setColumns($columns)
     {
@@ -92,7 +92,7 @@ class Index
      * Sets the index type.
      *
      * @param string $type
-     * @return Index
+     * @return \Phinx\Db\Table\Index
      */
     public function setType($type)
     {
@@ -115,7 +115,7 @@ class Index
      * Sets the index name.
      *
      * @param string $name
-     * @return Index
+     * @return \Phinx\Db\Table\Index
      */
     public function setName($name)
     {
@@ -138,7 +138,7 @@ class Index
      * Sets the index limit.
      *
      * @param int $limit
-     * @return Index
+     * @return \Phinx\Db\Table\Index
      */
     public function setLimit($limit)
     {
@@ -162,7 +162,7 @@ class Index
      *
      * @param array $options Options
      * @throws \RuntimeException
-     * @return Index
+     * @return \Phinx\Db\Table\Index
      */
     public function setOptions($options)
     {

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -51,17 +51,17 @@ abstract class AbstractMigration implements MigrationInterface
     protected $version;
 
     /**
-     * @var AdapterInterface
+     * @var \Phinx\Db\Adapter\AdapterInterface
      */
     protected $adapter;
 
     /**
-     * @var OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
 
     /**
-     * @var InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface
      */
     protected $input;
 
@@ -76,8 +76,8 @@ abstract class AbstractMigration implements MigrationInterface
      * Class Constructor.
      *
      * @param int $version Migration Version
-     * @param InputInterface|null $input
-     * @param OutputInterface|null $output
+     * @param \Symfony\Component\Console\Input\InputInterface|null $input
+     * @param \Symfony\Component\Console\Output\OutputInterface|null $output
      */
     final public function __construct($version, InputInterface $input = null, OutputInterface $output = null)
     {

--- a/src/Phinx/Migration/AbstractTemplateCreation.php
+++ b/src/Phinx/Migration/AbstractTemplateCreation.php
@@ -34,20 +34,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class AbstractTemplateCreation implements CreationInterface
 {
     /**
-     * @var InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface
      */
     protected $input;
 
     /**
-     * @var OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
 
     /**
      * Class Constructor.
      *
-     * @param InputInterface|null  $input
-     * @param OutputInterface|null $output
+     * @param \Symfony\Component\Console\Input\InputInterface|null  $input
+     * @param \Symfony\Component\Console\Output\OutputInterface|null $output
      */
     public function __construct(InputInterface $input = null, OutputInterface $output = null)
     {

--- a/src/Phinx/Migration/CreationInterface.php
+++ b/src/Phinx/Migration/CreationInterface.php
@@ -41,32 +41,32 @@ interface CreationInterface
     /**
      * CreationInterface constructor.
      *
-     * @param InputInterface|null  $input
-     * @param OutputInterface|null $output
+     * @param \Symfony\Component\Console\Input\InputInterface|null  $input
+     * @param \Symfony\Component\Console\Output\OutputInterface|null $output
      */
     public function __construct(InputInterface $input = null, OutputInterface $output = null);
 
     /**
-     * @param InputInterface $input
+     * @param \Symfony\Component\Console\Input\InputInterface $input
      *
-     * @return CreationInterface
+     * @return \Phinx\Migration\CreationInterface
      */
     public function setInput(InputInterface $input);
 
     /**
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return CreationInterface
+     * @return \Phinx\Migration\CreationInterface
      */
     public function setOutput(OutputInterface $output);
 
     /**
-     * @return InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface
      */
     public function getInput();
 
     /**
-     * @return OutputInterface
+     * @return \Symfony\Component\Console\Output\OutputInterface
      */
     public function getOutput();
 

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -40,17 +40,17 @@ use Phinx\Util\Util;
 class Manager
 {
     /**
-     * @var ConfigInterface
+     * @var \Phinx\Config\ConfigInterface
      */
     protected $config;
 
     /**
-     * @var InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface
      */
     protected $input;
 
     /**
-     * @var OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
 
@@ -82,9 +82,9 @@ class Manager
     /**
      * Class Constructor.
      *
-     * @param ConfigInterface $config Configuration Object
-     * @param InputInterface $input Console Input
-     * @param OutputInterface $output Console Output
+     * @param \Phinx\Config\ConfigInterface $config Configuration Object
+     * @param \Symfony\Component\Console\Input\InputInterface $input Console Input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Console Output
      */
     public function __construct(ConfigInterface $config, InputInterface $input, OutputInterface $output)
     {
@@ -357,7 +357,7 @@ class Manager
      * Execute a migration against the specified environment.
      *
      * @param string $name Environment Name
-     * @param MigrationInterface $migration Migration
+     * @param \Phinx\Migration\MigrationInterface $migration Migration
      * @param string $direction Direction
      * @return void
      */
@@ -387,7 +387,7 @@ class Manager
      * Execute a seeder against the specified environment.
      *
      * @param string $name Environment Name
-     * @param SeedInterface $seed Seed
+     * @param \Phinx\Seed\SeedInterface $seed Seed
      * @return void
      */
     public function executeSeed($name, SeedInterface $seed)
@@ -554,7 +554,7 @@ class Manager
      * Sets the environments.
      *
      * @param array $environments Environments
-     * @return Manager
+     * @return \Phinx\Migration\Manager
      */
     public function setEnvironments($environments = [])
     {
@@ -568,7 +568,7 @@ class Manager
      *
      * @param string $name Environment Name
      * @throws \InvalidArgumentException
-     * @return Environment
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function getEnvironment($name)
     {
@@ -599,8 +599,8 @@ class Manager
     /**
      * Sets the console input.
      *
-     * @param InputInterface $input Input
-     * @return Manager
+     * @param \Symfony\Component\Console\Input\InputInterface $input Input
+     * @return \Phinx\Migration\Manager
      */
     public function setInput(InputInterface $input)
     {
@@ -612,7 +612,7 @@ class Manager
     /**
      * Gets the console input.
      *
-     * @return InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface
      */
     public function getInput()
     {
@@ -622,8 +622,8 @@ class Manager
     /**
      * Sets the console output.
      *
-     * @param OutputInterface $output Output
-     * @return Manager
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
+     * @return \Phinx\Migration\Manager
      */
     public function setOutput(OutputInterface $output)
     {
@@ -635,7 +635,7 @@ class Manager
     /**
      * Gets the console output.
      *
-     * @return OutputInterface
+     * @return \Symfony\Component\Console\Output\OutputInterface
      */
     public function getOutput()
     {
@@ -646,7 +646,7 @@ class Manager
      * Sets the database migrations.
      *
      * @param array $migrations Migrations
-     * @return Manager
+     * @return \Phinx\Migration\Manager
      */
     public function setMigrations(array $migrations)
     {
@@ -660,7 +660,7 @@ class Manager
      * order
      *
      * @throws \InvalidArgumentException
-     * @return AbstractMigration[]
+     * @return \Phinx\Migration\AbstractMigration[]
      */
     public function getMigrations()
     {
@@ -669,7 +669,7 @@ class Manager
 
             // filter the files to only get the ones that match our naming scheme
             $fileNames = [];
-            /** @var AbstractMigration[] $versions */
+            /** @var \Phinx\Migration\AbstractMigration[] $versions */
             $versions = [];
 
             foreach ($phpFiles as $filePath) {
@@ -754,7 +754,7 @@ class Manager
      * Sets the database seeders.
      *
      * @param array $seeds Seeders
-     * @return Manager
+     * @return \Phinx\Migration\Manager
      */
     public function setSeeds(array $seeds)
     {
@@ -767,7 +767,7 @@ class Manager
      * Gets an array of database seeders.
      *
      * @throws \InvalidArgumentException
-     * @return AbstractSeed[]
+     * @return \Phinx\Seed\AbstractSeed[]
      */
     public function getSeeds()
     {
@@ -776,7 +776,7 @@ class Manager
 
             // filter the files to only get the ones that match our naming scheme
             $fileNames = [];
-            /** @var AbstractSeed[] $seeds */
+            /** @var \Phinx\Seed\AbstractSeed[] $seeds */
             $seeds = [];
 
             foreach ($phpFiles as $filePath) {
@@ -845,8 +845,8 @@ class Manager
     /**
      * Sets the config.
      *
-     * @param  ConfigInterface $config Configuration Object
-     * @return Manager
+     * @param  \Phinx\Config\ConfigInterface $config Configuration Object
+     * @return \Phinx\Migration\Manager
      */
     public function setConfig(ConfigInterface $config)
     {
@@ -858,7 +858,7 @@ class Manager
     /**
      * Gets the config.
      *
-     * @return ConfigInterface
+     * @return \Phinx\Config\ConfigInterface
      */
     public function getConfig()
     {

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -48,12 +48,12 @@ class Environment
     protected $options;
 
     /**
-     * @var InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface
      */
     protected $input;
 
     /**
-     * @var OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
 
@@ -68,7 +68,7 @@ class Environment
     protected $schemaTableName = 'phinxlog';
 
     /**
-     * @var AdapterInterface
+     * @var \Phinx\Db\Adapter\AdapterInterface
      */
     protected $adapter;
 
@@ -77,7 +77,7 @@ class Environment
      *
      * @param string $name Environment Name
      * @param array $options Options
-     * @return Environment
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function __construct($name, $options)
     {
@@ -88,7 +88,7 @@ class Environment
     /**
      * Executes the specified migration on this environment.
      *
-     * @param MigrationInterface $migration Migration
+     * @param \Phinx\Migration\MigrationInterface $migration Migration
      * @param string $direction Direction
      * @return void
      */
@@ -139,7 +139,7 @@ class Environment
     /**
      * Executes the specified seeder on this environment.
      *
-     * @param SeedInterface $seed
+     * @param \Phinx\Seed\SeedInterface $seed
      * @return void
      */
     public function executeSeed(SeedInterface $seed)
@@ -166,7 +166,7 @@ class Environment
      * Sets the environment's name.
      *
      * @param string $name Environment Name
-     * @return Environment
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function setName($name)
     {
@@ -189,7 +189,7 @@ class Environment
      * Sets the environment's options.
      *
      * @param array $options Environment Options
-     * @return Environment
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function setOptions($options)
     {
@@ -211,8 +211,8 @@ class Environment
     /**
      * Sets the console input.
      *
-     * @param InputInterface $input
-     * @return Environment
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function setInput(InputInterface $input)
     {
@@ -224,7 +224,7 @@ class Environment
     /**
      * Gets the console input.
      *
-     * @return InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface
      */
     public function getInput()
     {
@@ -234,8 +234,8 @@ class Environment
     /**
      * Sets the console output.
      *
-     * @param OutputInterface $output Output
-     * @return Environment
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function setOutput(OutputInterface $output)
     {
@@ -247,7 +247,7 @@ class Environment
     /**
      * Gets the console output.
      *
-     * @return OutputInterface
+     * @return \Symfony\Component\Console\Output\OutputInterface
      */
     public function getOutput()
     {
@@ -279,7 +279,7 @@ class Environment
      * Sets the current version of the environment.
      *
      * @param int $version Environment Version
-     * @return Environment
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function setCurrentVersion($version)
     {
@@ -313,8 +313,8 @@ class Environment
     /**
      * Sets the database adapter.
      *
-     * @param AdapterInterface $adapter Database Adapter
-     * @return Environment
+     * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function setAdapter(AdapterInterface $adapter)
     {
@@ -326,7 +326,7 @@ class Environment
     /**
      * Gets the database adapter.
      *
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter()
     {
@@ -380,7 +380,7 @@ class Environment
      * Sets the schema table name.
      *
      * @param string $schemaTableName Schema Table Name
-     * @return Environment
+     * @return \Phinx\Migration\Manager\Environment
      */
     public function setSchemaTableName($schemaTableName)
     {

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -72,45 +72,45 @@ interface MigrationInterface
     /**
      * Sets the database adapter.
      *
-     * @param AdapterInterface $adapter Database Adapter
-     * @return MigrationInterface
+     * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
+     * @return \Phinx\Migration\MigrationInterface
      */
     public function setAdapter(AdapterInterface $adapter);
 
     /**
      * Gets the database adapter.
      *
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter();
 
     /**
      * Sets the input object to be used in migration object
      *
-     * @param InputInterface $input
-     * @return MigrationInterface
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return \Phinx\Migration\MigrationInterface
      */
     public function setInput(InputInterface $input);
 
     /**
      * Gets the input object to be used in migration object
      *
-     * @return InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface
      */
     public function getInput();
 
     /**
      * Sets the output object to be used in migration object
      *
-     * @param OutputInterface $output
-     * @return MigrationInterface
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return \Phinx\Migration\MigrationInterface
      */
     public function setOutput(OutputInterface $output);
 
     /**
      * Gets the output object to be used in migration object
      *
-     * @return OutputInterface
+     * @return \Symfony\Component\Console\Output\OutputInterface
      */
     public function getOutput();
 
@@ -125,7 +125,7 @@ interface MigrationInterface
      * Sets the migration version number.
      *
      * @param float $version Version
-     * @return MigrationInterface
+     * @return \Phinx\Migration\MigrationInterface
      */
     public function setVersion($version);
 
@@ -140,7 +140,7 @@ interface MigrationInterface
      * Sets whether this migration is being applied or reverted
      *
      * @param bool $isMigratingUp True if the migration is being applied
-     * @return MigrationInterface
+     * @return \Phinx\Migration\MigrationInterface
      */
     public function setMigratingUp($isMigratingUp);
 
@@ -225,7 +225,7 @@ interface MigrationInterface
      *
      * @param string $tableName Table Name
      * @param array $options Options
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function table($tableName, $options);
 }

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -46,25 +46,25 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class AbstractSeed implements SeedInterface
 {
     /**
-     * @var AdapterInterface
+     * @var \Phinx\Db\Adapter\AdapterInterface
      */
     protected $adapter;
 
     /**
-     * @var InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface
      */
     protected $input;
 
     /**
-     * @var OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
 
     /**
      * Class Constructor.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      */
     final public function __construct(InputInterface $input = null, OutputInterface $output = null)
     {

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -56,45 +56,45 @@ interface SeedInterface
     /**
      * Sets the database adapter.
      *
-     * @param AdapterInterface $adapter Database Adapter
-     * @return SeedInterface
+     * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
+     * @return \Phinx\Seed\SeedInterface
      */
     public function setAdapter(AdapterInterface $adapter);
 
     /**
      * Gets the database adapter.
      *
-     * @return AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter();
 
     /**
      * Sets the input object to be used in migration object
      *
-     * @param InputInterface $input
-     * @return SeedInterface
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return \Phinx\Seed\SeedInterface
      */
     public function setInput(InputInterface $input);
 
     /**
      * Gets the input object to be used in migration object
      *
-     * @return InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface
      */
     public function getInput();
 
     /**
      * Sets the output object to be used in migration object
      *
-     * @param OutputInterface $output
-     * @return SeedInterface
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return \Phinx\Seed\SeedInterface
      */
     public function setOutput(OutputInterface $output);
 
     /**
      * Gets the output object to be used in migration object
      *
-     * @return OutputInterface
+     * @return \Symfony\Component\Console\Output\OutputInterface
      */
     public function getOutput();
 
@@ -161,7 +161,7 @@ interface SeedInterface
      *
      * @param string $tableName Table Name
      * @param array $options Options
-     * @return Table
+     * @return \Phinx\Db\Table
      */
     public function table($tableName, $options);
 }

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -214,7 +214,7 @@ class Util
     /**
      * Expands a path with curly braces (if supported by the OS).
      *
-     * @param $path
+     * @param string $path
      * @return array
      */
     public static function glob($path)

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -40,7 +40,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 class TextWrapper
 {
     /**
-     * @var PhinxApplication
+     * @var \Phinx\Console\PhinxApplication
      */
     private $app;
 
@@ -55,7 +55,7 @@ class TextWrapper
     private $exit_code;
 
     /**
-     * @param PhinxApplication $app
+     * @param \Phinx\Console\PhinxApplication $app
      * @param array $options
      */
     public function __construct(PhinxApplication $app, array $options = [])
@@ -67,7 +67,7 @@ class TextWrapper
     /**
      * Get the application instance.
      *
-     * @return PhinxApplication
+     * @return \Phinx\Console\PhinxApplication
      */
     public function getApp()
     {


### PR DESCRIPTION
Always use FQCN in doc blocks.
Required if you want to use UnusedUse to remove non needed use statements.

Run:

    vendor/bin/phpcs --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml -v --ignore=/vendor/ ./src/ --sniffs=Spryker.Commenting.FullyQualifiedClassNameInDocBlock

Also fixed a few missing type annotations.