### PR TITLE
Prevent PDO executing from constructor without input

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -45,20 +45,6 @@ abstract class PdoAdapter extends AbstractAdapter
     protected $connection;
 
     /**
-     * {@inheritdoc}
-     */
-    public function setOptions(array $options)
-    {
-        parent::setOptions($options);
-
-        if (isset($options['connection'])) {
-            $this->setConnection($options['connection']);
-        }
-
-        return $this;
-    }
-
-    /**
      * Sets the database connection.
      *
      * @param \PDO $connection Connection
@@ -100,7 +86,11 @@ abstract class PdoAdapter extends AbstractAdapter
     public function getConnection()
     {
         if ($this->connection === null) {
-            $this->connect();
+            if (isset($options['connection'])) {
+                $this->setConnection($options['connection']);
+            } else {
+                $this->connect();
+            }
         }
 
         return $this->connection;


### PR DESCRIPTION
In addition to #1181.

By default `AdapterFactory` pass our `$options` to adapter's constructor:

```php
abstract class AbstractAdapter implements AdapterInterface
{
    public function __construct(array $options, InputInterface $input = null, OutputInterface $output = null)
    {
        $this->setOptions($options);
        ...
    }
}
```

but without `$input` and `$output`:

```php
class AdapterFactory
{
    public function getAdapter($name, array $options)
    {
        $class = $this->getClass($name);
        return new $class($options);
    }
}
```

And when we manually pass `connection` from configuration, the `PdoAdapter` immediately calls `setConnection` with creating of schema table:

```php
abstract class PdoAdapter extends AbstractAdapter
{
    public function setOptions(array $options)
    {
        parent::setOptions($options);
        if (isset($options['connection'])) {
            $this->setConnection($options['connection']);
        }
        return $this;
    }

    public function setConnection(\PDO $connection)
    {
        $this->connection = $connection;
        if (!$this->hasSchemaTable()) {
            $this->createSchemaTable();
        } ...
        return $this;
    }
}
```

with calling of `$this->execute($sql)`, but `$this->getInput()` is still empty (it was a reason of #1181 error).

As a solution I propose to move `$this->setConnection($options['connection'])` call to `getConnection()` for lazy loading (as in this PR) or make `$input` and `$output` as required arguments without setters and pass them via factory:

```php
class AdapterFactory
{
    public function getAdapter($name, array $options, InputInterface $input, OutputInterface $output)
    {
        $class = $this->getClass($name);
        return new $class($options, $input, $output);
    }
}
```