### PR TITLE
Revert back to original documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Phinx makes it ridiculously easy to manage the database migrations for your PHP app. In less than 5 minutes, you can install Phinx and create your first database migration. Phinx is just about migrations without all the bloat of a database ORM system or framework.
 
-**Check out https://book.cakephp.org/3.0/en/phinx.html ([EN](https://book.cakephp.org/3.0/en/phinx.html), [ZH](https://tsy12321.gitbooks.io/phinx-doc/)) for the comprehensive documentation.**
+**Check out http://docs.phinx.org/ ([EN](http://docs.phinx.org/), [ZH](https://tsy12321.gitbooks.io/phinx-doc/)) for the comprehensive documentation.**
 
 ![phinxterm](https://cloud.githubusercontent.com/assets/178939/3887559/e6b5e524-21f2-11e4-8256-0ba6040725fc.gif)
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can also use the Box application to build Phinx as a Phar archive (https://b
 
 ## Documentation
 
-Check out https://book.cakephp.org/3.0/en/phinx.html for the comprehensive documentation.
+Check out http://docs.phinx.org/ for the comprehensive documentation.
 
 Other translations include:
 


### PR DESCRIPTION
Revert back to Phinx documentation until the cake documentation is sorted out?

IMO, the Phinx documentation should be standalone and not be included alongside all of the CakePHP documentation. The Cake documentation also doesn't have a phinx-specific search, which makes it much more difficult to find what you're looking for. 

Is there a specific reason why we can't stick to the original Phinx site anyway?