### PR TITLE
ensure unique file names are returned

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -747,7 +747,7 @@ class Manager
             );
         }
         // glob() can return the same file multiple times
-        // This will cause the migration to fail with a 
+        // This will cause the migration to fail with a
         // false assumption of duplicate migrations
         // http://php.net/manual/en/function.glob.php#110340
         $files = array_unique($files);
@@ -844,7 +844,7 @@ class Manager
             );
         }
         // glob() can return the same file multiple times
-        // This will cause the migration to fail with a 
+        // This will cause the migration to fail with a
         // false assumption of duplicate migrations
         // http://php.net/manual/en/function.glob.php#110340
         $files = array_unique($files);

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -746,6 +746,11 @@ class Manager
                 Util::glob($path . DIRECTORY_SEPARATOR . '*.php')
             );
         }
+        // glob() can return the same file multiple times
+        // This will cause the migration to fail with a 
+        // false assumption of duplicate migrations
+        // http://php.net/manual/en/function.glob.php#110340
+        $files = array_unique($files);
 
         return $files;
     }
@@ -838,6 +843,11 @@ class Manager
                 Util::glob($path . DIRECTORY_SEPARATOR . '*.php')
             );
         }
+        // glob() can return the same file multiple times
+        // This will cause the migration to fail with a 
+        // false assumption of duplicate migrations
+        // http://php.net/manual/en/function.glob.php#110340
+        $files = array_unique($files);
 
         return $files;
     }


### PR DESCRIPTION
// glob() can return the same file multiple times
        // This will cause the migration to fail with a 
        // false assumption of duplicate migrations
        // http://php.net/manual/en/function.glob.php#110340