### PR TITLE
Fix status command exit code

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -72,7 +72,7 @@ class Manager
     /**
      * @var integer
      */
-    const EXIT_STATUS_DOWN = 1;
+    const EXIT_STATUS_DOWN = 3;
 
     /**
      * @var integer


### PR DESCRIPTION
The status command exit code is now  **3** to distinguish it from erroneous situations whose status command exit code was already **1**.

For #806