### PR TITLE
Move List test to use namespaced PHPUnit TestCase

### DIFF
--- a/tests/Phinx/Console/Command/ListTest.php
+++ b/tests/Phinx/Console/Command/ListTest.php
@@ -3,9 +3,10 @@
 namespace Test\Phinx\Console\Command;
 
 use Phinx\Console\PhinxApplication;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
-class ListTest extends \PHPUnit_Framework_TestCase
+class ListTest extends TestCase
 {
     public function testVersionInfo()
     {


### PR DESCRIPTION
This class throws an exception on PHPUnit 6 currently. All other test classes use the namespaced TestCase already.