### PR TITLE
Adding column-type constants

### DIFF
--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -36,6 +36,40 @@ use Phinx\Db\Adapter\AdapterInterface;
  */
 class Column
 {
+    const BIG_INTEGER = 'BIGINTEGER';
+    const BINARY = 'BINARY';
+    const BOOLEAN = 'BOOLEAN';
+    const BOOL = 'BOOLEAN';
+    const CHAR = 'CHAR';
+    const DATE = 'DATE';
+    const DATETIME = 'DATETIME';
+    const DECIMAL = 'DECIMAL';
+    const FLOAT = 'FLOAT';
+    const INTEGER = 'INTEGER';
+    const STRING = 'STRING';
+    const TEXT = 'TEXT';
+    const TIME = 'TIME';
+    const TIMESTAMP = 'TIMESTAMP';
+    const UUID = 'UUID';
+    /** MySQL-only column type */
+    const ENUM = 'ENUM';
+    /** MySQL-only column type */
+    const SET = 'SET';
+    /** MySQL-only column type */
+    const BLOB = 'BLOB';
+    /** MySQL/Postgres-only column type */
+    const JSON = 'JSON';
+    /** Postgres-only column type */
+    const SMALLINT = 'SMALLINT';
+    /** Postgres-only column type */
+    const JSONB = 'JSONB';
+    /** Postgres-only column type */
+    const CIDR = 'CIDR';
+    /** Postgres-only column type */
+    const INET = 'INET';
+    /** Postgres-only column type */
+    const MACADDR = 'MACADDR';
+
     /**
      * @var string
      */

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20121213232502_create_initial_schema.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20121213232502_create_initial_schema.php
@@ -1,5 +1,6 @@
 <?php
 
+use Phinx\Db\Table\Column;
 use Phinx\Migration\AbstractMigration;
 
 class CreateInitialSchema extends AbstractMigration
@@ -11,26 +12,26 @@ class CreateInitialSchema extends AbstractMigration
     {
         // users table
         $users = $this->table('users');
-        $users->addColumn('username', 'string', ['limit' => 20])
-              ->addColumn('password', 'string', ['limit' => 40])
-              ->addColumn('password_salt', 'string', ['limit' => 40])
-              ->addColumn('email', 'string', ['limit' => 100])
-              ->addColumn('first_name', 'string', ['limit' => 30])
-              ->addColumn('last_name', 'string', ['limit' => 30])
-              ->addColumn('bio', 'string', ['limit' => 160, 'null' => true, 'default' => null])
-              ->addColumn('profile_image_url', 'string', ['limit' => 120, 'null' => true, 'default' => null])
-              ->addColumn('twitter', 'string', ['limit' => 30, 'null' => true, 'default' => null])
-              ->addColumn('role', 'string', ['limit' => 20])
-              ->addColumn('confirmed', 'boolean', ['null' => true, 'default' => null])
-              ->addColumn('confirmation_key', 'string', ['limit' => 40])
-              ->addColumn('created', 'datetime')
-              ->addColumn('updated', 'datetime', ['default' => null])
+        $users->addColumn('username', Column::STRING, ['limit' => 20])
+              ->addColumn('password', Column::STRING, ['limit' => 40])
+              ->addColumn('password_salt', Column::STRING, ['limit' => 40])
+              ->addColumn('email', Column::STRING, ['limit' => 100])
+              ->addColumn('first_name', Column::STRING, ['limit' => 30])
+              ->addColumn('last_name', Column::STRING, ['limit' => 30])
+              ->addColumn('bio', Column::STRING, ['limit' => 160, 'null' => true, 'default' => null])
+              ->addColumn('profile_image_url', Column::STRING, ['limit' => 120, 'null' => true, 'default' => null])
+              ->addColumn('twitter', Column::STRING, ['limit' => 30, 'null' => true, 'default' => null])
+              ->addColumn('role', Column::STRING, ['limit' => 20])
+              ->addColumn('confirmed', Column::BOOL, ['null' => true, 'default' => null])
+              ->addColumn('confirmation_key', Column::STRING, ['limit' => 40])
+              ->addColumn('created', Column::DATETIME)
+              ->addColumn('updated', Column::DATETIME, ['default' => null])
               ->addIndex(['username', 'email'], ['unique' => true])
               ->create();
 
         // info table
         $info = $this->table('info');
-        $info->addColumn('username', 'string', ['limit' => 20])
+        $info->addColumn('username', Column::STRING, ['limit' => 20])
              ->create();
     }
 

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20121223011815_update_info_table.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20121223011815_update_info_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Phinx\Db\Table\Column;
 use Phinx\Migration\AbstractMigration;
 
 class UpdateInfoTable extends AbstractMigration
@@ -11,7 +12,7 @@ class UpdateInfoTable extends AbstractMigration
     {
         // info table
         $info = $this->table('info');
-        $info->addColumn('password', 'string', ['limit' => 40])
+        $info->addColumn('password', Column::STRING, ['limit' => 40])
              ->update();
     }
 

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20121224200852_create_user_logins_table.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20121224200852_create_user_logins_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Phinx\Db\Table\Column;
 use Phinx\Migration\AbstractMigration;
 
 class CreateUserLoginsTable extends AbstractMigration
@@ -11,8 +12,8 @@ class CreateUserLoginsTable extends AbstractMigration
     {
         // user logins table
         $table = $this->table('user_logins');
-        $table->addColumn('user_id', 'integer')
-              ->addColumn('created', 'datetime')
+        $table->addColumn('user_id', Column::INTEGER)
+              ->addColumn('created', Column::DATETIME)
               ->create();
 
         // add a foreign key back to the users table

--- a/tests/Phinx/Migration/_files_baz/reversiblemigrations/20151213232502_create_initial_schema.php
+++ b/tests/Phinx/Migration/_files_baz/reversiblemigrations/20151213232502_create_initial_schema.php
@@ -2,6 +2,7 @@
 
 namespace Baz;
 
+use Phinx\Db\Table\Column;
 use Phinx\Migration\AbstractMigration;
 
 class CreateInitialSchema extends AbstractMigration
@@ -13,26 +14,26 @@ class CreateInitialSchema extends AbstractMigration
     {
         // users table
         $users = $this->table('users_baz');
-        $users->addColumn('username', 'string', ['limit' => 20])
-              ->addColumn('password', 'string', ['limit' => 40])
-              ->addColumn('password_salt', 'string', ['limit' => 40])
-              ->addColumn('email', 'string', ['limit' => 100])
-              ->addColumn('first_name', 'string', ['limit' => 30])
-              ->addColumn('last_name', 'string', ['limit' => 30])
-              ->addColumn('bio', 'string', ['limit' => 160, 'null' => true, 'default' => null])
-              ->addColumn('profile_image_url', 'string', ['limit' => 120, 'null' => true, 'default' => null])
-              ->addColumn('twitter', 'string', ['limit' => 30, 'null' => true, 'default' => null])
-              ->addColumn('role', 'string', ['limit' => 20])
-              ->addColumn('confirmed', 'boolean', ['null' => true, 'default' => null])
-              ->addColumn('confirmation_key', 'string', ['limit' => 40])
-              ->addColumn('created', 'datetime')
-              ->addColumn('updated', 'datetime', ['default' => null])
+        $users->addColumn('username', Column::STRING, ['limit' => 20])
+              ->addColumn('password', Column::STRING, ['limit' => 40])
+              ->addColumn('password_salt', Column::STRING, ['limit' => 40])
+              ->addColumn('email', Column::STRING, ['limit' => 100])
+              ->addColumn('first_name', Column::STRING, ['limit' => 30])
+              ->addColumn('last_name', Column::STRING, ['limit' => 30])
+              ->addColumn('bio', Column::STRING, ['limit' => 160, 'null' => true, 'default' => null])
+              ->addColumn('profile_image_url', Column::STRING, ['limit' => 120, 'null' => true, 'default' => null])
+              ->addColumn('twitter', Column::STRING, ['limit' => 30, 'null' => true, 'default' => null])
+              ->addColumn('role', Column::STRING, ['limit' => 20])
+              ->addColumn('confirmed', Column::BOOL, ['null' => true, 'default' => null])
+              ->addColumn('confirmation_key', Column::STRING, ['limit' => 40])
+              ->addColumn('created', Column::DATETIME)
+              ->addColumn('updated', Column::DATETIME, ['default' => null])
               ->addIndex(['username', 'email'], ['unique' => true])
               ->create();
 
         // info table
         $info = $this->table('info_baz');
-        $info->addColumn('username', 'string', ['limit' => 20])
+        $info->addColumn('username', Column::STRING, ['limit' => 20])
              ->create();
     }
 

--- a/tests/Phinx/Migration/_files_baz/reversiblemigrations/20151223011815_update_info_table.php
+++ b/tests/Phinx/Migration/_files_baz/reversiblemigrations/20151223011815_update_info_table.php
@@ -2,6 +2,7 @@
 
 namespace Baz;
 
+use Phinx\Db\Table\Column;
 use Phinx\Migration\AbstractMigration;
 
 class UpdateInfoTable extends AbstractMigration
@@ -13,7 +14,7 @@ class UpdateInfoTable extends AbstractMigration
     {
         // info table
         $info = $this->table('info_baz');
-        $info->addColumn('password', 'string', ['limit' => 40])
+        $info->addColumn('password', Column::STRING, ['limit' => 40])
              ->update();
     }
 

--- a/tests/Phinx/Migration/_files_baz/reversiblemigrations/20151224200852_create_user_logins_table.php
+++ b/tests/Phinx/Migration/_files_baz/reversiblemigrations/20151224200852_create_user_logins_table.php
@@ -2,6 +2,7 @@
 
 namespace Baz;
 
+use Phinx\Db\Table\Column;
 use Phinx\Migration\AbstractMigration;
 
 class CreateUserLoginsTable extends AbstractMigration
@@ -13,8 +14,8 @@ class CreateUserLoginsTable extends AbstractMigration
     {
         // user logins table
         $table = $this->table('user_logins_baz');
-        $table->addColumn('user_id', 'integer')
-              ->addColumn('created', 'datetime')
+        $table->addColumn('user_id', Column::INTEGER)
+              ->addColumn('created', Column::DATETIME)
               ->create();
 
         // add a foreign key back to the users table


### PR DESCRIPTION
Refer to #985 for initial discussion :)

- [x] type constants
- [x] column option constants
- [ ] table option constants
- [ ] update doc to refer to these constants
- [ ] verify doc mentions [ForeignKey](https://github.com/cakephp/phinx/blob/0.6.x-dev/src/Phinx/Db/Table/ForeignKey.php#L36-L39) constants as well
- [ ] remove duplication of "valid column types" sections (which is currently inconsistent and error prone)