### PR TITLE
Fix for always printing extended version info

### DIFF
--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -80,7 +80,7 @@ class PhinxApplication extends Application
     {
         // always show the version information except when the user invokes the help
         // command as that already does it
-        if ($input->hasParameterOption(['--help', '-h']) === false && $input->getFirstArgument() !== null && $input->getFirstArgument() !== 'list') {
+        if (($input->hasParameterOption(['--help', '-h']) !== false) || ($input->getFirstArgument() !== null && $input->getFirstArgument() !== 'list')) {
             $output->writeln($this->getLongVersion());
             $output->writeln('');
         }


### PR DESCRIPTION
It's apparant that this section of code was trying to always print an
extended version string because Symfony console only does it for certain
tasks by default.

Previously:
$ ./bin/phinx |head -3
```
Phinx by CakePHP - https://phinx.org. 0.10.0

Usage:
```
$ ./bin/phinx -h|head -3
```
Description:
  Lists commands
```
$ ./bin/phinx help|head -3
```
Phinx by CakePHP - https://phinx.org. 0.10.0

Description:
```
$ ./bin/phinx list|head -3
```
Phinx by CakePHP - https://phinx.org. 0.10.0

Usage:
```

After patch:

$ ./bin/phinx |head -3
```
Phinx by CakePHP - https://phinx.org. 0.10.0

Usage:
```
$ ./bin/phinx -h|head -3
```
Phinx by CakePHP - https://phinx.org. 0.10.0

Description:
```
$ ./bin/phinx help|head -3
```
Phinx by CakePHP - https://phinx.org. 0.10.0

Description:
```
$ ./bin/phinx list|head -3
```
Phinx by CakePHP - https://phinx.org. 0.10.0

Usage:
```