### PR TITLE
Improvement for composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
     }],
     "require": {
         "php": ">=5.4",
+        "ext-ctype": "*",
+        "ext-mbstring": "*",
+        "ext-pdo": "*",
         "symfony/console": "~2.8|~3.0|~4.0",
         "symfony/config": "~2.8|~3.0|~4.0",
         "symfony/yaml": "~2.8|~3.0|~4.0"
@@ -32,6 +35,12 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8.26|^5.0",
         "cakephp/cakephp-codesniffer": "^3.0"
+    },
+    "suggest": {
+        "ext-pdo_mysql": "Needed to support MySQL adapter",
+        "ext-pdo_pgsql": "Needed to support PostgreSQL adapter",
+        "ext-pdo_sqlite": "Needed to support SQLite adapter",
+        "ext-pdo_sqlite": "Needed to support SQL Server/ SQL Azure adapter"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-pdo_mysql": "Needed to support MySQL adapter",
         "ext-pdo_pgsql": "Needed to support PostgreSQL adapter",
         "ext-pdo_sqlite": "Needed to support SQLite adapter",
-        "ext-pdo_sqlite": "Needed to support SQL Server/ SQL Azure adapter"
+        "ext-pdo_sqlsrv": "Needed to support SQL Server/ SQL Azure adapter"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Adding required PHP extensions to composer and suggesting PDO extensions for each optional adapter.

As explained on [composer's documentation here](https://getcomposer.org/doc/04-schema.md#package-links), we should require all dependencies on composer.json because not all systems have the common extensions installed by default:

> Note: It is important to list PHP extensions your project requires. Not all PHP installations are created equal: some may miss extensions you may consider as standard (such as ext-mysqli which is not installed by default in Fedora/CentOS minimal installation systems). Failure to list required PHP extensions may lead to a bad user experience: Composer will install your package without any errors but it will then fail at run-time. The composer show --platform command lists all PHP extensions available on your system. You may use it to help you compile the list of extensions you use and require. Alternatively you may use third party tools to analyze your project for the list of extensions used.