### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Phinx/Config/ConfigMigrationPathsTest.php
+++ b/tests/Phinx/Config/ConfigMigrationPathsTest.php
@@ -41,7 +41,7 @@ class ConfigMigrationPathsTest extends AbstractConfigTest
         $config = new Config($values);
         $paths = $config->getMigrationPaths();
 
-        $this->assertTrue(is_array($paths));
-        $this->assertTrue(count($paths) === 1);
+        $this->assertInternalType('array', $paths);
+        $this->assertCount(1, $paths);
     }
 }

--- a/tests/Phinx/Config/ConfigSeedPathsTest.php
+++ b/tests/Phinx/Config/ConfigSeedPathsTest.php
@@ -41,7 +41,7 @@ class ConfigSeedPathsTest extends AbstractConfigTest
         $config = new Config($values);
         $paths = $config->getSeedPaths();
 
-        $this->assertTrue(is_array($paths));
-        $this->assertTrue(count($paths) === 1);
+        $this->assertInternalType('array', $paths);
+        $this->assertCount(1, $paths);
     }
 }

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -21,7 +21,7 @@ class ConfigTest extends AbstractConfigTest
         // this option is set to its default value when not being passed in the constructor, so we can ignore it
         unset($config['version_order']);
         $this->assertAttributeEmpty('values', $config);
-        $this->assertAttributeEquals(null, 'configFilePath', $config);
+        $this->assertAttributeEmpty('configFilePath', $config);
         $this->assertNull($config->getConfigFilePath());
     }
 
@@ -33,7 +33,7 @@ class ConfigTest extends AbstractConfigTest
     {
         $config = new Config($this->getConfigArray());
         $this->assertAttributeNotEmpty('values', $config);
-        $this->assertAttributeEquals(null, 'configFilePath', $config);
+        $this->assertAttributeEmpty('configFilePath', $config);
         $this->assertNull($config->getConfigFilePath());
     }
 
@@ -43,7 +43,7 @@ class ConfigTest extends AbstractConfigTest
     public function testGetEnvironmentsMethod()
     {
         $config = new Config($this->getConfigArray());
-        $this->assertEquals(2, count($config->getEnvironments()));
+        $this->assertCount(2, $config->getEnvironments());
         $this->assertArrayHasKey('testing', $config->getEnvironments());
         $this->assertArrayHasKey('production', $config->getEnvironments());
     }
@@ -107,9 +107,9 @@ class ConfigTest extends AbstractConfigTest
         $config = new Config([]);
         $config['foo'] = 'bar';
         $this->assertEquals('bar', $config['foo']);
-        $this->assertTrue(isset($config['foo']));
+        $this->assertArrayHasKey('foo', $config);
         unset($config['foo']);
-        $this->assertFalse(isset($config['foo']));
+        $this->assertArrayNotHasKey('foo', $config);
     }
 
     /**

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -374,11 +374,8 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         // Was migration created?
         $this->assertFileExists($match['MigrationFilename'], 'Failed to create migration file from template generator');
 
-        // Get migration.
-        $actualMigration = file_get_contents($match['MigrationFilename']);
-
         // Does the migration match our expectation?
         $expectedMigration = "useClassName Phinx\\Migration\\AbstractMigration / className {$commandLine['name']} / version {$match['Version']} / baseClassName AbstractMigration";
-        $this->assertSame($expectedMigration, $actualMigration, 'Failed to create migration file from template generator correctly.');
+        $this->assertStringEqualsFile($match['MigrationFilename'], $expectedMigration, 'Failed to create migration file from template generator correctly.');
     }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -48,7 +48,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testConnection()
     {
-        $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
     }
 
     public function testConnectionWithoutPort()
@@ -56,7 +56,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $options = $this->adapter->getOptions();
         unset($options['port']);
         $this->adapter->setOptions($options);
-        $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
     }
 
     public function testConnectionWithInvalidCredentials()
@@ -670,7 +670,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
 
         $described = $this->adapter->describeTable('t');
 
-        $this->assertTrue(in_array($described['TABLE_TYPE'], ['VIEW', 'BASE TABLE']));
+        $this->assertContains($described['TABLE_TYPE'], ['VIEW', 'BASE TABLE']);
         $this->assertEquals($described['TABLE_NAME'], 't');
         $this->assertEquals($described['TABLE_SCHEMA'], TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE);
         $this->assertEquals($described['TABLE_ROWS'], 0);

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -495,8 +495,8 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
         $columns = $this->adapter->getColumns("table_name");
 
-        $this->assertTrue(is_array($columns));
-        $this->assertEquals(2, count($columns));
+        $this->assertInternalType('array', $columns);
+        $this->assertCount(2, $columns);
 
         $this->assertEquals('column1', $columns[0]->getName());
         $this->assertInstanceOf('Phinx\Db\Table\Column', $columns[0]);
@@ -1425,8 +1425,8 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         list($index1, $index2, $index3, $index4) = $this->prepareCaseIndexes();
         $indexes = $this->adapter->getIndexes("table_name");
 
-        $this->assertTrue(is_array($indexes));
-        $this->assertEquals(3, count($indexes));
+        $this->assertInternalType('array', $indexes);
+        $this->assertCount(3, $indexes);
         $this->assertEquals(['columns' => [$index1['Column_name']]], $indexes[$index1['Key_name']]);
         $this->assertEquals(['columns' => [$index2['Column_name']]], $indexes[$index2['Key_name']]);
         $this->assertEquals(['columns' => [$index3['Column_name'], $index4['Column_name']]], $indexes[$index3['Key_name']]);
@@ -1581,8 +1581,8 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         list($fk, $fk1, $fk2) = $this->prepareCaseForeignKeys();
         $foreignkeys = $this->adapter->getForeignKeys("table_name");
 
-        $this->assertTrue(is_array($foreignkeys));
-        $this->assertEquals(2, count($foreignkeys));
+        $this->assertInternalType('array', $foreignkeys);
+        $this->assertCount(2, $foreignkeys);
         $this->assertEquals('table_name', $foreignkeys['fk1']['table']);
         $this->assertEquals(['other_table_id'], $foreignkeys['fk1']['columns']);
         $this->assertEquals('other_table', $foreignkeys['fk1']['referenced_table']);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -69,7 +69,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testConnection()
     {
-        $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
     }
 
     public function testConnectionWithoutPort()
@@ -77,7 +77,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $options = $this->adapter->getOptions();
         unset($options['port']);
         $this->adapter->setOptions($options);
-        $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
     }
 
     public function testConnectionWithInvalidCredentials()
@@ -1012,10 +1012,10 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
               ->save();
 
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
-        $this->assertEquals(2, count($rows));
+        $this->assertCount(2, $rows);
         $table->truncate();
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
-        $this->assertEquals(0, count($rows));
+        $this->assertCount(0, $rows);
     }
 
     public function testDumpCreateTable()

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -42,7 +42,7 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testConnection()
     {
-        $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
     }
 
     public function testBeginTransaction()
@@ -782,7 +782,7 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         // load table info
         $columns = $this->adapter->getColumns("table1");
 
-        $this->assertEquals(count($columns), 5);
+        $this->assertCount(5, $columns);
 
         $aa = $columns[1];
         $bb = $columns[2];
@@ -824,10 +824,10 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
               ->save();
 
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
-        $this->assertEquals(2, count($rows));
+        $this->assertCount(2, $rows);
         $table->truncate();
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
-        $this->assertEquals(0, count($rows));
+        $this->assertCount(0, $rows);
     }
 
     public function testDumpCreateTable()

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -43,7 +43,7 @@ class SqlServerAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testConnection()
     {
-        $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
     }
 
     public function testConnectionWithoutPort()
@@ -51,7 +51,7 @@ class SqlServerAdapterTest extends \PHPUnit_Framework_TestCase
         $options = $this->adapter->getOptions();
         unset($options['port']);
         $this->adapter->setOptions($options);
-        $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
     }
 
     public function testConnectionWithInvalidCredentials()
@@ -756,9 +756,9 @@ class SqlServerAdapterTest extends \PHPUnit_Framework_TestCase
               ->save();
 
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
-        $this->assertEquals(2, count($rows));
+        $this->assertCount(2, $rows);
         $table->truncate();
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
-        $this->assertEquals(0, count($rows));
+        $this->assertCount(0, $rows);
     }
 }

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -34,7 +34,10 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         // test methods
         $this->assertNull($migrationStub->getAdapter());
         $migrationStub->setAdapter($adapterStub);
-        $this->assertTrue($migrationStub->getAdapter() instanceof AdapterInterface);
+        $this->assertInstanceOf(
+            'Phinx\Db\Adapter\AdapterInterface',
+            $migrationStub->getAdapter()
+        );
     }
 
     public function testSetOutputMethods()
@@ -86,7 +89,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testGetName()
     {
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
-        $this->assertFalse(!(strpos($migrationStub->getName(), 'AbstractMigration')));
+        $this->assertContains('AbstractMigration', $migrationStub->getName());
     }
 
     public function testVersionMethods()
@@ -245,7 +248,10 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $migrationStub->setAdapter($adapterStub);
 
-        $this->assertTrue($migrationStub->table('test_table') instanceof Table);
+        $this->assertInstanceOf(
+            'Phinx\Db\Table',
+            $migrationStub->table('test_table')
+        );
     }
 
     public function testDropTableMethod()

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -118,7 +118,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testInstantiation()
     {
-        $this->assertTrue($this->manager->getOutput() instanceof StreamOutput);
+        $this->assertInstanceOf(
+            'Symfony\Component\Console\Output\StreamOutput',
+            $this->manager->getOutput()
+        );
     }
 
     public function testPrintStatusMethod()
@@ -1169,7 +1172,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGettingAValidEnvironment()
     {
-        $this->assertTrue($this->manager->getEnvironment('production') instanceof Environment);
+        $this->assertInstanceOf(
+            'Phinx\Migration\Manager\Environment',
+            $this->manager->getEnvironment('production')
+        );
     }
 
     /**


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInternalType` and `assertNotInternalType` instead of `is_*` functions;
- `assertContains` instead of `in_array` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertAttributeEmpty`;
- `assertArrayHasKey` instead of `isset` function;
- `assertStringEqualsFile` when comparing a `string` and a file.