### PR TITLE
Making dropTable work again and deprecating it

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -316,11 +316,12 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * A short-hand method to drop the given database table.
      *
+     * @deprecated Please use $this->table($tableName)->drop()->save()
      * @param string $tableName Table Name
      * @return void
      */
     public function dropTable($tableName)
     {
-        $this->table($tableName)->drop();
+        $this->table($tableName)->drop()->save();
     }
 }


### PR DESCRIPTION
There is little point of having yet another way of dropping a table. Migrations should happen only through the Table class.

refs #1367 