### PR TITLE
is_int check for precision & scale #1013

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -987,7 +987,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
 
         $def = '';
         $def .= strtoupper($sqlType['name']);
-        if ($column->getPrecision() && $column->getScale()) {
+        if (is_int($column->getPrecision()) && is_int($column->getScale())) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         } elseif (isset($sqlType['limit'])) {
             $def .= '(' . $sqlType['limit'] . ')';

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -901,7 +901,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $sqlType = $this->getSqlType($column->getType(), $column->getLimit());
             $buffer[] = strtoupper($sqlType['name']);
             // integers cant have limits in postgres
-            if (static::PHINX_TYPE_DECIMAL === $sqlType['name'] && ($column->getPrecision() || $column->getScale())) {
+            if (static::PHINX_TYPE_DECIMAL === $sqlType['name'] && (is_int($column->getPrecision()) || is_int($column->getScale())) {
                 $buffer[] = sprintf(
                     '(%s, %s)',
                     $column->getPrecision() ?: $sqlType['precision'],

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -971,7 +971,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $sqlType = $this->getSqlType($column->getType());
         $def = '';
         $def .= strtoupper($sqlType['name']);
-        if ($column->getPrecision() && $column->getScale()) {
+        if (is_int($column->getPrecision()) && is_int($column->getScale())) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         }
         $limitable = in_array(strtoupper($sqlType['name']), $this->definitionsWithLimits);

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1026,7 +1026,7 @@ SQL;
         if (!in_array($sqlType['name'], $noLimits) && ($column->getLimit() || isset($sqlType['limit']))) {
             $buffer[] = sprintf('(%s)', $column->getLimit() ?: $sqlType['limit']);
         }
-        if ($column->getPrecision() && $column->getScale()) {
+        if (is_int($column->getPrecision()) && is_int($column->getScale())) {
             $buffer[] = '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         }
 


### PR DESCRIPTION
I found is column type is decimal bug. #1013 
Decimal options precision & scale is not reflected.

So I decimal options conditional judgment modify.

This bug at run cakephp3 migrations code.

```
        $table->changeColumn('item_code', 'decimal', [
            'precision' => 20,
            'scale' => 0,
        ]);
```

