### PR TITLE
Handle `schema` option defined in the Configuration

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -75,6 +75,17 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 ));
             }
 
+            try {
+                if (isset($options['schema'])) {
+                    $this->execute('SET search_path TO '.$options['schema']);
+                }
+            } catch (\PDOException $exception) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Schema does not exists: %s',
+                    $exception->getMessage()
+                ));
+            }
+
             $this->setConnection($db);
         }
     }


### PR DESCRIPTION
Currently I'm not able to write migration for PostgreSQL for specific schema without specifying it in the migration file. The problem is with migration status if I operate on multiple schemas. Seting up `search_path` right after connection was set solves the problem.