### PR TITLE
Add option to addTimestamps with timezone column types

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -789,7 +789,8 @@ timezone enable or disable the ``with time zone`` option for ``time`` and ``time
 ======== ===========
 
 You can add ``created_at`` and ``updated_at`` timestamps to a table using the ``addTimestamps()`` method. This method also
-allows you to supply alternative names.
+allows you to supply alternative names. The optional third argument allows you to change the ``timezone`` option for the
+columns being added.
 
 .. code-block:: php
 
@@ -804,8 +805,14 @@ allows you to supply alternative names.
              */
             public function change()
             {
+                // Use defaults
+                $table = $this->table('users')->addTimestamps()->create();
+
                 // Override the 'updated_at' column name with 'amended_at'.
-                $table = $this->table('users')->addTimestamps(null, 'amended_at')->create();
+                $table = $this->table('books')->addTimestamps(null, 'amended_at')->create();
+
+                // Use defaults, but with timezones
+                $table = $this->table('clocks')->addTimestamps(null, null, true)->create();
             }
         }
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -790,7 +790,8 @@ timezone enable or disable the ``with time zone`` option for ``time`` and ``time
 
 You can add ``created_at`` and ``updated_at`` timestamps to a table using the ``addTimestamps()`` method. This method also
 allows you to supply alternative names. The optional third argument allows you to change the ``timezone`` option for the
-columns being added.
+columns being added. Additionally, you can use the ``addTimestampsWithTimezone()`` method, which is an alias to
+``addTimestamps()`` that will always set the third argument to ``true`` (see examples below).
 
 .. code-block:: php
 
@@ -805,14 +806,18 @@ columns being added.
              */
             public function change()
             {
-                // Use defaults
+                // Use defaults (without timezones)
                 $table = $this->table('users')->addTimestamps()->create();
+                // Use defaults (with timezones)
+                $table = $this->table('users')->addTimestampsWithTimezone()->create();
 
-                // Override the 'updated_at' column name with 'amended_at'.
-                $table = $this->table('books')->addTimestamps(null, 'amended_at')->create();
+                // Override the 'created_at' column name with 'recorded_at'.
+                $table = $this->table('books')->addTimestamps('recorded_at')->create();
 
-                // Use defaults, but with timezones
-                $table = $this->table('clocks')->addTimestamps(null, null, true)->create();
+                // Override the 'updated_at' column name with 'amended_at', preserving timezones.
+                // The two lines below do the same, the second one is simply cleaner.
+                $table = $this->table('books')->addTimestamps(null, 'amended_at', true)->create();
+                $table = $this->table('users')->addTimestampsWithTimezone(null, 'amended_at')->create();
             }
         }
 

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -472,22 +472,25 @@ class Table
      *
      * @param string|null $createdAtColumnName
      * @param string|null $updatedAtColumnName
+     * @param bool        $withTimezone
      *
      * @return \Phinx\Db\Table
      */
-    public function addTimestamps($createdAtColumnName = 'created_at', $updatedAtColumnName = 'updated_at')
+    public function addTimestamps($createdAtColumnName = 'created_at', $updatedAtColumnName = 'updated_at', $withTimezone = false)
     {
         $createdAtColumnName = is_null($createdAtColumnName) ? 'created_at' : $createdAtColumnName;
         $updatedAtColumnName = is_null($updatedAtColumnName) ? 'updated_at' : $updatedAtColumnName;
 
         $this->addColumn($createdAtColumnName, 'timestamp', [
-                'default' => 'CURRENT_TIMESTAMP',
-                'update' => ''
-            ])
-             ->addColumn($updatedAtColumnName, 'timestamp', [
-                 'null' => true,
-                 'default' => null
-             ]);
+                   'default' => 'CURRENT_TIMESTAMP',
+                   'update' => '',
+                   'timezone' => $withTimezone,
+               ])
+               ->addColumn($updatedAtColumnName, 'timestamp', [
+                   'null' => true,
+                   'default' => null,
+                   'timezone' => $withTimezone,
+               ]);
 
         return $this;
     }

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -470,23 +470,23 @@ class Table
     /**
      * Add timestamp columns created_at and updated_at to the table.
      *
-     * @param string|null $createdAtColumnName
-     * @param string|null $updatedAtColumnName
-     * @param bool        $withTimezone
+     * @param string|null $createdAt    Alternate name for the created_at column
+     * @param string|null $updatedAt    Alternate name for the updated_at column
+     * @param bool        $withTimezone Whether to set the timezone option on the added columns
      *
      * @return \Phinx\Db\Table
      */
-    public function addTimestamps($createdAtColumnName = 'created_at', $updatedAtColumnName = 'updated_at', $withTimezone = false)
+    public function addTimestamps($createdAt = 'created_at', $updatedAt = 'updated_at', $withTimezone = false)
     {
-        $createdAtColumnName = is_null($createdAtColumnName) ? 'created_at' : $createdAtColumnName;
-        $updatedAtColumnName = is_null($updatedAtColumnName) ? 'updated_at' : $updatedAtColumnName;
+        $createdAt = is_null($createdAt) ? 'created_at' : $createdAt;
+        $updatedAt = is_null($updatedAt) ? 'updated_at' : $updatedAt;
 
-        $this->addColumn($createdAtColumnName, 'timestamp', [
+        $this->addColumn($createdAt, 'timestamp', [
                    'default' => 'CURRENT_TIMESTAMP',
                    'update' => '',
                    'timezone' => $withTimezone,
                ])
-               ->addColumn($updatedAtColumnName, 'timestamp', [
+               ->addColumn($updatedAt, 'timestamp', [
                    'null' => true,
                    'default' => null,
                    'timezone' => $withTimezone,
@@ -499,14 +499,14 @@ class Table
      * Alias that always sets $withTimezone to true
      * @see addTimestamps
      *
-     * @param string|null $createdAtColumnName
-     * @param string|null $updatedAtColumnName
+     * @param string|null $createdAt Alternate name for the created_at column
+     * @param string|null $updatedAt Alternate name for the updated_at column
      *
      * @return \Phinx\Db\Table
      */
-    public function addTimestampsWithTimezone($createdAtColumnName = null, $updatedAtColumnName = null)
+    public function addTimestampsWithTimezone($createdAt = null, $updatedAt = null)
     {
-        $this->addTimestamps($createdAtColumnName, $updatedAtColumnName, true);
+        $this->addTimestamps($createdAt, $updatedAt, true);
 
         return $this;
     }

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -485,12 +485,12 @@ class Table
                    'default' => 'CURRENT_TIMESTAMP',
                    'update' => '',
                    'timezone' => $withTimezone,
-               ])
-               ->addColumn($updatedAt, 'timestamp', [
-                   'null' => true,
-                   'default' => null,
-                   'timezone' => $withTimezone,
-               ]);
+             ])
+             ->addColumn($updatedAt, 'timestamp', [
+                 'null' => true,
+                 'default' => null,
+                 'timezone' => $withTimezone,
+             ]);
 
         return $this;
     }

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -496,6 +496,22 @@ class Table
     }
 
     /**
+     * Alias that always sets $withTimezone to true
+     * @see addTimestamps
+     *
+     * @param string|null $createdAtColumnName
+     * @param string|null $updatedAtColumnName
+     *
+     * @return \Phinx\Db\Table
+     */
+    public function addTimestampsWithTimezone($createdAtColumnName = null, $updatedAtColumnName = null)
+    {
+        $this->addTimestamps($createdAtColumnName, $updatedAtColumnName, true);
+
+        return $this;
+    }
+
+    /**
      * Insert data into the table.
      *
      * @param array $data array of data in the form:


### PR DESCRIPTION
This PR adds a third argument to `Db\Table::addTimestamps` which lets the developer control whether the timestamp columns being added will retain the timezone information. I also fixed the indentation being all over the place in that method.

This is the cleanest solution I could think of to add support for changing this value, but I'm open to feedback.