### PR TITLE
Make counts in JSON output of status more meaningful

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -107,6 +107,9 @@ class Manager
         $hasDownMigration = false;
         $hasMissingMigration = false;
         $migrations = $this->getMigrations($environment);
+        $migrationCount = 0;
+        $missingCount = 0;
+        $pendingMigrationCount = 0;
         if (count($migrations)) {
             // TODO - rewrite using Symfony Table Helper as we already have this library
             // included and it will fix formatting issues (e.g drawing the lines)
@@ -134,6 +137,7 @@ class Manager
             }, $versions)) : 0;
 
             $missingVersions = array_diff_key($versions, $migrations);
+            $missingCount = count($missingVersions);
 
             $hasMissingMigration = !empty($missingVersions);
 
@@ -163,6 +167,7 @@ class Manager
                 $sortedMigrations = array_merge($sortedMigrations, $migrations);
             }
 
+            $migrationCount = count($sortedMigrations);
             foreach ($sortedMigrations as $migration) {
                 $version = array_key_exists($migration->getVersion(), $versions) ? $versions[$migration->getVersion()] : false;
                 if ($version) {
@@ -188,6 +193,7 @@ class Manager
 
                     $status = '     <info>up</info> ';
                 } else {
+                    $pendingMigrationCount++;
                     $hasDownMigration = true;
                     $status = '   <error>down</error> ';
                 }
@@ -229,7 +235,9 @@ class Manager
                 case 'json':
                     $output->writeln(json_encode(
                         [
-                            'pending_count' => count($this->getMigrations($environment)),
+                            'pending_count' => $pendingMigrationCount,
+                            'missing_count' => $missingCount,
+                            'total_count' => $migrationCount + $missingCount,
                             'migrations' => $migrations
                         ]
                     ));

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -103,7 +103,6 @@ class Manager
     public function printStatus($environment, $format = null)
     {
         $output = $this->getOutput();
-        $migrations = [];
         $hasDownMigration = false;
         $hasMissingMigration = false;
         $migrations = $this->getMigrations($environment);


### PR DESCRIPTION
Adds a 'missing_count' (for number of missing migrations) and 'total_count' (for total number, including missing, migrations). Pending migrations only counts migrations that exist and are down.

Fixes #1014

Example outputs:
```
 Status  Migration ID    [Started          ]  Finished             Migration Name
----------------------------------------------------------------------------------
     up  20180302192357  2018-05-10 21:26:28  2018-05-10 21:26:28  Test  ** MISSING **
   down  20180510210702                                            TestMe

{"pending_count":1,"missing_count":1,"total_count":2,"migrations":{"20180510210702":{},"20180510210703":{"migration_status":"down","migration_id":"20180510210702","migration_name":"TestMe"}}}
```

```
 Status  Migration ID    [Started          ]  Finished             Migration Name
----------------------------------------------------------------------------------
     up  20180302192357  2018-05-10 21:26:28  2018-05-10 21:26:28  Test
     up  20180510210702  2018-05-10 22:13:38  2018-05-10 22:13:38  TestMe

{"pending_count":0,"missing_count":0,"total_count":2,"migrations":{"20180510210703":{"migration_status":"up","migration_id":"20180302192357","migration_name":"Test"},"20180510210704":{"migration_status":"up","migration_id":"20180510210702","migration_name":"TestMe"}}}
```

```
 Status  Migration ID    [Started          ]  Finished             Migration Name
----------------------------------------------------------------------------------
     up  20180302192357  2018-05-10 21:26:28  2018-05-10 21:26:28  Test    ** MISSING **
     up  20180510210702  2018-05-10 22:13:38  2018-05-10 22:13:38  TestMe

{"pending_count":0,"missing_count":1,"total_count":2,"migrations":{"20180510210703":{"migration_status":"up","migration_id":"20180510210702","migration_name":"TestMe"}}}
```

```
 Status  Migration ID    [Started          ]  Finished             Migration Name
----------------------------------------------------------------------------------
     up  20180302192357  2018-05-10 21:26:28  2018-05-10 21:26:28  Test
   down  20180510210702                                            TestMe

{"pending_count":1,"missing_count":0,"total_count":2,"migrations":{"20180510210702":{},"20180510210703":{"migration_status":"up","migration_id":"20180302192357","migration_name":"Test"},"20180510210704":{"migration_status":"down","migration_id":"20180510210702","migration_name":"TestMe"}}}
```