### PR TITLE
Allow file suffix db adapter option for sqlite

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -304,6 +304,7 @@ Declaring an SQLite database uses a simplified structure:
         development:
             adapter: sqlite
             name: ./data/derby
+            suffix: ".db"    # Defaults to ".sqlite3"
         testing:
             adapter: sqlite
             memory: true     # Setting memory to *any* value overrides name

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -54,6 +54,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         'NVARCHAR'
     ];
 
+    protected $suffix = '.sqlite3';
+
     /**
      * {@inheritdoc}
      */
@@ -74,8 +76,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                 $dsn = 'sqlite::memory:';
             } else {
                 $dsn = 'sqlite:' . $options['name'];
-                if (file_exists($options['name'] . '.sqlite3')) {
-                    $dsn = 'sqlite:' . $options['name'] . '.sqlite3';
+                if (file_exists($options['name'] . $this->suffix)) {
+                    $dsn = 'sqlite:' . $options['name'] . $this->suffix;
                 }
             }
 
@@ -92,6 +94,25 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $this->setConnection($db);
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options)
+    {
+        parent::setOptions($options);
+
+        if (isset($options['suffix'])) {
+            $this->suffix = $options['suffix'];
+        }
+        if (substr($this->suffix, 0,1) !== '.') {
+            $this->suffix = '.'.$this->suffix;
+        }
+
+        return $this;
+    }
+
+
 
     /**
      * {@inheritdoc}
@@ -932,7 +953,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function createDatabase($name, $options = [])
     {
-        touch($name . '.sqlite3');
+        touch($name . $this->suffix);
     }
 
     /**
@@ -940,7 +961,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasDatabase($name)
     {
-        return is_file($name . '.sqlite3');
+        return is_file($name . $this->suffix);
     }
 
     /**
@@ -1092,8 +1113,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         if (!empty($options['name'])) {
             $options['database'] = $options['name'];
 
-            if (file_exists($options['name'] . '.sqlite3')) {
-                $options['database'] = $options['name'] . '.sqlite3';
+            if (file_exists($options['name'] . $this->suffix)) {
+                $options['database'] = $options['name'] . $this->suffix;
             }
         }
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -75,10 +75,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             if (isset($options['memory'])) {
                 $dsn = 'sqlite::memory:';
             } else {
-                $dsn = 'sqlite:' . $options['name'];
-                if (file_exists($options['name'] . $this->suffix)) {
-                    $dsn = 'sqlite:' . $options['name'] . $this->suffix;
-                }
+                $dsn = 'sqlite:' . $options['name'].$this->suffix;
             }
 
             try {

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -105,14 +105,12 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         if (isset($options['suffix'])) {
             $this->suffix = $options['suffix'];
         }
-        if (substr($this->suffix, 0,1) !== '.') {
+        if (substr($this->suffix, 0, 1) !== '.') {
             $this->suffix = '.'.$this->suffix;
         }
 
         return $this;
     }
-
-
 
     /**
      * {@inheritdoc}

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -75,7 +75,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             if (isset($options['memory'])) {
                 $dsn = 'sqlite::memory:';
             } else {
-                $dsn = 'sqlite:' . $options['name'].$this->suffix;
+                $dsn = 'sqlite:' . $options['name'] . $this->suffix;
             }
 
             try {
@@ -102,7 +102,9 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         if (isset($options['suffix'])) {
             $this->suffix = $options['suffix'];
         }
-        if (substr($this->suffix, 0, 1) !== '.') {
+        //don't "fix" the file extension if it is blank, some people
+        //might want a SQLITE db file with absolutely no extension.
+        if (strlen($this->suffix) && substr($this->suffix, 0, 1) !== '.') {
             $this->suffix = '.' . $this->suffix;
         }
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -103,7 +103,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $this->suffix = $options['suffix'];
         }
         if (substr($this->suffix, 0, 1) !== '.') {
-            $this->suffix = '.'.$this->suffix;
+            $this->suffix = '.' . $this->suffix;
         }
 
         return $this;


### PR DESCRIPTION
The file extension was hardcoded to ".sqlite3", this allows for
overriding that in the phinx.yml options for database adapters.

Partially fixes #1245