### PR TITLE
remove duplicate version string from list command

### DIFF
--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -75,7 +75,7 @@ class PhinxApplication extends Application
     {
         // always show the version information except when the user invokes the help
         // command as that already does it
-        if ($input->hasParameterOption(['--help', '-h']) === false && $input->getFirstArgument() !== null) {
+        if ($input->hasParameterOption(['--help', '-h']) === false && $input->getFirstArgument() !== null && $input->getFirstArgument() !== 'list') {
             $output->writeln($this->getLongVersion());
             $output->writeln('');
         }

--- a/tests/Phinx/Console/Command/ListTest.php
+++ b/tests/Phinx/Console/Command/ListTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Test\Phinx\Console\Command;
+
+use Phinx\Console\PhinxApplication;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+class ListTest extends \PHPUnit_Framework_TestCase
+{
+    public function testVersionInfo() {
+        $application = new PhinxApplication();
+        $application->setAutoExit(false); // Set autoExit to false when testing
+        $application->setCatchExceptions(false);
+
+        $appTester = new ApplicationTester($application);
+        $appTester->run(['command' => 'list', '--format' => 'txt']);
+        $stream = $appTester->getOutput()->getStream();
+        rewind($stream);
+
+        $this->assertEquals(1, substr_count(stream_get_contents($stream), 'Phinx by CakePHP - https://phinx.org'));
+    }
+
+}

--- a/tests/Phinx/Console/Command/ListTest.php
+++ b/tests/Phinx/Console/Command/ListTest.php
@@ -7,7 +7,8 @@ use Symfony\Component\Console\Tester\ApplicationTester;
 
 class ListTest extends \PHPUnit_Framework_TestCase
 {
-    public function testVersionInfo() {
+    public function testVersionInfo()
+    {
         $application = new PhinxApplication();
         $application->setAutoExit(false); // Set autoExit to false when testing
         $application->setCatchExceptions(false);
@@ -19,5 +20,4 @@ class ListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, substr_count(stream_get_contents($stream), 'Phinx by CakePHP - https://phinx.org'));
     }
-
 }


### PR DESCRIPTION
Fixes #525 
When running `bin/phinx list` aka `bin/phinx list --format=txt` it would output two version lines when using the text format.
> Phinx by CakePHP - https://phinx.org. version 0.8.1
> Phinx by CakePHP - https://phinx.org. version 0.8.1
> Usage:
>  command [options] [arguments]
>
> Options:
>  -h, --help            Display this help message
>  -q, --quiet           Do not output any message
>  -V, --version         Display this application version
>      --ansi            Force ANSI output
>      --no-ansi         Disable ANSI output
> ...

With this patch it only displays one version line.

The line duplicates because the list command is part of the Symfony Console component which is configured it display the version string for the list command. Phinx is configured to output the version string for all modules except "help", which results in one being output by Symfony and one by Phinx.

----

From `Symfony\Component\Console\Descriptor\TextDescription::describeApplication()`.
```
if ('' != $help = $application->getHelp()) {
    $this->writeText("$help\n\n", $options);
}
```

`$application->getHelp()` is an alias to `$application->getLongVersion()` so it prints the application name/version out.