### PR TITLE
Move from PHP 5.4 to PHP 7.0 for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.4
+FROM php:7.0
 
 # system dependecies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
PHP 5.4 hit EOL over two years ago so it's probably not worth building Docker against it anymore. Moving to PHP 7.0 also has the added advantage of using PHPUnit 6.x development work.