### PR TITLE
Fix tests breaking due to double column type check in PostgresAdapter

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -362,8 +362,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 $column->setLimit($columnInfo['character_maximum_length']);
             }
 
-            $phinxType = $this->getPhinxType($columnInfo['data_type']);
-            if (in_array($phinxType, [static::PHINX_TYPE_TIME, static::PHINX_TYPE_DATETIME])) {
+            if (in_array($columnType, [static::PHINX_TYPE_TIME, static::PHINX_TYPE_DATETIME])) {
                 $column->setPrecision($columnInfo['datetime_precision']);
             } else {
                 $column->setPrecision($columnInfo['numeric_precision']);


### PR DESCRIPTION
This is a follow-up to #1175 which apparently started breaking tests. I think this might be enough to fix the issue.