### PR TITLE
Support PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/yaml": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.26|^5.0",
+        "phpunit/phpunit": "^4.8.35|^5.7|^6.5",
         "cakephp/cakephp-codesniffer": "^3.0"
     },
     "autoload": {

--- a/tests/Phinx/Config/AbstractConfigTest.php
+++ b/tests/Phinx/Config/AbstractConfigTest.php
@@ -2,13 +2,15 @@
 
 namespace Test\Phinx\Config;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class AbstractConfigTest
  * @package Test\Phinx\Config
  * @group config
  * @coversNothing
  */
-abstract class AbstractConfigTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractConfigTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
+++ b/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
@@ -2,7 +2,7 @@
 
 namespace Test\Phinx\Config;
 
-use \Phinx\Config\Config;
+use Phinx\Config\Config;
 
 /**
  * Class ConfigDefaultEnvironmentTest

--- a/tests/Phinx/Config/ConfigFileTest.php
+++ b/tests/Phinx/Config/ConfigFileTest.php
@@ -3,12 +3,13 @@
 namespace Test\Phinx\Config;
 
 use Phinx\Console\Command\AbstractCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
-class ConfigFileTest extends \PHPUnit_Framework_TestCase
+class ConfigFileTest extends TestCase
 {
     private $previousDir;
 

--- a/tests/Phinx/Config/ConfigJsonTest.php
+++ b/tests/Phinx/Config/ConfigJsonTest.php
@@ -2,14 +2,15 @@
 
 namespace Test\Phinx\Config;
 
-use \Phinx\Config\Config;
+use Phinx\Config\Config;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigJsonTest
  * @package Test\Phinx\Config
  * @group config
  */
-class ConfigJsonTest extends \PHPUnit_Framework_TestCase
+class ConfigJsonTest extends TestCase
 {
     /**
      * @covers \Phinx\Config\Config::fromJson

--- a/tests/Phinx/Config/ConfigMigrationPathsTest.php
+++ b/tests/Phinx/Config/ConfigMigrationPathsTest.php
@@ -2,7 +2,7 @@
 
 namespace Test\Phinx\Config;
 
-use \Phinx\Config\Config;
+use Phinx\Config\Config;
 
 /**
  * Class ConfigMigrationPathsTest

--- a/tests/Phinx/Config/ConfigPhpTest.php
+++ b/tests/Phinx/Config/ConfigPhpTest.php
@@ -2,14 +2,15 @@
 
 namespace Test\Phinx\Config;
 
-use \Phinx\Config\Config;
+use Phinx\Config\Config;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigPhpTest
  * @package Test\Phinx\Config
  * @group config
  */
-class ConfigPhpTest extends \PHPUnit_Framework_TestCase
+class ConfigPhpTest extends TestCase
 {
     /**
      * @covers \Phinx\Config\Config::fromPhp

--- a/tests/Phinx/Config/ConfigSeedPathsTest.php
+++ b/tests/Phinx/Config/ConfigSeedPathsTest.php
@@ -2,7 +2,7 @@
 
 namespace Test\Phinx\Config;
 
-use \Phinx\Config\Config;
+use Phinx\Config\Config;
 
 /**
  * Class ConfigSeedPathsTest

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -2,7 +2,7 @@
 
 namespace Test\Phinx\Config;
 
-use \Phinx\Config\Config;
+use Phinx\Config\Config;
 
 /**
  * Class ConfigTest

--- a/tests/Phinx/Config/ConfigYamlTest.php
+++ b/tests/Phinx/Config/ConfigYamlTest.php
@@ -2,14 +2,15 @@
 
 namespace Test\Phinx\Config;
 
-use \Phinx\Config\Config;
+use Phinx\Config\Config;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigYamlTest
  * @package Test\Phinx\Config
  * @group config
  */
-class ConfigYamlTest extends \PHPUnit_Framework_TestCase
+class ConfigYamlTest extends TestCase
 {
     /**
      * @covers \Phinx\Config\Config::fromYaml

--- a/tests/Phinx/Config/NamespaceAwareTraitTest.php
+++ b/tests/Phinx/Config/NamespaceAwareTraitTest.php
@@ -2,7 +2,9 @@
 
 namespace Test\Phinx\Config;
 
-class NamespaceAwareTraitTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NamespaceAwareTraitTest extends TestCase
 {
     public function testGetMigrationNamespaceByPath()
     {

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -7,6 +7,7 @@ use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\Create;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,7 +19,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @package Test\Phinx\Console\Command
  * @group create
  */
-class CreateTest extends \PHPUnit_Framework_TestCase
+class CreateTest extends TestCase
 {
     /**
      * @var ConfigInterface|array
@@ -377,5 +378,22 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         // Does the migration match our expectation?
         $expectedMigration = "useClassName Phinx\\Migration\\AbstractMigration / className {$commandLine['name']} / version {$match['Version']} / baseClassName AbstractMigration";
         $this->assertStringEqualsFile($match['MigrationFilename'], $expectedMigration, 'Failed to create migration file from template generator correctly.');
+    }
+
+    public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            //PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            //PHPUnit 4
+            parent::setExpectedException($exceptionName, $exceptionMessage, $exceptionCode);
+        }
     }
 }

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -4,9 +4,10 @@ namespace Test\Phinx\Console\Command;
 
 use Phinx\Console\Command\Init;
 use Phinx\Console\PhinxApplication;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class InitTest extends \PHPUnit_Framework_TestCase
+class InitTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -7,6 +7,7 @@ use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\Migrate;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class MigrateTest extends \PHPUnit_Framework_TestCase
+class MigrateTest extends TestCase
 {
     /**
      * @var ConfigInterface|array

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -7,6 +7,7 @@ use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\Rollback;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class RollbackTest extends \PHPUnit_Framework_TestCase
+class RollbackTest extends TestCase
 {
     /**
      * @var ConfigInterface|array

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -7,6 +7,7 @@ use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\SeedCreate;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class SeedCreateTest extends \PHPUnit_Framework_TestCase
+class SeedCreateTest extends TestCase
 {
     /**
      * @var ConfigInterface|array

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -7,6 +7,7 @@ use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\SeedRun;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class SeedRunTest extends \PHPUnit_Framework_TestCase
+class SeedRunTest extends TestCase
 {
     /**
      * @var ConfigInterface|array

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -7,6 +7,7 @@ use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\Status;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class StatusTest extends \PHPUnit_Framework_TestCase
+class StatusTest extends TestCase
 {
     /**
      * @var ConfigInterface|array

--- a/tests/Phinx/Console/PhinxApplicationTest.php
+++ b/tests/Phinx/Console/PhinxApplicationTest.php
@@ -4,9 +4,10 @@ namespace Test\Phinx\Console;
 
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\PhinxApplication;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
-class PhinxApplicationTest extends \PHPUnit_Framework_TestCase
+class PhinxApplicationTest extends TestCase
 {
     /**
      * @dataProvider provider

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -3,8 +3,9 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\AdapterFactory;
+use PHPUnit\Framework\TestCase;
 
-class AdapterFactoryTest extends \PHPUnit_Framework_TestCase
+class AdapterFactoryTest extends TestCase
 {
     /**
      * @var \Phinx\Db\Adapter\AdapterFactory

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\MysqlAdapter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -11,7 +12,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\StreamOutput;
 
-class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
+class MysqlAdapterTest extends TestCase
 {
     /**
      * @var \Phinx\Db\Adapter\MysqlAdapter

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -5,6 +5,7 @@ namespace Test\Phinx\Db\Adapter;
 use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Index;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -54,7 +55,7 @@ class MysqlAdapterTester extends MysqlAdapter
     }
 }
 
-class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
+class MysqlAdapterUnitTest extends TestCase
 {
     /**
      * @var MysqlAdapterTester
@@ -808,6 +809,10 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         $this->adapter->renameColumn('table_name', 'column_old', 'column_new');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The specified column doesn't exist: column_old
+     */
     public function testRenameColumnNotExists()
     {
         $column1 = [
@@ -838,7 +843,6 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
         $this->assertQuerySql("DESCRIBE `table_name`", $this->result);
 
-        $this->setExpectedException('\InvalidArgumentException', 'The specified column doesn\'t exist: column_old');
         $this->adapter->renameColumn('table_name', 'column_old', 'column_new');
     }
 
@@ -1094,9 +1098,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The type: "fake" is not supported.
+     */
     public function testGetSqlTypeNotExists()
     {
-        $this->setExpectedException('\RuntimeException', 'The type: "fake" is not supported.');
         $this->adapter->getSqlType('fake');
     }
 
@@ -1276,15 +1283,21 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The type: "fake" is not supported.
+     */
     public function testPhinxTypeNotValidType()
     {
-        $this->setExpectedException('\RuntimeException', 'The type: "fake" is not supported.');
         $this->adapter->getPhinxType('fake');
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Column type ?int? is not supported
+     */
     public function testPhinxTypeNotValidTypeRegex()
     {
-        $this->setExpectedException('\RuntimeException', 'Column type ?int? is not supported');
         $this->adapter->getPhinxType('?int?');
     }
 

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\PdoAdapter;
+use PHPUnit\Framework\TestCase;
 
 class PdoAdapterTestPDOMock extends \PDO
 {
@@ -32,7 +33,7 @@ class PdoAdapterTestPDOMockWithExecChecks extends PdoAdapterTestPDOMock
     }
 }
 
-class PdoAdapterTest extends \PHPUnit_Framework_TestCase
+class PdoAdapterTest extends TestCase
 {
     private $adapter;
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -3,13 +3,14 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\PostgresAdapter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
-class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
+class PostgresAdapterTest extends TestCase
 {
     /**
      * Check if Postgres is enabled in the current PHP

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -8,8 +8,9 @@ use Phinx\Db\Table;
 use Phinx\Db\Table\ForeignKey;
 use Phinx\Db\Table\Index;
 use Phinx\Migration\IrreversibleMigrationException;
+use PHPUnit\Framework\TestCase;
 
-class ProxyAdapterTest extends \PHPUnit_Framework_TestCase
+class ProxyAdapterTest extends TestCase
 {
     /**
      * @var \Phinx\Db\Adapter\ProxyAdapter

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -3,13 +3,14 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\SQLiteAdapter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
-class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
+class SQLiteAdapterTest extends TestCase
 {
     /**
      * @var \Phinx\Db\Adapter\SQLiteAdapter
@@ -612,15 +613,21 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/\/\* Comments from "column1" \*\//', $sql);
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The type: "fake" is not supported.
+     */
     public function testPhinxTypeNotValidType()
     {
-        $this->setExpectedException('\RuntimeException', 'The type: "fake" is not supported.');
         $this->adapter->getPhinxType('fake');
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Column type ?int? is not supported
+     */
     public function testPhinxTypeNotValidTypeRegex()
     {
-        $this->setExpectedException('\RuntimeException', 'Column type ?int? is not supported');
         $this->adapter->getPhinxType('?int?');
     }
 

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -3,10 +3,11 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\SqlServerAdapter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
-class SqlServerAdapterTest extends \PHPUnit_Framework_TestCase
+class SqlServerAdapterTest extends TestCase
 {
     /**
      * @var \Phinx\Db\Adapter\SqlServerAdapter

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -6,8 +6,9 @@ use Phinx\Db\Adapter\TablePrefixAdapter;
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\ForeignKey;
+use PHPUnit\Framework\TestCase;
 
-class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
+class TablePrefixAdapterTest extends TestCase
 {
     /**
      * @var \Phinx\Db\Adapter\TablePrefixAdapter

--- a/tests/Phinx/Db/Table/ColumnTest.php
+++ b/tests/Phinx/Db/Table/ColumnTest.php
@@ -3,8 +3,9 @@
 namespace Test\Phinx\Db\Table;
 
 use Phinx\Db\Table\Column;
+use PHPUnit\Framework\TestCase;
 
-class ColumnTest extends \PHPUnit_Framework_TestCase
+class ColumnTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -3,8 +3,9 @@
 namespace Test\Phinx\Db\Table;
 
 use Phinx\Db\Table\ForeignKey;
+use PHPUnit\Framework\TestCase;
 
-class ForeignKeyTest extends \PHPUnit_Framework_TestCase
+class ForeignKeyTest extends TestCase
 {
 
     /**

--- a/tests/Phinx/Db/Table/IndexTest.php
+++ b/tests/Phinx/Db/Table/IndexTest.php
@@ -3,8 +3,9 @@
 namespace Test\Phinx\Db\Table;
 
 use Phinx\Db\Table\Index;
+use PHPUnit\Framework\TestCase;
 
-class IndexTest extends \PHPUnit_Framework_TestCase
+class IndexTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -7,8 +7,9 @@ use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Db\Adapter\PostgresAdapter;
 use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Db\Adapter\SqlServerAdapter;
+use PHPUnit\Framework\TestCase;
 
-class TableTest extends \PHPUnit_Framework_TestCase
+class TableTest extends TestCase
 {
     public function provideTimestampColumnNames()
     {

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -4,8 +4,9 @@ namespace Test\Phinx\Migration;
 
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
+use PHPUnit\Framework\TestCase;
 
-class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
+class AbstractMigrationTest extends TestCase
 {
     public function testUp()
     {

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -6,6 +6,7 @@ use Phinx\Db\Adapter\AdapterFactory;
 use Phinx\Db\Adapter\PdoAdapter;
 use Phinx\Migration\Manager\Environment;
 use Phinx\Migration\MigrationInterface;
+use PHPUnit\Framework\TestCase;
 
 class PDOMock extends \PDO
 {
@@ -26,7 +27,7 @@ class PDOMock extends \PDO
     }
 }
 
-class EnvironmentTest extends \PHPUnit_Framework_TestCase
+class EnvironmentTest extends TestCase
 {
     /**
      * @var \Phinx\Migration\Manager\Environment

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5,12 +5,13 @@ namespace Test\Phinx\Migration;
 use Phinx\Config\Config;
 use Phinx\Migration\Manager;
 use Phinx\Migration\Manager\Environment;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
-class ManagerTest extends \PHPUnit_Framework_TestCase
+class ManagerTest extends TestCase
 {
     /** @var Config */
     protected $config;
@@ -5695,6 +5696,23 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
         $this->assertContains('is not a valid version', $output);
+    }
+
+    public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            //PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            //PHPUnit 4
+            parent::setExpectedException($exceptionName, $exceptionMessage, $exceptionCode);
+        }
     }
 }
 

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -3,8 +3,9 @@
 namespace Test\Phinx\Util;
 
 use Phinx\Util\Util;
+use PHPUnit\Framework\TestCase;
 
-class UtilTest extends \PHPUnit_Framework_TestCase
+class UtilTest extends TestCase
 {
     private function getCorrectedPath($path)
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.