### PR TITLE
Include composer.json in Phar archive

### DIFF
--- a/box.json
+++ b/box.json
@@ -8,7 +8,8 @@
     "directories": ["src","app"],
     "files": [
         "LICENSE",
-        "phinx.yml"
+        "phinx.yml",
+        "composer.json"
     ],
     "finder": [
         {


### PR DESCRIPTION
The displayed version number is now being read from composer.json, so this file should be part of the Phar archive as well.