### PR TITLE
Add deprecated warning to insert() and trigger_error on both

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -297,8 +297,7 @@ insert methods in your migrations.
                     ]
                 ];
 
-                // this is a handy shortcut
-                $this->insert('status', $rows);
+                $this->table('status')->insert($rows)->save();
             }
 
             /**

--- a/docs/seeding.rst
+++ b/docs/seeding.rst
@@ -178,7 +178,7 @@ Then use it in your seed classes:
                     ];
                 }
 
-                $this->insert('users', $data)->save();
+                $this->table('users')->insert($data)->save();
             }
         }
 

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -274,6 +274,7 @@ abstract class AbstractMigration implements MigrationInterface
      */
     public function insert($table, $data)
     {
+        trigger_error('insert() is deprecated since 0.10.0, to be removed in 0.11.0. Use $this->table($tableName)->insert($data)->save() instead.', E_USER_DEPRECATED);
         // convert to table object
         if (is_string($table)) {
             $table = new Table($table, [], $this->getAdapter());
@@ -316,12 +317,13 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * A short-hand method to drop the given database table.
      *
-     * @deprecated Please use $this->table($tableName)->drop()->save()
+     * @deprecated since 0.10.0, to be removed in 0.11.0. Use $this->table($tableName)->drop()->save() instead.
      * @param string $tableName Table Name
      * @return void
      */
     public function dropTable($tableName)
     {
+        trigger_error('dropTable() is deprecated since 0.10.0, to be removed in 0.11.0. Use \$this->table(\$tableName)->drop()->save() instead.', E_USER_DEPRECATED);
         $this->table($tableName)->drop()->save();
     }
 }

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -274,7 +274,7 @@ abstract class AbstractMigration implements MigrationInterface
      */
     public function insert($table, $data)
     {
-        trigger_error('insert() is deprecated since 0.10.0, to be removed in 0.11.0. Use $this->table($tableName)->insert($data)->save() instead.', E_USER_DEPRECATED);
+        trigger_error('insert() is deprecated since 0.10.0. Use $this->table($tableName)->insert($data)->save() instead.', E_USER_DEPRECATED);
         // convert to table object
         if (is_string($table)) {
             $table = new Table($table, [], $this->getAdapter());
@@ -317,13 +317,13 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * A short-hand method to drop the given database table.
      *
-     * @deprecated since 0.10.0, to be removed in 0.11.0. Use $this->table($tableName)->drop()->save() instead.
+     * @deprecated since 0.10.0. Use $this->table($tableName)->drop()->save() instead.
      * @param string $tableName Table Name
      * @return void
      */
     public function dropTable($tableName)
     {
-        trigger_error('dropTable() is deprecated since 0.10.0, to be removed in 0.11.0. Use \$this->table(\$tableName)->drop()->save() instead.', E_USER_DEPRECATED);
+        trigger_error('dropTable() is deprecated since 0.10.0. Use \$this->table(\$tableName)->drop()->save() instead.', E_USER_DEPRECATED);
         $this->table($tableName)->drop()->save();
     }
 }

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -205,7 +205,7 @@ interface MigrationInterface
     /**
      * Insert data into a table.
      *
-     * @deprecated since 0.10.0, to be removed in 0.11.0. Use $this->table($tableName)->insert($data)->save() instead.
+     * @deprecated since 0.10.0. Use $this->table($tableName)->insert($data)->save() instead.
      *
      * @param string $tableName
      * @param array $data

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -205,6 +205,8 @@ interface MigrationInterface
     /**
      * Insert data into a table.
      *
+     * @deprecated since 0.10.0, to be removed in 0.11.0. Use $this->table($tableName)->insert($data)->save() instead.
+     *
      * @param string $tableName
      * @param array $data
      * @return void

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -190,7 +190,15 @@ class AbstractMigrationTest extends TestCase
         $table = new Table('testdb', [], $adapterStub);
 
         $migrationStub->setAdapter($adapterStub);
-        @$migrationStub->insert($table, ['row' => 'value']);
+        if (PHP_VERSION_ID < 70000) {
+            $class = \PHPUnit_Framework_Error_Deprecated::class;
+        }
+        else {
+            $class = \PHPUnit\Framework\Error\Deprecated::class;
+        }
+        $class::$enabled = false;
+        $migrationStub->insert($table, ['row' => 'value']);
+        $class::$enabled = true;
     }
 
     public function testInsertString()
@@ -206,7 +214,15 @@ class AbstractMigrationTest extends TestCase
             ->method('bulkinsert');
 
         $migrationStub->setAdapter($adapterStub);
-        @$migrationStub->insert('testdb', ['row' => 'value']);
+        if (PHP_VERSION_ID < 70000) {
+            $class = \PHPUnit_Framework_Error_Deprecated::class;
+        }
+        else {
+            $class = \PHPUnit\Framework\Error\Deprecated::class;
+        }
+        $class::$enabled = false;
+        $migrationStub->insert('testdb', ['row' => 'value']);
+        $class::$enabled = true;
     }
 
     public function testInsertDeprecated()

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -175,7 +175,7 @@ class AbstractMigrationTest extends TestCase
         $this->assertEquals([['0' => 'bar', 'foo' => 'bar']], $migrationStub->fetchAll('SELECT FOO FROM BAR'));
     }
 
-    public function testInsert()
+    public function testInsertTable()
     {
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
@@ -190,7 +190,32 @@ class AbstractMigrationTest extends TestCase
         $table = new Table('testdb', [], $adapterStub);
 
         $migrationStub->setAdapter($adapterStub);
-        $migrationStub->insert($table, ['row' => 'value']);
+        @$migrationStub->insert($table, ['row' => 'value']);
+    }
+
+    public function testInsertString() {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+
+        // stub adapter
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+            ->method('bulkinsert');
+
+        $migrationStub->setAdapter($adapterStub);
+        @$migrationStub->insert('testdb', ['row' => 'value']);
+    }
+
+    /**
+     * @expectedException \PHPUnit\Framework\Error\Deprecated
+     */
+    public function testInsertDeprecated()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+        $migrationStub->insert('testdb', ['row' => 'value']);
     }
 
     public function testCreateDatabase()
@@ -259,5 +284,15 @@ class AbstractMigrationTest extends TestCase
             'Phinx\Db\Table',
             $migrationStub->table('test_table')
         );
+    }
+
+    /**
+     * @expectedException \PHPUnit\Framework\Error\Deprecated
+     */
+    public function testDropTableDeprecated()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+        $migrationStub->dropTable('test_table');
     }
 }

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -208,11 +208,14 @@ class AbstractMigrationTest extends TestCase
         @$migrationStub->insert('testdb', ['row' => 'value']);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Deprecated
-     */
     public function testInsertDeprecated()
     {
+        if (PHP_VERSION_ID < 70000) {
+            $this->expectException(\PHPUnit_Framework_Error_Deprecated::class);
+        }
+        else {
+            $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
+        }
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
         $migrationStub->insert('testdb', ['row' => 'value']);
@@ -286,11 +289,14 @@ class AbstractMigrationTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Deprecated
-     */
     public function testDropTableDeprecated()
     {
+        if (PHP_VERSION_ID < 70000) {
+            $this->expectException(\PHPUnit_Framework_Error_Deprecated::class);
+        }
+        else {
+            $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
+        }
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
         $migrationStub->dropTable('test_table');

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -190,15 +190,7 @@ class AbstractMigrationTest extends TestCase
         $table = new Table('testdb', [], $adapterStub);
 
         $migrationStub->setAdapter($adapterStub);
-        if (PHP_VERSION_ID < 70000) {
-            $class = \PHPUnit_Framework_Error_Deprecated::class;
-        }
-        else {
-            $class = \PHPUnit\Framework\Error\Deprecated::class;
-        }
-        $class::$enabled = false;
-        $migrationStub->insert($table, ['row' => 'value']);
-        $class::$enabled = true;
+        @$migrationStub->insert($table, ['row' => 'value']);
     }
 
     public function testInsertString()
@@ -214,15 +206,7 @@ class AbstractMigrationTest extends TestCase
             ->method('bulkinsert');
 
         $migrationStub->setAdapter($adapterStub);
-        if (PHP_VERSION_ID < 70000) {
-            $class = \PHPUnit_Framework_Error_Deprecated::class;
-        }
-        else {
-            $class = \PHPUnit\Framework\Error\Deprecated::class;
-        }
-        $class::$enabled = false;
-        $migrationStub->insert('testdb', ['row' => 'value']);
-        $class::$enabled = true;
+        @$migrationStub->insert('testdb', ['row' => 'value']);
     }
 
     public function testInsertDeprecated()

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20170824134305_direction_aware_reversible_up.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20170824134305_direction_aware_reversible_up.php
@@ -13,7 +13,7 @@ class DirectionAwareReversibleUp extends AbstractMigration
             ->create();
 
         if ($this->isMigratingUp()) {
-            $this->insert('change_direction_test', [
+            $this->table('change_direction_test')->insert([
                 [
                     'thing' => 'one',
                 ],
@@ -26,7 +26,7 @@ class DirectionAwareReversibleUp extends AbstractMigration
                 [
                     'thing' => 'mouse_box',
                 ],
-            ]);
+            ])->save();
         }
     }
 }


### PR DESCRIPTION
Building off https://github.com/cakephp/phinx/issues/1367#issuecomment-396966171 and the previous commits of today on dropTable.

This adds a deprecated tag on insert() as well (to match dropTable's) and has both methods trigger a `E_USER_DEPRECATED` warning so as to be explicit about this going away (and to follow PHP's model of having deprecated functions issuing said warning).

I also added version information to the deprecated tag to show when it was deprecated. You may also want to add info when the functions will be removed.

The releases page probably should also be updated to reflect that these two functions are deprecated.