### PR TITLE
Allow user to specify format for starting Phinx file

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -174,8 +174,8 @@ Use ``--dry-run`` to print the queries to standard output without executing them
 
 .. note::
 
-        When rolling back, Phinx orders the executed migrations using 
-        the order specified in the ``version_order`` option of your 
+        When rolling back, Phinx orders the executed migrations using
+        the order specified in the ``version_order`` option of your
         ``phinx.yml`` file.
         Please see the :doc:`Configuration <configuration>` chapter for more information.
 
@@ -253,8 +253,9 @@ configuration file may be the computed output of a PHP file as a PHP array:
                 ]
             ];
 
-Phinx auto-detects which language parser to use for files with ``*.yml`` and ``*.php`` extensions. The appropriate
-parser may also be specified via the ``--parser`` and ``-p`` parameters. Anything other than ``"php"`` is treated as YAML.
+Phinx auto-detects which language parser to use for files with ``*.yml``, ``*.json``, and ``*.php`` extensions. The appropriate
+parser may also be specified via the ``--parser`` and ``-p`` parameters. Anything other than  ``"json"`` or ``"php"`` is
+treated as YAML.
 
 When using a PHP array, you can provide a ``connection`` key with an existing PDO instance. It is also important to pass
 the database name too, as Phinx requires this for certain methods such as ``hasTable()``:
@@ -313,7 +314,8 @@ Phinx can be used within your unit tests to prepare or seed the database. You ca
           $app->run(new StringInput('migrate'), new NullOutput());
         }
 
-If you use a memory database, you'll need to give Phinx a specific PDO instance. You can interact with Phinx directly using the Manager class : 
+If you use a memory database, you'll need to give Phinx a specific PDO instance. You can interact with Phinx directly
+using the Manager class :
 
 .. code-block:: php
 
@@ -325,7 +327,7 @@ If you use a memory database, you'll need to give Phinx a specific PDO instance.
         use Symfony\Component\Console\Output\NullOutput;
 
         class DatabaseTestCase extends TestCase {
-                
+
             public function setUp ()
             {
                 $pdo = new PDO('sqlite::memory:', null, null, [

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,8 +5,9 @@ Configuration
 =============
 
 When you initialize your project using the :doc:`Init Command<commands>`, Phinx
-creates a default file called ``phinx.yml`` in the root of your project directory.
-This file uses the YAML data serialization format.
+creates a default file in the root of your project directory. By default, this
+file uses the YAML data serialization format, but you can use the ``--format``
+command line option to specify either ``yml``, ``json``, or ``php``.
 
 If a ``--configuration`` command line option is given, Phinx will load the
 specified file. Otherwise, it will attempt to find ``phinx.php``, ``phinx.json`` or
@@ -34,19 +35,18 @@ This means that:
 
 .. code-block:: php
 
-   require 'app/init.php';
+    $app = require 'app/phinx.php';
+    $pdo = $app->getDatabase()->getPdo();
 
-   global $app;
-   $pdo = $app->getDatabase()->getPdo();
-
-   return ['environments' => [
-              'default_database' => 'development',
-              'development' => [
+    return [
+        'environments' => [
+            'default_database' => 'development',
+            'development' => [
                 'name' => 'devdb',
                 'connection' => $pdo
-              ]
             ]
-          ];
+        ]
+    ];
 
 Migration Paths
 ---------------
@@ -303,7 +303,7 @@ The aliased classes will still be required to implement the ``Phinx\Migration\Cr
 Version Order
 ------
 
-When rolling back or printing the status of migrations, Phinx orders the executed migrations according to the 
+When rolling back or printing the status of migrations, Phinx orders the executed migrations according to the
 ``version_order`` option, which can have the following values:
 
 * ``creation`` (the default): migrations are ordered by their creation time, which is also part of their filename.

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -37,7 +37,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Init extends Command
 {
-    const FILE_NAME = 'phinx.yml';
+    const FILE_NAME = 'phinx';
 
     /**
      * {@inheritdoc}
@@ -47,6 +47,7 @@ class Init extends Command
         $this->setName('init')
             ->setDescription('Initialize the application for Phinx')
             ->addArgument('path', InputArgument::OPTIONAL, 'Which path should we initialize for Phinx?')
+            ->addOption('--format', '-f', InputArgument::OPTIONAL, 'What format should we use to initialize?', 'yml')
             ->setHelp(sprintf(
                 '%sInitializes the application for Phinx%s',
                 PHP_EOL,
@@ -67,7 +68,8 @@ class Init extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $path = $this->resolvePath($input);
-        $this->writeConfig($path);
+        $format = strtolower($input->getOption('format'));
+        $this->writeConfig($path, $format);
 
         $output->writeln("<info>created</info> {$path}");
     }
@@ -84,14 +86,22 @@ class Init extends Command
         // get the migration path from the config
         $path = $input->getArgument('path');
 
+        $format = strtolower($input->getOption('format'));
+        if (!in_array($format, ['yml', 'json', 'php'])) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid format "%s". Format must be either yml, json, or php.',
+                $format
+            ));
+        }
+
         // Fallback
         if (!$path) {
-            $path = getcwd() . DIRECTORY_SEPARATOR . self::FILE_NAME;
+            $path = getcwd() . DIRECTORY_SEPARATOR . self::FILE_NAME . '.' . $format;
         }
 
         // Adding file name if necessary
         if (is_dir($path)) {
-            $path .= DIRECTORY_SEPARATOR . self::FILE_NAME;
+            $path .= DIRECTORY_SEPARATOR . self::FILE_NAME . '.' . $format;
         }
 
         // Check if path is available
@@ -118,13 +128,14 @@ class Init extends Command
     /**
      * Writes Phinx's config in provided $path
      *
-     * @param string $path Config file's path.
+     * @param string $path   Config file's path.
+     * @param string $format Format to use for config file
      *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      * @return void
      */
-    protected function writeConfig($path)
+    protected function writeConfig($path, $format = 'yml')
     {
         // Check if dir is writable
         $dirname = dirname($path);
@@ -136,10 +147,15 @@ class Init extends Command
         }
 
         // load the config template
-        if (is_dir(__DIR__ . '/../../../data/Phinx')) {
-            $contents = file_get_contents(__DIR__ . '/../../../data/Phinx/phinx.yml');
+        if (is_dir(__DIR__ . '/../../../data')) {
+            $contents = file_get_contents(__DIR__ . '/../../../data/'.self::FILE_NAME . '.' . $format . '.dist');
+        } elseif ($format === 'yml') {
+            $contents = file_get_contents(__DIR__ . '/../../../../' . self::FILE_NAME . '.' . $format);
         } else {
-            $contents = file_get_contents(__DIR__ . '/../../../../phinx.yml');
+            throw new RuntimeException(sprintf(
+                'Could not find template for format "%s".',
+                $format
+            ));
         }
 
         if (file_put_contents($path, $contents) === false) {

--- a/src/data/phinx.json.dist
+++ b/src/data/phinx.json.dist
@@ -1,0 +1,38 @@
+{
+    "paths": {
+        "migrations": "%%PHINX_CONFIG_DIR%%/db/migrations",
+        "seeds": "%%PHINX_CONFIG_DIR%%/db/seeds"
+    },
+    "environments": {
+        "default_migration_table": "phinxlog",
+        "default_database": "development",
+        "production": {
+            "adapter": "mysql",
+            "host": "localhost",
+            "name": "production_db",
+            "user": "root",
+            "pass": "",
+            "port": 3306,
+            "charset": "utf8"
+        },
+        "development": {
+            "adapter": "mysql",
+            "host": "localhost",
+            "name": "development_db",
+            "user": "root",
+            "pass": "",
+            "port": 3306,
+            "charset": "utf8"
+        },
+        "testing": {
+            "adapter": "mysql",
+            "host": "localhost",
+            "name": "testing_db",
+            "user": "root",
+            "pass": "",
+            "port": 3306,
+            "charset": "utf8"
+        }
+    },
+    "version_order": "creation"
+}

--- a/src/data/phinx.php.dist
+++ b/src/data/phinx.php.dist
@@ -1,0 +1,41 @@
+<?php
+
+return
+[
+    'paths' => [
+        'migrations' => '%%PHINX_CONFIG_DIR%%/db/migrations',
+        'seeds' => '%%PHINX_CONFIG_DIR%%/db/seeds'
+    ],
+    'environments' => [
+        'default_migration_table' => 'phinxlog',
+        'default_database' => 'development',
+        'production' => [
+            'adapter' => 'mysql',
+            'host' => 'localhost',
+            'name' => 'production_db',
+            'user' => 'root',
+            'pass' => '',
+            'port' => '3306',
+            'charset' => 'utf8',
+        ],
+        'development' => [
+            'adapter' => 'mysql',
+            'host' => 'localhost',
+            'name' => 'development_db',
+            'user' => 'root',
+            'pass' => '',
+            'port' => '3306',
+            'charset' => 'utf8',
+        ],
+        'testing' => [
+            'adapter' => 'mysql',
+            'host' => 'localhost',
+            'name' => 'testing_db',
+            'user' => 'root',
+            'pass' => '',
+            'port' => '3306',
+            'charset' => 'utf8',
+        ]
+    ],
+    'version_order' => 'creation'
+];

--- a/src/data/phinx.yml.dist
+++ b/src/data/phinx.yml.dist
@@ -1,0 +1,35 @@
+paths:
+    migrations: '%%PHINX_CONFIG_DIR%%/db/migrations'
+    seeds: '%%PHINX_CONFIG_DIR%%/db/seeds'
+
+environments:
+    default_migration_table: phinxlog
+    default_database: development
+    production:
+        adapter: mysql
+        host: localhost
+        name: production_db
+        user: root
+        pass: ''
+        port: 3306
+        charset: utf8
+
+    development:
+        adapter: mysql
+        host: localhost
+        name: development_db
+        user: root
+        pass: ''
+        port: 3306
+        charset: utf8
+
+    testing:
+        adapter: mysql
+        host: localhost
+        name: testing_db
+        user: root
+        pass: ''
+        port: 3306
+        charset: utf8
+
+version_order: creation

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -11,9 +11,11 @@ class InitTest extends TestCase
 {
     protected function setUp()
     {
-        $file = sys_get_temp_dir() . '/phinx.yml';
-        if (is_file($file)) {
-            unlink($file);
+        foreach (['.yml', '.json', '.php'] as $format) {
+            $file = sys_get_temp_dir() . '/phinx'. $format;
+            if (is_file($file)) {
+                unlink($file);
+            }
         }
     }
 
@@ -25,12 +27,16 @@ class InitTest extends TestCase
         $commandTester = new CommandTester($command);
         $fullPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $configName;
 
-        $commandTester->execute([
+        $command = [
             'command' => $command->getName(),
             'path' => $fullPath,
-        ], [
-            'decorated' => false,
-        ]);
+        ];
+
+        if ($configName !== '') {
+            $command['--format'] = pathinfo($configName, PATHINFO_EXTENSION);
+        }
+
+        $commandTester->execute($command, ['decorated' => false]);
 
         $this->assertContains(
             "created $fullPath",
@@ -46,16 +52,32 @@ class InitTest extends TestCase
     public function testDefaultConfigIsWritten()
     {
         $this->writeConfig();
+        $this->assertFileExists(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.yml', 'Default format was not yaml');
     }
 
-    public function testConfigIsWritten()
+    public function formatDataProvider()
     {
-        $this->writeConfig('phinx.yml');
+        return [['.yml'], ['.json'], ['.php']];
     }
 
-    public function testCustomNameConfigIsWritten()
+    /**
+     * @dataProvider formatDataProvider
+     *
+     * @param string $format format to use for file
+     */
+    public function testConfigIsWritten($format)
     {
-        $this->writeConfig(uniqid() . '.yml');
+        $this->writeConfig('phinx' . $format);
+    }
+
+    /**
+     * @dataProvider formatDataProvider
+     *
+     * @param string $format format to use for file
+     */
+    public function testCustomNameConfigIsWritten($format)
+    {
+        $this->writeConfig(uniqid() . $format);
     }
 
     /**
@@ -96,6 +118,27 @@ class InitTest extends TestCase
             'path' => '/this/dir/does/not/exists',
         ], [
             'decorated' => false,
+        ]);
+    }
+
+    /**
+     * @expectedException              \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Invalid format "invalid". Format must be either yml, json, or php./
+     */
+    public function testThrowsExceptionWhenInvalidFormat()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Init());
+
+        $command = $application->find('init');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'path' => sys_get_temp_dir() . DIRECTORY_SEPARATOR,
+            '--format' => 'invalid'
+        ], [
+            'decorated' => false
         ]);
     }
 }


### PR DESCRIPTION
Implements #466.

Usage:
```
bin/phinx init --help
Usage:
  init [options] [--] [<path>]

Arguments:
  path                  Which path should we initialize for Phinx?

Options:
  -f, --format=FORMAT   What format should we use to initialize? [default: "yml"]
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:

  Initializes the application for Phinx
```