### PR TITLE
Add more files to gitattributes export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,11 @@
 /docs export-ignore
 /tests export-ignore
 /.* export-ignore
+/appveyor.yml export-ignore
+/box.json export-ignore
+/CONTRIBUTING.md export-ignore
+/docker-compose.yml export-ignore
+/Dockerfile export-ignore
+/phpcs.xml.dist export-ignore
+/phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
This might be a bit too strict for you, but it's what seems to be non-essential for package installation.

(Sorry for spamming PRs, let me know if you want me to stop 😛)