### PR TITLE
Add Support for Database-Agnostic DSN

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -238,6 +238,51 @@ demonstrated by the following example:
             port: 3306
             charset: utf8
 
+Data Source Names
+-----------------
+
+Phinx supports the use of data source names (DSN) to specify the connection
+options, which can be useful if you use a single environment variable to hold
+the database credentials. PDO has a different DSN formats depending on the
+underlying driver, so Phinx uses a database-agnostic DSN format used by other
+projects (Doctrine, Rails, AMQP, PaaS, etc).
+
+.. code-block:: text
+
+    <adapter>://[<user>[:<pass>]@]<host>[:<port>]/<name>[?<additionalOptions>]
+
+* A DSN requires at least ``adapter``, ``host`` and ``name``.
+* You cannot specify a password without a username.
+* ``port`` must be a positive integer.
+* ``additionalOptions`` takes the form of a query string, and will be passed to
+  the adapter in the options array.
+
+.. code-block:: yaml
+
+    environments:
+        default_migration_table: phinxlog
+        default_database: development
+        production:
+            # Example data source name
+            dsn: mysql://root@localhost:3306/mydb?charset=utf8
+
+Once a DSN is parsed, it's values are merged with the already existing
+connection options. Values in specified in a DSN will never override any value
+specified directly as connection options.
+
+.. code-block:: yaml
+
+    environments:
+        default_migration_table: phinxlog
+        default_database: development
+        development:
+            dsn: %%DATABASE_URL%%
+        production:
+            dsn: %%DATABASE_URL%%
+            name: production_database
+
+If the supplied DSN is invalid, then it is completely ignored.
+
 Supported Adapters
 ------------------
 
@@ -303,7 +348,7 @@ The aliased classes will still be required to implement the ``Phinx\Migration\Cr
 Version Order
 ------
 
-When rolling back or printing the status of migrations, Phinx orders the executed migrations according to the 
+When rolling back or printing the status of migrations, Phinx orders the executed migrations according to the
 ``version_order`` option, which can have the following values:
 
 * ``creation`` (the default): migrations are ordered by their creation time, which is also part of their filename.

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -205,7 +205,33 @@ class Environment
      */
     public function getOptions()
     {
-        return $this->options;
+        return $this->parseAgnosticDsn($this->options);
+    }
+
+    /**
+     * Parse a database-agnostic DSN into individual options.
+     *
+     * @param array $options Options
+     * @return array
+     */
+    protected function parseAgnosticDsn(array $options)
+    {
+        if (isset($options['dsn']) && is_string($options['dsn'])) {
+            $regex = '#^(?P<adapter>[^\\:]+)\\://(?:(?P<user>[^\\:@]+)(?:\\:(?P<pass>[^@]*))?@)?'
+                   . '(?P<host>[^\\:@/]+)(?:\\:(?P<port>[1-9]\\d*))?/(?P<name>[^\?]+)(?:\?(?P<query>.*))?$#';
+            if (preg_match($regex, trim($options['dsn']), $parsedOptions)) {
+                $additionalOpts = [];
+                if (isset($parsedOptions['query'])) {
+                    parse_str($parsedOptions['query'], $additionalOpts);
+                }
+                $validOptions = ['adapter', 'user', 'pass', 'host', 'port', 'name'];
+                $parsedOptions = array_filter(array_intersect_key($parsedOptions, array_flip($validOptions)));
+                $options = array_merge($additionalOpts, $parsedOptions, $options);
+                unset($options['dsn']);
+            }
+        }
+
+        return $options;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixes issues? | #646
| Agree to license? | yes
| Documentation? | yes

Adds support for providing database connection details as a DSN string (such as with Symfony 4).

It's a feature that I want, so I wrote it - would love feedback on it!
I'm not sure if its the correct way of doing things, I just dived headfirst into it.

### Example

```yaml
environments:
    default_migration_table: phinxlog
    default_database: development
    development:
        dsn: mysql://appuser:supersecretpassword@localhost:3306/mydb?charset=utf8
```

### Regular Expression

That regex string can be a little unwieldy, so here's a handy diagram to help anyone trying to decipher it!

![pathways_dsn_regex](https://user-images.githubusercontent.com/123245/38094437-a2a2610e-3365-11e8-9e59-a0b0056dce3f.png)
