### PR TITLE
Added support for symfony 4 components.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     }],
     "require": {
         "php": ">=5.4",
-        "symfony/console": "~2.8|~3.0",
-        "symfony/config": "~2.8|~3.0",
-        "symfony/yaml": "~2.8|~3.0"
+        "symfony/console": "~2.8|~3.0|~4.0",
+        "symfony/config": "~2.8|~3.0|~4.0",
+        "symfony/yaml": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.26|^5.0",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -82,7 +82,7 @@ You can also use the ``%%PHINX_CONFIG_DIR%%`` token in your path.
 .. code-block:: yaml
 
     paths:
-        migrations: %%PHINX_CONFIG_DIR%%/your/relative/path
+        migrations: '%%PHINX_CONFIG_DIR%%/your/relative/path'
 
 Migrations are captured with ``glob``, so you can define a pattern for multiple
 directories.
@@ -90,7 +90,7 @@ directories.
 .. code-block:: yaml
 
     paths:
-        migrations: %%PHINX_CONFIG_DIR%%/module/*/{data,scripts}/migrations
+        migrations: '%%PHINX_CONFIG_DIR%%/module/*/{data,scripts}/migrations'
 
 Custom Migration Base
 ---------------------
@@ -137,7 +137,7 @@ You can also use the ``%%PHINX_CONFIG_DIR%%`` token in your path.
 .. code-block:: yaml
 
     paths:
-        seeds: %%PHINX_CONFIG_DIR%%/your/relative/path
+        seeds: '%%PHINX_CONFIG_DIR%%/your/relative/path'
 
 Environments
 ------------
@@ -219,7 +219,7 @@ External Variables
 Phinx will automatically grab any environment variable prefixed with ``PHINX_``
 and make it available as a token in the config file. The token will have
 exactly the same name as the variable but you must access it by wrapping two
-``%%`` symbols on either side. e.g: ``%%PHINX_DBUSER%%``. This is especially
+``%%`` symbols on either side. e.g: ``'%%PHINX_DBUSER%%'``. This is especially
 useful if you wish to store your secret database credentials directly on the
 server and not in a version control system. This feature can be easily
 demonstrated by the following example:
@@ -231,10 +231,10 @@ demonstrated by the following example:
         default_database: development
         production:
             adapter: mysql
-            host: %%PHINX_DBHOST%%
-            name: %%PHINX_DBNAME%%
-            user: %%PHINX_DBUSER%%
-            pass: %%PHINX_DBPASS%%
+            host: '%%PHINX_DBHOST%%'
+            name: '%%PHINX_DBNAME%%'
+            user: '%%PHINX_DBUSER%%'
+            pass: '%%PHINX_DBPASS%%'
             port: 3306
             charset: utf8
 

--- a/phinx.yml
+++ b/phinx.yml
@@ -1,6 +1,6 @@
 paths:
-    migrations: %%PHINX_CONFIG_DIR%%/db/migrations
-    seeds: %%PHINX_CONFIG_DIR%%/db/seeds
+    migrations: '%%PHINX_CONFIG_DIR%%/db/migrations'
+    seeds: '%%PHINX_CONFIG_DIR%%/db/seeds'
 
 environments:
     default_migration_table: phinxlog

--- a/tests/Phinx/Config/_files/external_variables.yml
+++ b/tests/Phinx/Config/_files/external_variables.yml
@@ -1,13 +1,13 @@
 paths:
-    migrations: %%PHINX_CONFIG_DIR%%/migrations
-        
+    migrations: '%%PHINX_CONFIG_DIR%%/migrations'
+
 environments:
     default_migration_table: phinxlog
     default_database: production
     production:
         adapter: mysql
-        host: %%PHINX_DBHOST%%
-        name: %%PHINX_DBNAME%%
-        user: %%PHINX_DBUSER%%
-        pass: %%PHINX_DBPASS%%
-        port: %%PHINX_DBPORT%%
+        host: '%%PHINX_DBHOST%%'
+        name: '%%PHINX_DBNAME%%'
+        user: '%%PHINX_DBUSER%%'
+        pass: '%%PHINX_DBPASS%%'
+        port: '%%PHINX_DBPORT%%'

--- a/tests/Phinx/Config/_files/missing_environment_entry.yml
+++ b/tests/Phinx/Config/_files/missing_environment_entry.yml
@@ -1,5 +1,5 @@
 paths:
-    migrations: %%PHINX_CONFIG_DIR%%/db/migrations
+    migrations: '%%PHINX_CONFIG_DIR%%/db/migrations'
 
 environments:
     default_migration_table: phinxlog

--- a/tests/Phinx/Config/_files/no_default_database_key.yml
+++ b/tests/Phinx/Config/_files/no_default_database_key.yml
@@ -1,5 +1,5 @@
 paths:
-    migrations: %%PHINX_CONFIG_DIR%%/migrations
+    migrations: '%%PHINX_CONFIG_DIR%%/migrations'
         
 environments:
     default_migration_table: phinxlog
@@ -34,4 +34,3 @@ environments:
         user: root
         pass: ''
         port: 3306
-                 

--- a/tests/Phinx/Config/_files/seeds.yml
+++ b/tests/Phinx/Config/_files/seeds.yml
@@ -1,6 +1,6 @@
 paths:
-    migrations: %%PHINX_CONFIG_DIR%%/db/migrations
-    seeds: %%PHINX_CONFIG_DIR%%/db/seeds
+    migrations: '%%PHINX_CONFIG_DIR%%/db/migrations'
+    seeds: '%%PHINX_CONFIG_DIR%%/db/seeds'
 
 environments:
     default_migration_table: phinxlog


### PR DESCRIPTION
This required adding quotes around `%` in the yaml files. See http://symfony.com/blog/new-in-symfony-3-1-yaml-deprecations for more info on that.

In order to support v4, I tried to find all the places that had `%` unquoted and added them. I'm not sure if there should be another PR to have handled that or not, as I think users should be warned.

Fixes #1223 