### PR TITLE
Add ordered seeds feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 script:
     - if [[ $DEFAULT = 1 ]]; then vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover; fi
     - if [[ $PHPSTAN = 1 ]]; then composer require --dev phpstan/phpstan:^0.8 && vendor/bin/phpstan analyse -c phpstan.neon -l 4 src; fi
-    - if [[ $PHPCS = 1 ]]; then composer require --dev squizlabs/php_codesniffer:^3.0 && vendor/bin/phpcs -p -s src; fi
+    - if [[ $PHPCS = 1 ]]; then composer require --dev squizlabs/php_codesniffer:~3.1.1 && vendor/bin/phpcs -p -s src; fi
 
 after_success:
   - if [[ $DEFAULT = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -95,6 +95,16 @@ abstract class AbstractSeed implements SeedInterface
     }
 
     /**
+     * Return seeds dependencies.
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return [];
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function setAdapter(AdapterInterface $adapter)

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5412,6 +5412,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Foo\Bar\UserSeeder', $output);
     }
 
+    public function testOrderSeeds()
+    {
+        $seeds = array_values($this->manager->getSeeds());
+        $this->assertInstanceOf('UserSeeder', $seeds[0]);
+        $this->assertInstanceOf('GSeeder', $seeds[1]);
+        $this->assertInstanceOf('PostSeeder', $seeds[2]);
+    }
+
     public function testGettingInputObject()
     {
         $migrations = $this->manager->getMigrations();

--- a/tests/Phinx/Migration/_files/seeds/PostSeeder.php
+++ b/tests/Phinx/Migration/_files/seeds/PostSeeder.php
@@ -21,4 +21,12 @@ class PostSeeder extends AbstractSeed
         $posts->insert($data)
               ->save();
     }
+
+    public function getDependencies()
+    {
+        return [
+            'UserSeeder',
+            'GSeeder',
+        ];
+    }
 }


### PR DESCRIPTION
This feature is for ordering seeds execution by seeds dependencies. You can define other seeds which are dependencies for your seed and change seeds execution order automatically.

This feature is useful when you extend phinx manager (for example in unit tests to use in memory database) and do not have possibility execute seeds command from terminal.

Also if you have a lot of seeds it is not convenient to order seeds writing one by one in terminal to run ordered seeds.

Just run `phinx seeds:run` and your seeds will be executed in ordered way.

Use this function to define dependencies:
```
public function getDependencies()
{
    return [
        'UserSeeder',
        'GSeeder',
    ];
}
```
