### PR TITLE
Fix CS for test

### DIFF
--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -463,7 +463,6 @@ class SqlServerAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->dropIndex($table->getName(), 'email');
         $this->assertFalse($table->hasIndex('email'));
 
-        return;
         // multiple column index
         $table2 = new \Phinx\Db\Table('table2', [], $this->adapter);
         $table2->addColumn('fname', 'string')


### PR DESCRIPTION
It looks like that the test just works after removing the return.

The Appveyor job is also green: https://ci.appveyor.com/project/Iandenh/phinx/build/1.0.7