### PR TITLE
Add --fake flag to migrate and rollback commands

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -76,7 +76,7 @@ EOT
         $version = $input->getOption('target');
         $environment = $input->getOption('environment');
         $date = $input->getOption('date');
-        $fake = (bool) $input->getOption('fake');
+        $fake = (bool)$input->getOption('fake');
 
         if ($environment === null) {
             $environment = $this->getConfig()->getDefaultEnvironment();

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -48,6 +48,7 @@ class Migrate extends AbstractCommand
             ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to migrate to')
             ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to migrate to')
             ->addOption('--dry-run', '-x', InputOption::VALUE_NONE, 'Dump query to standard output instead of executing it')
+            ->addOption('--fake', null, InputOption::VALUE_NONE, "Mark any migrations selected as run, but don't actually execute them")
             ->setHelp(
                 <<<EOT
 The <info>migrate</info> command runs all available migrations, optionally up to a specific version
@@ -75,6 +76,7 @@ EOT
         $version = $input->getOption('target');
         $environment = $input->getOption('environment');
         $date = $input->getOption('date');
+        $fake = (bool) $input->getOption('fake');
 
         if ($environment === null) {
             $environment = $this->getConfig()->getDefaultEnvironment();
@@ -107,12 +109,16 @@ EOT
             $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
         }
 
+        if ($fake) {
+            $output->writeln('<comment>warning</comment> performing fake migrations');
+        }
+
         // run the migrations
         $start = microtime(true);
         if ($date !== null) {
-            $this->getManager()->migrateToDateTime($environment, new \DateTime($date));
+            $this->getManager()->migrateToDateTime($environment, new \DateTime($date), $fake);
         } else {
-            $this->getManager()->migrate($environment, $version);
+            $this->getManager()->migrate($environment, $version, $fake);
         }
         $end = microtime(true);
 

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -49,6 +49,7 @@ class Rollback extends AbstractCommand
             ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to rollback to')
             ->addOption('--force', '-f', InputOption::VALUE_NONE, 'Force rollback to ignore breakpoints')
             ->addOption('--dry-run', '-x', InputOption::VALUE_NONE, 'Dump query to standard output instead of executing it')
+            ->addOption('--fake', null, InputOption::VALUE_NONE, "Mark any rollbacks selected as run, but don\'t actually execute them")
             ->setHelp(
                 <<<EOT
 The <info>rollback</info> command reverts the last migration, or optionally up to a specific version
@@ -85,6 +86,7 @@ EOT
         $version = $input->getOption('target');
         $date = $input->getOption('date');
         $force = (bool)$input->getOption('force');
+        $fake = (bool) $input->getOption('fake');
 
         $config = $this->getConfig();
 
@@ -111,6 +113,10 @@ EOT
         $versionOrder = $this->getConfig()->getVersionOrder();
         $output->writeln('<info>ordering by </info>' . $versionOrder . " time");
 
+        if ($fake) {
+            $output->writeln('<comment>warning</comment> performing fake rollbacks');
+        }
+
         // rollback the specified environment
         if ($date === null) {
             $targetMustMatchVersion = true;
@@ -121,7 +127,7 @@ EOT
         }
 
         $start = microtime(true);
-        $this->getManager()->rollback($environment, $target, $force, $targetMustMatchVersion);
+        $this->getManager()->rollback($environment, $target, $force, $targetMustMatchVersion, $fake);
         $end = microtime(true);
 
         $output->writeln('');

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -86,7 +86,7 @@ EOT
         $version = $input->getOption('target');
         $date = $input->getOption('date');
         $force = (bool)$input->getOption('force');
-        $fake = (bool) $input->getOption('fake');
+        $fake = (bool)$input->getOption('fake');
 
         $config = $this->getConfig();
 

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -45,7 +45,7 @@ class PhinxApplication extends Application
      *
      * Initialize the Phinx console application.
      *
-     * @param string $version The Application Version, if null, use version out of composer.json file
+     * @param string|null $version The Application Version, if null, use version out of composer.json file
      */
     public function __construct($version = null)
     {

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -45,12 +45,14 @@ class PhinxApplication extends Application
      *
      * Initialize the Phinx console application.
      *
-     * @param string $version The Application Version
+     * @param string $version The Application Version, if null, use version out of composer.json file
      */
-    public function __construct()
+    public function __construct($version = null)
     {
-        $composerConfig = json_decode(file_get_contents(__DIR__ . '/../../../composer.json'));
-        $version = $composerConfig->version;
+        if ($version === null) {
+            $composerConfig = json_decode(file_get_contents(__DIR__ . '/../../../composer.json'));
+            $version = $composerConfig->version;
+        }
 
         parent::__construct('Phinx by CakePHP - https://phinx.org.', $version);
 

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -251,7 +251,7 @@ class Manager
     /**
      * Print Missing Version
      *
-     * @param array     $version        The missing version to print (in the format returned by Environment.getVersionLog).
+     * @param array $version        The missing version to print (in the format returned by Environment.getVersionLog).
      * @param int   $maxNameLength  The maximum migration name length.
      */
     private function printMissingVersion($version, $maxNameLength)
@@ -274,10 +274,12 @@ class Manager
      *
      * @param string    $environment Environment
      * @param \DateTime $dateTime    Date to migrate to
+     * @param bool      $fake        flag that if true, we just record running the migration, but not actually do the
+     *                               migration
      *
      * @return void
      */
-    public function migrateToDateTime($environment, \DateTime $dateTime)
+    public function migrateToDateTime($environment, \DateTime $dateTime, $fake = false)
     {
         $versions = array_keys($this->getMigrations($environment));
         $dateString = $dateTime->format('YmdHis');
@@ -289,7 +291,7 @@ class Manager
         if (count($outstandingMigrations) > 0) {
             $migration = max($outstandingMigrations);
             $this->getOutput()->writeln('Migrating to version ' . $migration);
-            $this->migrate($environment, $migration);
+            $this->migrate($environment, $migration, $fake);
         }
     }
 
@@ -297,10 +299,11 @@ class Manager
      * Migrate an environment to the specified version.
      *
      * @param string $environment Environment
-     * @param int $version
+     * @param int    $version
+     * @param bool   $fake flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function migrate($environment, $version = null)
+    public function migrate($environment, $version = null, $fake = false)
     {
         $migrations = $this->getMigrations($environment);
         $env = $this->getEnvironment($environment);
@@ -336,7 +339,7 @@ class Manager
                 }
 
                 if (in_array($migration->getVersion(), $versions)) {
-                    $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                    $this->executeMigration($environment, $migration, MigrationInterface::DOWN, $fake);
                 }
             }
         }
@@ -348,7 +351,7 @@ class Manager
             }
 
             if (!in_array($migration->getVersion(), $versions)) {
-                $this->executeMigration($environment, $migration, MigrationInterface::UP);
+                $this->executeMigration($environment, $migration, MigrationInterface::UP, $fake);
             }
         }
     }
@@ -359,9 +362,10 @@ class Manager
      * @param string $name Environment Name
      * @param \Phinx\Migration\MigrationInterface $migration Migration
      * @param string $direction Direction
+     * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function executeMigration($name, MigrationInterface $migration, $direction = MigrationInterface::UP)
+    public function executeMigration($name, MigrationInterface $migration, $direction = MigrationInterface::UP, $fake = false)
     {
         $this->getOutput()->writeln('');
         $this->getOutput()->writeln(
@@ -372,7 +376,7 @@ class Manager
 
         // Execute the migration and log the time elapsed.
         $start = microtime(true);
-        $this->getEnvironment($name)->executeMigration($migration, $direction);
+        $this->getEnvironment($name)->executeMigration($migration, $direction, $fake);
         $end = microtime(true);
 
         $this->getOutput()->writeln(
@@ -419,9 +423,10 @@ class Manager
      * @param int|string $target
      * @param bool $force
      * @param bool $targetMustMatchVersion
+     * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function rollback($environment, $target = null, $force = false, $targetMustMatchVersion = true)
+    public function rollback($environment, $target = null, $force = false, $targetMustMatchVersion = true, $fake = false)
     {
         // note that the migrations are indexed by name (aka creation time) in ascending order
         $migrations = $this->getMigrations($environment);
@@ -512,7 +517,7 @@ class Manager
                     $this->getOutput()->writeln('<error>Breakpoint reached. Further rollbacks inhibited.</error>');
                     break;
                 }
-                $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                $this->executeMigration($environment, $migration, MigrationInterface::DOWN, $fake);
                 $rollbacked = true;
             }
         }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -299,8 +299,8 @@ class Manager
      * Migrate an environment to the specified version.
      *
      * @param string $environment Environment
-     * @param int    $version
-     * @param bool   $fake flag that if true, we just record running the migration, but not actually do the migration
+     * @param int    $version     version to migrate to
+     * @param bool   $fake        flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
     public function migrate($environment, $version = null, $fake = false)

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -134,7 +134,8 @@ class MigrateTest extends TestCase
         $this->assertSame(0, $exitCode);
     }
 
-    public function testFakeMigrate() {
+    public function testFakeMigrate()
+    {
         $application = new PhinxApplication('testing');
         $application->add(new Migrate());
 
@@ -157,6 +158,5 @@ class MigrateTest extends TestCase
 
         $this->assertRegExp('/warning performing fake migrations/', $commandTester->getDisplay());
         $this->assertSame(0, $exitCode);
-
     }
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -133,4 +133,30 @@ class MigrateTest extends TestCase
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
         $this->assertSame(0, $exitCode);
     }
+
+    public function testFakeMigrate() {
+        $application = new PhinxApplication('testing');
+        $application->add(new Migrate());
+
+        /** @var Migrate $command */
+        $command = $application->find('migrate');
+
+        // mock the manager class
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+        $managerStub->expects($this->once())
+            ->method('migrate');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), '--fake' => true], ['decorated' => false]);
+
+        $this->assertRegExp('/warning performing fake migrations/', $commandTester->getDisplay());
+        $this->assertSame(0, $exitCode);
+
+    }
 }

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -283,4 +283,32 @@ class RollbackTest extends TestCase
         $commandTester->execute(['command' => $command->getName(), '-d' => $targetDate], ['decorated' => false]);
         $this->assertRegExp('/ordering by execution time/', $commandTester->getDisplay());
     }
+
+    public function testFakeRollback()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        /** @var Rollback $command */
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+        $managerStub->expects($this->once())
+            ->method('rollback')
+            ->with(self::DEFAULT_TEST_ENVIRONMENT, null, false, true);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName(), '--fake' => true], ['decorated' => false]);
+
+        $display = $commandTester->getDisplay();
+
+        $this->assertRegExp('/warning performing fake rollback/', $display);
+    }
 }


### PR DESCRIPTION
Sort of implements what #841 is asking fo with a different implementation than #266 (more inline with how Django's migration tool works). Though, this doesn't add a 'fake-initial' command, you'd just have to use fake with the appropriate options to just run it for your initial migration if you only wanted to fake that.

Both migrate and rollback accept a `--fake` flag that when used will mark any specified migrations/rollbacks as having been done, but won't actually run the up/down/change methods for the migration.

Usage:
```
bin/phinx migrate --help                                                                 [11:30:28]
Usage:
  migrate [options]

Options:
  -c, --configuration=CONFIGURATION  The configuration file to load
  -p, --parser=PARSER                Parser used to read the config file. Defaults to YAML
  -e, --environment=ENVIRONMENT      The target environment
  -t, --target=TARGET                The version number to migrate to
  -d, --date=DATE                    The date to migrate to
  -x, --dry-run                      Dump query to standard output instead of executing it
      --fake                         Mark any migrations selected as run, but don't actually execute them
  -h, --help                         Display this help message
  -q, --quiet                        Do not output any message
  -V, --version                      Display this application version
      --ansi                         Force ANSI output
      --no-ansi                      Disable ANSI output
  -n, --no-interaction               Do not ask any interactive question
  -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  The migrate command runs all available migrations, optionally up to a specific version

  phinx migrate -e development
  phinx migrate -e development -t 20110103081132
  phinx migrate -e development -d 20110103
  phinx migrate -e development -v

bin/phinx rollback --help                                                                [11:31:27]
Usage:
  rollback [options]

Options:
  -c, --configuration=CONFIGURATION  The configuration file to load
  -p, --parser=PARSER                Parser used to read the config file. Defaults to YAML
  -e, --environment=ENVIRONMENT      The target environment
  -t, --target=TARGET                The version number to rollback to
  -d, --date=DATE                    The date to rollback to
  -f, --force                        Force rollback to ignore breakpoints
  -x, --dry-run                      Dump query to standard output instead of executing it
      --fake                         Mark any rollbacks selected as run, but don\'t actually execute them
  -h, --help                         Display this help message
  -q, --quiet                        Do not output any message
  -V, --version                      Display this application version
      --ansi                         Force ANSI output
      --no-ansi                      Disable ANSI output
  -n, --no-interaction               Do not ask any interactive question
  -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  The rollback command reverts the last migration, or optionally up to a specific version

  phinx rollback -e development
  phinx rollback -e development -t 20111018185412
  phinx rollback -e development -d 20111018
  phinx rollback -e development -v
  phinx rollback -e development -t 20111018185412 -f

  If you have a breakpoint set, then you can rollback to target 0 and the rollbacks will stop at the breakpoint.
  phinx rollback -e development -t 0

  The version_order configuration option is used to determine the order of the migrations when rolling back.
  This can be used to allow the rolling back of the last executed migration instead of the last created one, or combined
  with the -d|--date option to rollback to a certain date using the migration start times to order them.
```


Test Migration:
```
<?php

use Phinx\Migration\AbstractMigration;

class Test extends AbstractMigration
{
    public function up()
    {
        $table = $this->table('test_table');
        $table->addColumn('name', 'string')->create();
        $this->insert('test_table', [['name' => 'test1'], ['name' => 'test2']]);
    }

    public function down()
    {
        $this->dropTable('test_table');
    }
}
```

Testing CLI:
```
root@8dc2af648658:/src# bin/phinx status
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
ordering by creation time

 Status  [Migration ID]  Started              Finished             Migration Name
----------------------------------------------------------------------------------
   down  20180302161813                                            Test

root@8dc2af648658:/src# mysql -Ddevelopment_db -e 'SELECT * FROM test_table;'
ERROR 1146 (42S02) at line 1: Table 'development_db.test_table' doesn't exist
root@8dc2af648658:/src# bin/phinx migrate
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db

 == 20180302161813 Test: migrating
 == 20180302161813 Test: migrated 0.0238s

All Done. Took 0.0847s
root@8dc2af648658:/src# bin/phinx status
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
ordering by creation time

 Status  [Migration ID]  Started              Finished             Migration Name
----------------------------------------------------------------------------------
     up  20180302161813  2018-03-02 16:28:46  2018-03-02 16:28:46  Test

root@8dc2af648658:/src# mysql -Ddevelopment_db -e 'SELECT * FROM test_table;'
+----+-------+
| id | name  |
+----+-------+
|  1 | test1 |
|  2 | test2 |
+----+-------+
root@8dc2af648658:/src# bin/phinx rollback
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db
ordering by creation time

 == 20180302161813 Test: reverting
 == 20180302161813 Test: reverted 0.0075s

All Done. Took 0.0692s
root@8dc2af648658:/src# bin/phinx status
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
ordering by creation time

 Status  [Migration ID]  Started              Finished             Migration Name
----------------------------------------------------------------------------------
   down  20180302161813                                            Test

root@8dc2af648658:/src# mysql -Ddevelopment_db -e 'SELECT * FROM test_table;'
ERROR 1146 (42S02) at line 1: Table 'development_db.test_table' doesn't exist
root@8dc2af648658:/src# bin/phinx migrate --fake
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db
warning performing fake migrations

 == 20180302161813 Test: migrating
 == 20180302161813 Test: migrated 0.0039s

All Done. Took 0.0720s
root@8dc2af648658:/src# bin/phinx status
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
ordering by creation time

 Status  [Migration ID]  Started              Finished             Migration Name
----------------------------------------------------------------------------------
     up  20180302161813  2018-03-02 16:29:06  2018-03-02 16:29:06  Test

root@8dc2af648658:/src# mysql -Ddevelopment_db -e 'SELECT * FROM test_table;'
ERROR 1146 (42S02) at line 1: Table 'development_db.test_table' doesn't exist
root@8dc2af648658:/src# bin/phinx rollback
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db
ordering by creation time

 == 20180302161813 Test: reverting

In PdoAdapter.php line 134:

  SQLSTATE[42S02]: Base table or view not found: 1051 Unknown table 'test_table'


rollback [-c|--configuration CONFIGURATION] [-p|--parser PARSER] [-e|--environment ENVIRONMENT] [-t|--target TARGET] [-d|--date DATE] [-f|--force] [-x|--dry-run] [--fake]

root@8dc2af648658:/src# bin/phinx rollback --fake
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db
ordering by creation time
warning performing fake rollbacks

 == 20180302161813 Test: reverting
 == 20180302161813 Test: reverted 0.0059s

All Done. Took 0.0718s
root@8dc2af648658:/src# bin/phinx status
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
ordering by creation time

 Status  [Migration ID]  Started              Finished             Migration Name
----------------------------------------------------------------------------------
   down  20180302161813                                            Test

root@8dc2af648658:/src# bin/phinx migrate
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db

 == 20180302161813 Test: migrating
 == 20180302161813 Test: migrated 0.0175s

All Done. Took 0.0689s
root@8dc2af648658:/src# bin/phinx rollback --fake
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db
ordering by creation time
warning performing fake rollbacks

 == 20180302161813 Test: reverting
 == 20180302161813 Test: reverted 0.0043s

All Done. Took 0.0759s
root@8dc2af648658:/src# mysql -Ddevelopment_db -e 'SELECT * FROM test_table;'
+----+-------+
| id | name  |
+----+-------+
|  1 | test1 |
|  2 | test2 |
+----+-------+
root@8dc2af648658:/src# bin/phinx migrate
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db

 == 20180302161813 Test: migrating

In PdoAdapter.php line 134:

  SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'test_table' already exists


migrate [-c|--configuration CONFIGURATION] [-p|--parser PARSER] [-e|--environment ENVIRONMENT] [-t|--target TARGET] [-d|--date DATE] [-x|--dry-run] [--fake]

root@8dc2af648658:/src# bin/phinx migrate --fake
Phinx by CakePHP - https://phinx.org. 0.9.2

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /src/db/migrations
using seed paths
warning no environment specified, defaulting to: development
using adapter mysql
using database development_db
warning performing fake migrations

 == 20180302161813 Test: migrating
 == 20180302161813 Test: migrated 0.0042s

All Done. Took 0.0991s
root@8dc2af648658:/src#
```