### PR TITLE
Enhancing init command

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -79,7 +79,21 @@ project directory.
 .. code-block:: bash
 
         $ cd yourapp
-        $ phinx init .
+        $ phinx init
+
+Optionally you can specify a custom location for Phing's config file:
+
+.. code-block:: bash
+
+        $ cd yourapp
+        $ phinx init ./custom/location/
+
+You can also specify a custom file name:
+
+.. code-block:: bash
+
+        $ cd yourapp
+        $ phinx init custom-config.yml
 
 Open this file in your text editor to setup your project configuration. Please
 see the :doc:`Configuration <configuration>` chapter for more information.

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -81,7 +81,7 @@ project directory.
         $ cd yourapp
         $ phinx init
 
-Optionally you can specify a custom location for Phing's config file:
+Optionally you can specify a custom location for Phinx's config file:
 
 .. code-block:: bash
 

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -57,8 +57,8 @@ class Init extends Command
     /**
      * Initializes the application.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
+     * @param InputInterface  $input  Interface implemented by all input classes.
+     * @param OutputInterface $output Interface implemented by all output classes.
      *
      * @throws RuntimeException
      * @throws InvalidArgumentException
@@ -75,7 +75,7 @@ class Init extends Command
     /**
      * Return valid $path for Phing's config file.
      *
-     * @param InputInterface $input
+     * @param InputInterface $input Interface implemented by all input classes.
      *
      * @return string
      */
@@ -112,7 +112,9 @@ class Init extends Command
     /**
      * Writes Phing's config in provided $path
      *
-     * @param string $path
+     * @param string $path Location for new config file
+     *
+     * @return void
      */
     protected function writeConfig($path)
     {

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -57,11 +57,11 @@ class Init extends Command
     /**
      * Initializes the application.
      *
-     * @param InputInterface  $input  Interface implemented by all input classes.
-     * @param OutputInterface $output Interface implemented by all output classes.
+     * @param \Symfony\Component\Console\Input\InputInterface   $input  Interface implemented by all input classes.
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Interface implemented by all output classes.
      *
-     * @throws RuntimeException
-     * @throws InvalidArgumentException
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -73,9 +73,9 @@ class Init extends Command
     }
 
     /**
-     * Return valid $path for Phing's config file.
+     * Return valid $path for Phinx's config file.
      *
-     * @param InputInterface $input Interface implemented by all input classes.
+     * @param \Symfony\Component\Console\Input\InputInterface $input Interface implemented by all input classes.
      *
      * @return string
      */
@@ -85,7 +85,7 @@ class Init extends Command
         $path = $input->getArgument('path');
 
         // Fallback
-        if (empty($path)) {
+        if (!$path) {
             $path = getcwd() . DIRECTORY_SEPARATOR . self::FILE_NAME;
         }
 
@@ -102,15 +102,15 @@ class Init extends Command
 
         // Path is valid, but file already exists
         if (is_file($path)) {
-            throw new InvalidArgumentException('Config file already exists.');
+            throw new InvalidArgumentException('Config file "$path" already exists.');
         }
 
         // Dir is invalid
-        throw new InvalidArgumentException('Invalid path for config file.');
+        throw new InvalidArgumentException('Invalid path "$path" for config file.');
     }
 
     /**
-     * Writes Phing's config in provided $path
+     * Writes Phinx's config in provided $path
      *
      * @param string $path Location for new config file
      *

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -112,12 +112,23 @@ class Init extends Command
     /**
      * Writes Phinx's config in provided $path
      *
-     * @param string $path Location for new config file
+     * @param string $path Config file's path.
      *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
      * @return void
      */
     protected function writeConfig($path)
     {
+        // Check if dir is writable
+        $dirname = dirname($path);
+        if (!is_writable($dirname)) {
+            throw new InvalidArgumentException(sprintf(
+                'The directory "%s" is not writable',
+                $dirname
+            ));
+        }
+
         // load the config template
         if (is_dir(__DIR__ . '/../../../data/Phinx')) {
             $contents = file_get_contents(__DIR__ . '/../../../data/Phinx/phinx.yml');

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -102,11 +102,17 @@ class Init extends Command
 
         // Path is valid, but file already exists
         if (is_file($path)) {
-            throw new InvalidArgumentException('Config file "$path" already exists.');
+            throw new InvalidArgumentException(sprintf(
+                'Config file "%s" already exists.',
+                $path
+            ));
         }
 
         // Dir is invalid
-        throw new InvalidArgumentException('Invalid path "$path" for config file.');
+        throw new InvalidArgumentException(sprintf(
+            'Invalid path "%s" for config file.',
+            $path
+        ));
     }
 
     /**

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -31,8 +31,8 @@ class InitTest extends \PHPUnit_Framework_TestCase
             'decorated' => false,
         ]);
 
-        $this->assertRegExp(
-            sprintf('|created %s|', $fullPath),
+        $this->assertContains(
+            "created $fullPath",
             $commandTester->getDisplay()
         );
 
@@ -59,7 +59,7 @@ class InitTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException              \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Config file already exists./
+     * @expectedExceptionMessageRegExp /Config file ".*" already exists./
      */
     public function testThrowsExceptionWhenConfigFilePresent()
     {
@@ -80,7 +80,7 @@ class InitTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException              \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Invalid path for config file./
+     * @expectedExceptionMessageRegExp /Invalid path ".*" for config file./
      */
     public function testThrowsExceptionWhenInvalidDir()
     {

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -20,13 +20,13 @@ class InitTest extends \PHPUnit_Framework_TestCase
     {
         $application = new PhinxApplication('testing');
         $application->add(new Init());
-        $command       = $application->find("init");
+        $command = $application->find("init");
         $commandTester = new CommandTester($command);
-        $fullPath      = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $configName;
+        $fullPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $configName;
 
         $commandTester->execute([
             'command' => $command->getName(),
-            'path'    => $fullPath,
+            'path' => $fullPath,
         ], [
             'decorated' => false,
         ]);
@@ -72,7 +72,7 @@ class InitTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute([
             'command' => $command->getName(),
-            'path'    => sys_get_temp_dir(),
+            'path' => sys_get_temp_dir(),
         ], [
             'decorated' => false,
         ]);
@@ -92,7 +92,7 @@ class InitTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute([
             'command' => $command->getName(),
-            'path'    => '/this/dir/does/not/exists',
+            'path' => '/this/dir/does/not/exists',
         ], [
             'decorated' => false,
         ]);


### PR DESCRIPTION
With this update Init command can specify custom config names.

All these commands are valid:
```bash
$ vendor/bin/phinx init
$ vendor/bin/phinx init .
$ vendor/bin/phinx init phinx.yml
$ vendor/bin/phinx init ~/Project/custom-config.yml
``` 