### PR TITLE
Added missing comments to phpDocs 

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -57,6 +57,9 @@ Phinx automatically creates a skeleton migration file with a single method:
              *
              * Remember to call "create()" or "update()" and NOT "save()" when working
              * with the Table class.
+             *
+             * @throws \InvalidArgumentException
+             * @throws \RuntimeException
              */
             public function change()
             {

--- a/src/Phinx/Migration/Migration.template.php.dist
+++ b/src/Phinx/Migration/Migration.template.php.dist
@@ -25,6 +25,9 @@ class $className extends $baseClassName
      *
      * Remember to call "create()" or "update()" and NOT "save()" when working
      * with the Table class.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
      */
     public function change()
     {


### PR DESCRIPTION
Hello! I very often create my own migrations using the `vendor/bin/phinx create CreateTestTable` command and it creates the next class.
```php
<?php

use Phinx\Migration\AbstractMigration;

class CreateTestTable extends AbstractMigration
{
    /**
     * Change Method.
     *
     * Write your reversible migrations using this method.
     *
     * More information on writing migrations is available here:
     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
     *
     * The following commands can be used in this method and Phinx will
     * automatically reverse them when rolling back:
     *
     *    createTable
     *    renameTable
     *    addColumn
     *    renameColumn
     *    addIndex
     *    addForeignKey
     *
     * Remember to call "create()" or "update()" and NOT "save()" when working
     * with the Table class.
     */
    public function change()
    {

    }
}
```

This code is correct and simple, even contains a detailed PHPDocs.

I want to create a new table `test` and add an integer numeric field "num" to it.
```php
    public function change()
    {
        $this->table('test')
            ->addColumn('num', 'integer')
            ->create();
    }
```

This will also be a valid code, migration is correctly executed. But comments in the PHPDocs will be incorrect. It will be necessary to add the following text to the commentary.
```php
/**
     * @throws \InvalidArgumentException
     * @throws \RuntimeException
*/
```

And these actions must be repeated each time the `addColumn` method is used in the migration. If you do not do this, my code editor (PHPStorm) swears at the line with the call to the `addColumn` function.

![image](https://user-images.githubusercontent.com/6000708/34984144-453313ee-fac9-11e7-9a5b-d9d58d7f072f.png)

And most developers are faced with this problem when writing their migrations. I propose to simplify the writing of migrations and to indicate this text in advance in the comments. This does not make the migration code complex, but it helps when writing migrations.

I propose the simplest and most obvious solution to this problem.
