### PR TITLE
Fix SQLite & MySQL identity definition incompatibility

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -187,6 +187,20 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $sql .= $this->quoteTableName($table->getName()) . ' (';
         foreach ($columns as $column) {
             $sql .= $this->quoteColumnName($column->getName()) . ' ' . $this->getColumnSqlDefinition($column) . ', ';
+
+            if (isset($options['primary_key']) && $column->getIdentity()) {
+                //remove column from the primary key array as it is already defined as an autoincrement
+                //primary id
+                $identityColumnIndex = array_search($column->getName(), $options['primary_key']);
+                if ($identityColumnIndex !== false) {
+                    unset($options['primary_key'][$identityColumnIndex]);
+
+                    if (empty($options['primary_key'])) {
+                        //The last primary key has been removed
+                        unset($options['primary_key']);
+                    }
+                }
+            }
         }
 
         // set the primary key(s)

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -110,6 +110,20 @@ class SQLiteAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
     }
 
+    public function testCreateTableIdentityIdColumn()
+    {
+        $table = new \Phinx\Db\Table('ntable', ['id' => false, 'primary_key' => ['custom_id']], $this->adapter);
+        $table->addColumn('custom_id', 'integer', ['identity' => true])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'custom_id'));
+
+        /** @var \Phinx\Db\Table\Column $idColumn */
+        $idColumn = $this->adapter->getColumns('ntable')[0];
+        $this->assertEquals(true, $idColumn->getIdentity());
+    }
+
     public function testCreateTableWithNoOptions()
     {
         $this->markTestIncomplete();


### PR DESCRIPTION
Modify createTable to remove any identity columns from the primary_key
list to ensure that the SQLite adapter doesn't attempt to define the
primary key multiple times.

Fixes #1297