### PR TITLE
Fix SQLite transaction handling

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -109,7 +109,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function beginTransaction()
     {
-        $this->execute('BEGIN TRANSACTION');
+        $this->getConnection()->beginTransaction();
     }
 
     /**
@@ -117,7 +117,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function commitTransaction()
     {
-        $this->execute('COMMIT');
+        $this->getConnection()->commit();
     }
 
     /**
@@ -125,7 +125,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function rollbackTransaction()
     {
-        $this->execute('ROLLBACK');
+        $this->getConnection()->rollBack();
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -52,8 +52,38 @@ class SQLiteAdapterTest extends TestCase
             ->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $this->adapter->beginTransaction();
 
-        $this->assertTrue(true, 'Transaction query succeeded');
+        $this->assertTrue(
+            $this->adapter->getConnection()->inTransaction(),
+            "Underlying PDO instance did not detect new transaction"
+        );
     }
+
+    public function testRollbackTransaction()
+    {
+        $this->adapter->getConnection()
+            ->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->adapter->beginTransaction();
+        $this->adapter->rollbackTransaction();
+
+        $this->assertFalse(
+            $this->adapter->getConnection()->inTransaction(),
+            "Underlying PDO instance did not detect rolled back transaction"
+        );
+    }
+
+    public function testCommitTransactionTransaction()
+    {
+        $this->adapter->getConnection()
+            ->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->adapter->beginTransaction();
+        $this->adapter->commitTransaction();
+
+        $this->assertFalse(
+            $this->adapter->getConnection()->inTransaction(),
+            "Underlying PDO instance didn't detect committed transaction"
+        );
+    }
+
 
     public function testCreatingTheSchemaTableOnConnect()
     {


### PR DESCRIPTION
Modify SQLiteAdapter to use the transaction methods provided by PDO
rather than directly executing transaction commands against the connection.

This allows getConnection()->inTransaction() to return the proper value.

Fixes #1312