### PR TITLE
Allow signed named primary_key

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -229,6 +229,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $column = new Column();
             $column->setName($options['id'])
                    ->setType('integer')
+                   ->setSigned(isset($options['signed']) ? $options['signed'] : true)
                    ->setIdentity(true);
 
             array_unshift($columns, $column);
@@ -338,6 +339,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                    ->setNull($columnInfo['Null'] !== 'NO')
                    ->setDefault($columnInfo['Default'])
                    ->setType($phinxType['name'])
+                   ->setSigned(strpos($columnInfo['Type'], 'unsigned') === false)
                    ->setLimit($phinxType['limit']);
 
             if ($columnInfo['Extra'] === 'auto_increment') {

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -341,10 +341,35 @@ class MysqlAdapterTest extends TestCase
     {
         $table = new \Phinx\Db\Table('ntable', ['signed' => false], $this->adapter);
         $table->addColumn('realname', 'string')
+            ->addColumn('email', 'integer')
+            ->save();
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'email'));
+        $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
+        $column_definitions = $this->adapter->getColumns('ntable');
+        foreach ($column_definitions as $column_definition) {
+            if ($column_definition->getName() === 'id') {
+                $this->assertFalse($column_definition->getSigned());
+            }
+        }
+    }
+
+    public function testCreateTableWithUnsignedNamedPK()
+    {
+        $table = new \Phinx\Db\Table('ntable', ['id' => 'named_id', 'signed' => false], $this->adapter);
+        $table->addColumn('realname', 'string')
               ->addColumn('email', 'integer')
               ->save();
         $this->assertTrue($this->adapter->hasTable('ntable'));
-        $this->assertTrue($this->adapter->hasColumn('ntable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'named_id'));
+        $column_definitions = $this->adapter->getColumns('ntable');
+        foreach ($column_definitions as $column_definition) {
+            if ($column_definition->getName() === 'named_id') {
+               $this->assertFalse($column_definition->getSigned());
+            }
+        }
         $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));
         $this->assertTrue($this->adapter->hasColumn('ntable', 'email'));
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -367,7 +367,7 @@ class MysqlAdapterTest extends TestCase
         $column_definitions = $this->adapter->getColumns('ntable');
         foreach ($column_definitions as $column_definition) {
             if ($column_definition->getName() === 'named_id') {
-               $this->assertFalse($column_definition->getSigned());
+                $this->assertFalse($column_definition->getSigned());
             }
         }
         $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));


### PR DESCRIPTION
When overriding the id field name, the signed option was not working.

In addition, the unit test for signed/unsigned wasn't actually checking
to make sure that option was working.

The fact that I have to loop over the columns and check by name isn't the best, but it seemed to be all I had without writing more code.