### PR TITLE
Fix overriding mysql default options by environment options

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -710,7 +710,7 @@ limit   set maximum length for strings, also hints column types in adapters (see
 length  alias for ``limit``
 default set default value or action
 null    allow ``NULL`` values (should not be used with primary keys!)
-after   specify the column that a new column should be placed after
+after   specify the column that a new column should be placed after *(only applies to MySQL)*
 comment set a text comment on the column
 ======= ===========
 

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -206,6 +206,10 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             'engine' => 'InnoDB',
             'collation' => 'utf8_general_ci'
         ];
+
+        // use the default options, overriden by the environment options, overriden by the table options (especialy for charset & collation)
+        $defaultOptions = array_merge($defaultOptions, $this->options);
+
         $options = array_merge($defaultOptions, $table->getOptions());
 
         // Add the default primary key

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -162,7 +162,8 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($tableComment, $comment['table_comment'], 'Dont set table comment correctly');
     }
 
-    public function testCreateTableWithCollation(){
+    public function testCreateTableWithCollation()
+    {
         $saveAdapter = $this->adapter;
 
         $options = [
@@ -180,8 +181,8 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
             ->save();
 
         $rows = $this->adapter->fetchAll(sprintf(
-           "SELECT table_collation FROM INFORMATION_SCHEMA.TABLES WHERE table_schema='%s' AND table_name='ntable'",
-           TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE
+            "SELECT table_collation FROM INFORMATION_SCHEMA.TABLES WHERE table_schema='%s' AND table_name='ntable'",
+            TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE
         ));
         $collation = $rows[0];
         $this->adapter->dropTable("ntable");

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Output\StreamOutput;
 
 class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
 {
@@ -161,6 +160,36 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $comment = $rows[0];
 
         $this->assertEquals($tableComment, $comment['table_comment'], 'Dont set table comment correctly');
+    }
+
+    public function testCreateTableWithCollation(){
+        $saveAdapter = $this->adapter;
+
+        $options = [
+            'host' => TESTS_PHINX_DB_ADAPTER_MYSQL_HOST,
+            'name' => TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE,
+            'user' => TESTS_PHINX_DB_ADAPTER_MYSQL_USERNAME,
+            'pass' => TESTS_PHINX_DB_ADAPTER_MYSQL_PASSWORD,
+            'port' => TESTS_PHINX_DB_ADAPTER_MYSQL_PORT,
+            'collation' => 'utf8mb4_general_ci'
+        ];
+        $this->adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
+
+        $table = new \Phinx\Db\Table('ntable', [], $this->adapter);
+        $table->addColumn('realname', 'string')
+            ->save();
+
+        $rows = $this->adapter->fetchAll(sprintf(
+           "SELECT table_collation FROM INFORMATION_SCHEMA.TABLES WHERE table_schema='%s' AND table_name='ntable'",
+           TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE
+        ));
+        $collation = $rows[0];
+        $this->adapter->dropTable("ntable");
+
+        $this->adapter->disconnect();
+        $this->adapter = $saveAdapter;
+
+        $this->assertEquals("utf8mb4_general_ci", $collation['table_collation']);
     }
 
     public function testCreateTableWithForeignKeys()


### PR DESCRIPTION
I encountered a bug when creating a table with table()->create() : the charset used in the CREATE TABLE sentence was the hardcoded value "utf8_general_ci" even if I defined a charset in my environment file.

In this PR, the default hardcoded options are overridden by the environment options and the environemnt options are override by the table options is specified in the migration (= one more level).

I have fixed it in the MysqlAdapter. I checked in the other adapters if the charset was used in the table creation and it is not use anywhere else.