### PR TITLE
Bump year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT license)
 
-Copyright (c) 2012-2017 Rob Morgan
+Copyright (c) 2012-2018 Rob Morgan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Should we also add `Copyright (c) 2005-2018, Cake Software Foundation, Inc. (https://cakefoundation.org)` underneath?