### PR TITLE
Allow using uuid_*() functions as defaults in PostgreSQL

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -877,7 +877,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getDefaultValueDefinition($default)
     {
-        if (is_string($default) && 'CURRENT_TIMESTAMP' !== $default) {
+        if (is_string($default) && 'CURRENT_TIMESTAMP' !== $default && !preg_match('/^uuid_.*\(.*\)$/', $default)) {
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {
             $default = $this->castToBool($default);


### PR DESCRIPTION
Through the use of the [`uuid-ossp`](https://www.postgresql.org/docs/current/static/uuid-ossp.html) module PostgreSQL allows the using various functions within queries, which includes database column defintions' default values.

This PR adds an exception to `getDefaultValueDefinition` on `PostgresAdapter` which will allow using these functions by directly passing them as a string, e.g.:

```php
$this->table('mytable')
	->addColumn('token', 'uuid', ['default' => 'uuid_generate_v4()'])
	->save();
```

This would fail in the current version with the message

```
[PDOException]
SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type uuid: "uuid_generate_v4()"
```

If you think there's a different way to do this that could work better then let me know, this was just the first solution that came to my mind.