### PR TITLE
Add ability to specify limit for timestamp/date/time columns for mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
             - TESTS_PHINX_DB_ADAPTER_MYSQL_HOST=mysql
             - TESTS_PHINX_DB_ADAPTER_POSTGRES_HOST=postgres
     mysql:
-        image: mysql:5.5
+        image: mysql:5.6
         environment:
             - MYSQL_DATABASE=phinx_testing
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -718,9 +718,6 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:
             case static::PHINX_TYPE_DECIMAL:
-            case static::PHINX_TYPE_DATETIME:
-            case static::PHINX_TYPE_TIMESTAMP:
-            case static::PHINX_TYPE_TIME:
             case static::PHINX_TYPE_DATE:
             case static::PHINX_TYPE_ENUM:
             case static::PHINX_TYPE_SET:
@@ -731,6 +728,11 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_LINESTRING:
             case static::PHINX_TYPE_POLYGON:
                 return ['name' => $type];
+            case static::PHINX_TYPE_DATETIME:
+            case static::PHINX_TYPE_TIMESTAMP:
+            case static::PHINX_TYPE_TIME:
+                $return = ['name' => $type, 'limit' => $limit];
+                return $return;
             case static::PHINX_TYPE_STRING:
                 return ['name' => 'varchar', 'limit' => $limit ?: 255];
             case static::PHINX_TYPE_CHAR:

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -731,8 +731,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_DATETIME:
             case static::PHINX_TYPE_TIMESTAMP:
             case static::PHINX_TYPE_TIME:
-                $return = ['name' => $type, 'limit' => $limit];
-                return $return;
+                return ['name' => $type, 'limit' => $limit];
             case static::PHINX_TYPE_STRING:
                 return ['name' => 'varchar', 'limit' => $limit ?: 255];
             case static::PHINX_TYPE_CHAR:

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -392,7 +392,8 @@ abstract class PdoAdapter extends AbstractAdapter
      * @param int $attribute One of the PDO::ATTR_* constants
      * @return mixed
      */
-    public function getAttribute($attribute) {
+    public function getAttribute($attribute)
+    {
         return $this->connection->getAttribute($attribute);
     }
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -384,4 +384,13 @@ abstract class PdoAdapter extends AbstractAdapter
     {
         return (bool)$value ? 1 : 0;
     }
+
+    /**
+     * @param $attribute
+     *
+     * @return mixed
+     */
+    public function getAttribute($attribute) {
+        return $this->connection->getAttribute($attribute);
+    }
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -237,14 +237,14 @@ abstract class PdoAdapter extends AbstractAdapter
         $result = [];
 
         switch ($this->options['version_order']) {
-            case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
-                $orderBy = 'version ASC';
-                break;
-            case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
-                $orderBy = 'start_time ASC, version ASC';
-                break;
-            default:
-                throw new \RuntimeException('Invalid version_order configuration option');
+        case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
+            $orderBy = 'version ASC';
+            break;
+        case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
+            $orderBy = 'start_time ASC, version ASC';
+            break;
+        default:
+            throw new \RuntimeException('Invalid version_order configuration option');
         }
 
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY %s', $this->getSchemaTableName(), $orderBy));
@@ -396,8 +396,8 @@ abstract class PdoAdapter extends AbstractAdapter
     {
         return $this->connection->getAttribute($attribute);
     }
-  
-   /**
+
+    /**
      * Get the defintion for a `DEFAULT` statement.
      *
      * @param  mixed $default Default value

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -237,14 +237,14 @@ abstract class PdoAdapter extends AbstractAdapter
         $result = [];
 
         switch ($this->options['version_order']) {
-        case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
-            $orderBy = 'version ASC';
-            break;
-        case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
-            $orderBy = 'start_time ASC, version ASC';
-            break;
-        default:
-            throw new \RuntimeException('Invalid version_order configuration option');
+            case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
+                $orderBy = 'version ASC';
+                break;
+            case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
+                $orderBy = 'start_time ASC, version ASC';
+                break;
+            default:
+                throw new \RuntimeException('Invalid version_order configuration option');
         }
 
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY %s', $this->getSchemaTableName(), $orderBy));

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -386,8 +386,10 @@ abstract class PdoAdapter extends AbstractAdapter
     }
 
     /**
-     * @param $attribute
+     * Retrieve a database connection attribute
+     * @see http://php.net/manual/en/pdo.getattribute.php
      *
+     * @param int $attribute One of the PDO::ATTR_* constants
      * @return mixed
      */
     public function getAttribute($attribute) {

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -671,7 +671,8 @@ class MysqlAdapterTest extends TestCase
         $this->assertEquals($limit, $sqlType['limit']);
     }
 
-    public function testDatetimeColumn() {
+    public function testDatetimeColumn()
+    {
         $this->adapter->connect();
         if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
             $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -671,6 +671,73 @@ class MysqlAdapterTest extends TestCase
         $this->assertEquals($limit, $sqlType['limit']);
     }
 
+    public function testDatetimeColumn() {
+        $this->adapter->connect();
+        if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+            $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
+        }
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'datetime')->save();
+        $columns = $table->getColumns();
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals(null, $sqlType['limit']);
+    }
+
+    public function testDatetimeColumnLimit()
+    {
+        $this->adapter->connect();
+        if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+            $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
+        }
+        $limit = 6;
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'datetime', ['limit' => $limit])->save();
+        $columns = $table->getColumns();
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals($limit, $sqlType['limit']);
+    }
+
+    public function testTimeColumnLimit()
+    {
+        $this->adapter->connect();
+        if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+            $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
+        }
+        $limit = 3;
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'time', ['limit' => $limit])->save();
+        $columns = $table->getColumns();
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals($limit, $sqlType['limit']);
+    }
+
+    public function testTimestampColumnLimit()
+    {
+        $this->adapter->connect();
+        if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+            $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
+        }
+        $limit = 1;
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'timestamp', ['limit' => $limit])->save();
+        $columns = $table->getColumns();
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals($limit, $sqlType['limit']);
+    }
+
+    /**
+     * @expectedException \PDOException
+     */
+    public function testTimestampInvalidLimit()
+    {
+        $this->adapter->connect();
+        if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+            $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
+        }
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'timestamp', ['limit' => 7])->save();
+    }
+
     public function testDropColumn()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -1049,11 +1049,11 @@ class MysqlAdapterUnitTest extends TestCase
             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_DECIMAL)
         );
         $this->assertEquals(
-            ['name' => 'datetime'],
+            ['name' => 'datetime', 'limit' => null],
             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_DATETIME)
         );
         $this->assertEquals(
-            ['name' => 'timestamp'],
+            ['name' => 'timestamp', 'limit' => null],
             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_TIMESTAMP)
         );
         $this->assertEquals(
@@ -1061,7 +1061,7 @@ class MysqlAdapterUnitTest extends TestCase
             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_DATE)
         );
         $this->assertEquals(
-            ['name' => 'time'],
+            ['name' => 'time', 'limit' => null],
             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_TIME)
         );
         $this->assertEquals(


### PR DESCRIPTION
Implements #1003 and #1301, allowing someone to specify a limit for time, timestamp, and datetime types. Trying to use this on older versions of mysql (< 5.6.3) will throw a PDO exception. 

For local testing, I bumped the docker-compose to use mysql 5.6 instead of 5.5.

I've added a check on mysql version for the related tests so as to skip them on those MySQL versions (and added the necessary function to get database version for the PDOAdapter using http://php.net/manual/en/pdo.getattribute.php).