### PR TITLE
Pass Environment Variable Down To Migrations

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -196,16 +196,6 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * {@inheritdoc}
      */
-    public function setEnvironment($environment)
-    {
-        $this->environment = $environment;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function setVersion($version)
     {
         $this->version = $version;

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -46,6 +46,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class AbstractMigration implements MigrationInterface
 {
     /**
+     * @var string
+     */
+    protected $environment;
+    /**
      * @var float
      */
     protected $version;
@@ -75,16 +79,20 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * Class Constructor.
      *
+     * @param string $environment Environment Detected
      * @param int $version Migration Version
      * @param \Symfony\Component\Console\Input\InputInterface|null $input
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output
      */
-    final public function __construct($version, InputInterface $input = null, OutputInterface $output = null)
+    final public function __construct($environment, $version, InputInterface $input = null, OutputInterface $output = null)
     {
+        $this->environment = $environment;
         $this->version = $version;
+
         if (!is_null($input)) {
             $this->setInput($input);
         }
+
         if (!is_null($output)) {
             $this->setOutput($output);
         }
@@ -175,6 +183,22 @@ abstract class AbstractMigration implements MigrationInterface
     public function getName()
     {
         return get_class($this);
+    }
+
+    /**
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    /**
+     * @param string $environment
+     */
+    public function setEnvironment($environment)
+    {
+        $this->environment = $environment;
     }
 
     /**

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -186,7 +186,7 @@ abstract class AbstractMigration implements MigrationInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getEnvironment()
     {
@@ -194,11 +194,13 @@ abstract class AbstractMigration implements MigrationInterface
     }
 
     /**
-     * @param string $environment
+     * {@inheritdoc}
      */
     public function setEnvironment($environment)
     {
         $this->environment = $environment;
+
+        return $this;
     }
 
     /**

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -106,7 +106,7 @@ class Manager
         $migrations = [];
         $hasDownMigration = false;
         $hasMissingMigration = false;
-        $migrations = $this->getMigrations();
+        $migrations = $this->getMigrations($environment);
         if (count($migrations)) {
             // TODO - rewrite using Symfony Table Helper as we already have this library
             // included and it will fix formatting issues (e.g drawing the lines)
@@ -229,7 +229,7 @@ class Manager
                 case 'json':
                     $output->writeln(json_encode(
                         [
-                            'pending_count' => count($this->getMigrations()),
+                            'pending_count' => count($this->getMigrations($environment)),
                             'migrations' => $migrations
                         ]
                     ));
@@ -279,7 +279,7 @@ class Manager
      */
     public function migrateToDateTime($environment, \DateTime $dateTime)
     {
-        $versions = array_keys($this->getMigrations());
+        $versions = array_keys($this->getMigrations($environment));
         $dateString = $dateTime->format('YmdHis');
 
         $outstandingMigrations = array_filter($versions, function ($version) use ($dateString) {
@@ -302,7 +302,7 @@ class Manager
      */
     public function migrate($environment, $version = null)
     {
-        $migrations = $this->getMigrations();
+        $migrations = $this->getMigrations($environment);
         $env = $this->getEnvironment($environment);
         $versions = $env->getVersions();
         $current = $env->getCurrentVersion();
@@ -424,7 +424,7 @@ class Manager
     public function rollback($environment, $target = null, $force = false, $targetMustMatchVersion = true)
     {
         // note that the migrations are indexed by name (aka creation time) in ascending order
-        $migrations = $this->getMigrations();
+        $migrations = $this->getMigrations($environment);
 
         // note that the version log are also indexed by name with the proper ascending order according to the version order
         $executedVersions = $this->getEnvironment($environment)->getVersionLog();
@@ -659,10 +659,11 @@ class Manager
      * Gets an array of the database migrations, indexed by migration name (aka creation time) and sorted in ascending
      * order
      *
+     * @param string $environment
      * @throws \InvalidArgumentException
      * @return \Phinx\Migration\AbstractMigration[]
      */
-    public function getMigrations()
+    public function getMigrations($environment)
     {
         if ($this->migrations === null) {
             $phpFiles = $this->getMigrationFiles();
@@ -708,7 +709,7 @@ class Manager
                     }
 
                     // instantiate it
-                    $migration = new $class($version, $this->getInput(), $this->getOutput());
+                    $migration = new $class($environment, $version, $this->getInput(), $this->getOutput());
 
                     if (!($migration instanceof AbstractMigration)) {
                         throw new \InvalidArgumentException(sprintf(
@@ -933,8 +934,8 @@ class Manager
      */
     public function toggleBreakpoint($environment, $version)
     {
-        $migrations = $this->getMigrations();
-        $this->getMigrations();
+        $migrations = $this->getMigrations($environment);
+        $this->getMigrations($environment);
         $env = $this->getEnvironment($environment);
         $versions = $env->getVersionLog();
 

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -659,7 +659,7 @@ class Manager
      * Gets an array of the database migrations, indexed by migration name (aka creation time) and sorted in ascending
      * order
      *
-     * @param string $environment
+     * @param string $environment Environment
      * @throws \InvalidArgumentException
      * @return \Phinx\Migration\AbstractMigration[]
      */

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -128,14 +128,6 @@ interface MigrationInterface
     public function getEnvironment();
 
     /**
-     * Set the migration's environment parameter
-     *
-     * @param string $environment Environment
-     * @return \Phinx\Migration\MigrationInterface
-     */
-    public function setEnvironment($environment);
-
-    /**
      * Sets the migration version number.
      *
      * @param float $version Version

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -121,6 +121,20 @@ interface MigrationInterface
     public function getName();
 
     /**
+     * Gets the detected environment
+     *
+     * @return string
+     */
+    public function getEnvironment();
+
+    /**
+     * Sets environment
+     *
+     * @param string $environment
+     */
+    public function setEnvironment($environment);
+
+    /**
      * Sets the migration version number.
      *
      * @param float $version Version

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -128,9 +128,10 @@ interface MigrationInterface
     public function getEnvironment();
 
     /**
-     * Sets environment
+     * Set the migration's environment parameter
      *
-     * @param string $environment
+     * @param string $environment Environment
+     * @return \Phinx\Migration\MigrationInterface
      */
     public function setEnvironment($environment);
 

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -40,14 +40,11 @@ class AbstractMigrationTest extends TestCase
         );
     }
 
-    public function testGetSetEnvironment()
+    public function testGetEnvironment()
     {
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
         $this->assertEquals('mockenv', $migrationStub->getEnvironment());
-
-        $migrationStub->setEnvironment('mock_env');
-        $this->assertEquals('mock_env', $migrationStub->getEnvironment());
     }
 
     public function testSetOutputMethods()

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -2,7 +2,6 @@
 
 namespace Test\Phinx\Migration;
 
-use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
 use PHPUnit\Framework\TestCase;
 
@@ -11,21 +10,21 @@ class AbstractMigrationTest extends TestCase
     public function testUp()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
         $this->assertNull($migrationStub->up());
     }
 
     public function testDown()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
         $this->assertNull($migrationStub->down());
     }
 
     public function testAdapterMethods()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -41,10 +40,20 @@ class AbstractMigrationTest extends TestCase
         );
     }
 
+    public function testGetSetEnvironment()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+        $this->assertEquals('mockenv', $migrationStub->getEnvironment());
+
+        $migrationStub->setEnvironment('mock_env');
+        $this->assertEquals('mock_env', $migrationStub->getEnvironment());
+    }
+
     public function testSetOutputMethods()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub output
         $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
@@ -65,7 +74,7 @@ class AbstractMigrationTest extends TestCase
             ->getMock();
 
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0, $inputStub, null]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0, $inputStub, null]);
 
         // test methods
         $this->assertNotNull($migrationStub->getInput());
@@ -80,7 +89,7 @@ class AbstractMigrationTest extends TestCase
             ->getMock();
 
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0, null, $outputStub]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0, null, $outputStub]);
 
         // test methods
         $this->assertNotNull($migrationStub->getOutput());
@@ -89,13 +98,13 @@ class AbstractMigrationTest extends TestCase
 
     public function testGetName()
     {
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
         $this->assertContains('AbstractMigration', $migrationStub->getName());
     }
 
     public function testVersionMethods()
     {
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [20120103080000]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 20120103080000]);
         $this->assertEquals(20120103080000, $migrationStub->getVersion());
         $migrationStub->setVersion(20120915093312);
         $this->assertEquals(20120915093312, $migrationStub->getVersion());
@@ -104,7 +113,7 @@ class AbstractMigrationTest extends TestCase
     public function testExecute()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -121,7 +130,7 @@ class AbstractMigrationTest extends TestCase
     public function testQuery()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -138,7 +147,7 @@ class AbstractMigrationTest extends TestCase
     public function testFetchRow()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -155,7 +164,7 @@ class AbstractMigrationTest extends TestCase
     public function testFetchAll()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -172,7 +181,7 @@ class AbstractMigrationTest extends TestCase
     public function testInsert()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -190,7 +199,7 @@ class AbstractMigrationTest extends TestCase
     public function testCreateDatabase()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -207,7 +216,7 @@ class AbstractMigrationTest extends TestCase
     public function testDropDatabase()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -224,7 +233,7 @@ class AbstractMigrationTest extends TestCase
     public function testHasTable()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -241,7 +250,7 @@ class AbstractMigrationTest extends TestCase
     public function testTableMethod()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
@@ -258,7 +267,7 @@ class AbstractMigrationTest extends TestCase
     public function testDropTableMethod()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', [0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
 
         // stub adapter
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -150,7 +150,7 @@ class EnvironmentTest extends TestCase
 
         // up
         $upMigration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20110301080000'])
+            ->setConstructorArgs(['mockenv', '20110301080000'])
             ->setMethods(['up'])
             ->getMock();
         $upMigration->expects($this->once())
@@ -173,7 +173,7 @@ class EnvironmentTest extends TestCase
 
         // down
         $downMigration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20110301080000'])
+            ->setConstructorArgs(['mockenv', '20110301080000'])
             ->setMethods(['down'])
             ->getMock();
         $downMigration->expects($this->once())
@@ -202,7 +202,7 @@ class EnvironmentTest extends TestCase
 
         // migrate
         $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20110301080000'])
+            ->setConstructorArgs(['mockenv', '20110301080000'])
             ->setMethods(['up'])
             ->getMock();
         $migration->expects($this->once())
@@ -225,7 +225,7 @@ class EnvironmentTest extends TestCase
 
         // migration
         $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20130301080000'])
+            ->setConstructorArgs(['mockenv', '20130301080000'])
             ->setMethods(['change'])
             ->getMock();
         $migration->expects($this->once())
@@ -248,7 +248,7 @@ class EnvironmentTest extends TestCase
 
         // migration
         $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
-            ->setConstructorArgs(['20130301080000'])
+            ->setConstructorArgs(['mockenv', '20130301080000'])
             ->setMethods(['change'])
             ->getMock();
         $migration->expects($this->once())

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -1075,7 +1075,7 @@ class ManagerTest extends TestCase
         );
         $config = new Config(['paths' => ['migrations' => $this->getCorrectedPath(__DIR__ . '/_files/duplicateversions')]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationVersionsWithNamespace()
@@ -1086,7 +1086,7 @@ class ManagerTest extends TestCase
         );
         $config = new Config(['paths' => ['migrations' => ['Foo\Bar' => $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/duplicateversions')]]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationVersionsWithMixedNamespace()
@@ -1102,7 +1102,7 @@ class ManagerTest extends TestCase
             ]
         ]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationNames()
@@ -1113,7 +1113,7 @@ class ManagerTest extends TestCase
         );
         $config = new Config(['paths' => ['migrations' => $this->getCorrectedPath(__DIR__ . '/_files/duplicatenames')]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationNamesWithNamespace()
@@ -1124,7 +1124,7 @@ class ManagerTest extends TestCase
         );
         $config = new Config(['paths' => ['migrations' => ['Foo\Bar' => $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/duplicatenames')]]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithInvalidMigrationClassName()
@@ -1135,7 +1135,7 @@ class ManagerTest extends TestCase
         );
         $config = new Config(['paths' => ['migrations' => $this->getCorrectedPath(__DIR__ . '/_files/invalidclassname')]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithInvalidMigrationClassNameWithNamespace()
@@ -1146,7 +1146,7 @@ class ManagerTest extends TestCase
         );
         $config = new Config(['paths' => ['migrations' => ['Foo\Bar' => $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/invalidclassname')]]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithClassThatDoesntExtendAbstractMigration()
@@ -1157,7 +1157,7 @@ class ManagerTest extends TestCase
         );
         $config = new Config(['paths' => ['migrations' => $this->getCorrectedPath(__DIR__ . '/_files/invalidsuperclass')]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithClassThatDoesntExtendAbstractMigrationWithNamespace()
@@ -1168,7 +1168,7 @@ class ManagerTest extends TestCase
         );
         $config = new Config(['paths' => ['migrations' => ['Foo\Bar' => $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/invalidsuperclass')]]]);
         $manager = new Manager($config, $this->input, $this->output);
-        $manager->getMigrations();
+        $manager->getMigrations('mockenv');
     }
 
     public function testGettingAValidEnvironment()
@@ -5423,7 +5423,7 @@ class ManagerTest extends TestCase
 
     public function testGettingInputObject()
     {
-        $migrations = $this->manager->getMigrations();
+        $migrations = $this->manager->getMigrations('mockenv');
         $seeds = $this->manager->getSeeds();
         $inputObject = $this->manager->getInput();
         $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $inputObject);
@@ -5438,7 +5438,7 @@ class ManagerTest extends TestCase
 
     public function testGettingOutputObject()
     {
-        $migrations = $this->manager->getMigrations();
+        $migrations = $this->manager->getMigrations('mockenv');
         $seeds = $this->manager->getSeeds();
         $outputObject = $this->manager->getOutput();
         $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $outputObject);


### PR DESCRIPTION
This PR adds functionality requested in #1137.

**Issue**
Sometimes within a migration you may want to have different behavior based on the environment you are in. For example, in my development environment I also stage fixtures in my database i.e add a default user to the development database but not in the testing database.

**Documentation**
- `AbstractMigration` and `MigrationInterface` have been modified with one new methods `::getEnvironment()`.
- The constructor signature of `AbstractMigration` has been modified so the migration gets instantiated with the `$environment` parameter. I don't think this will cause any issues to the end user as I assume users do not override the constructor, they simply extend the migration when creating their own. 

**Example Usage**
```php
use DI\Container;
use Dotenv\Dotenv;
use Phinx\Migration\AbstractMigration;

abstract class SQLMigration extends AbstractMigration
{
    /**
     * @return bool
     */
    protected function shouldStage()
    {
        return $this->getEnvironment() !== 'testing' && $this->isMigratingUp();
    }
}
```

**Status**
- [X] Implement functionality
- [X] Refactor existing tests and add new coverage for additional feature
- [ ] Discussion and Code Review