### PR TITLE
Added support for "signed" option when using custom name for "id" column

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -224,6 +224,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $column = new Column();
             $column->setName($options['id'])
                    ->setType('integer')
+                   ->setSigned(isset($options['signed']) ? $options['signed'] : true)
                    ->setIdentity(true);
 
             array_unshift($columns, $column);

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -211,7 +211,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         // Add the default primary key
         $columns = $table->getPendingColumns();
 
-        if(!isset($options['id']) || $options['id'] !== false){
+        if (!isset($options['id']) || $options['id'] !== false) {
             $column = new Column();
             $columnName = isset($options['id']) && is_string($options['id']) ? $options['id'] : 'id';
             $column->setName($columnName)

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -207,6 +207,26 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
     }
 
+    public function testCreateTableUnsignedIdColumn()
+    {
+        $table = new \Phinx\Db\Table('ntable', ['signed' => false], $this->adapter);
+        $table->save();
+
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'id'));
+        $this->assertFalse($this->adapter->getColumns('ntable')[0]->getSigned());
+    }
+
+    public function testCreateTableCustomUnsignedIdColumn()
+    {
+        $table = new \Phinx\Db\Table('ntable', ['id' => 'custom_id', 'signed' => false], $this->adapter);
+        $table->save();
+
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'custom_id'));
+        $this->assertFalse($this->adapter->getColumns('ntable')[0]->getSigned());
+    }
+
     public function testCreateTableWithNoOptions()
     {
         $this->markTestIncomplete();


### PR DESCRIPTION
When creating custom id columns (e.g. `["id" => "custom_id"]`) the `signed` option got totally ignored. Example:

    // Note: it's important to set a custom name for the "id" column to reproduce this
    $this->table('foo', [ 'id' => 'custom_id', 'signed' => false ])->save();

This statement created a table called "foo" with an `id` column of type `int(11)` (signed!), which is obviously wrong. This commit fixes this behavior so the created column will be of type `int(11) unsigned`. Additionally I simplified the code a bit.

---

The method `MysqlAdapter::getPhinxType()` totally ignored the `signed` attribute, too. While writing unit tests for the fix mentioned above, I found out that it is not possible to check whetever a column's type is *really* signed or not, when reading the columns through `MysqlAdapter::getColumns()`. This is because

  a) `MysqlAdapter::getColumns()` doesn't set the signed attribute at all (e.g. with `setSigned()`)
  b) `MysqlAdapter::getPhinxType()` doesn't return the information whetever the column's type is signed or not.

That's why this call:

    $this->adapter->getColumns('ntable')[0];

returned:

    class Phinx\Db\Table\Column{
        // ..
        protected $signed => bool(true) // (!)
        // ..
    }

Even if the column actually was an `int(11) unsigned` in the database.

To fix this, this commit added the `signed` property to the return value of `getPhinxType()`, so `getColumns()` can now make use of it to provide accurate informations to the caller.