### PR TITLE
Warn when up or down will be ignored

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -326,4 +326,25 @@ abstract class AbstractMigration implements MigrationInterface
         trigger_error('dropTable() is deprecated since 0.10.0. Use $this->table($tableName)->drop()->save() instead.', E_USER_DEPRECATED);
         $this->table($tableName)->drop()->save();
     }
+
+
+    /**
+     * Perform checks on the migration, print a warning
+     * if there are potential problems.
+     *
+     * Right now, the only check is if there is both a `change()` and
+     * an `up()` or a `down()` method.
+     *
+     * @return void
+     */
+    public function preFlightCheck() {
+        if (method_exists($this, MigrationInterface::CHANGE)) {
+            if (method_exists($this, MigrationInterface::UP) ||
+                method_exists($this, MigrationInterface::DOWN) ) {
+                $this->output->writeln(sprintf(
+                    '<comment>warning</comment> Migration contains both change() and/or up()/down() methods.  <options=bold>Ignoring up() and down()</>.'
+                ));
+            }
+        }
+    }
 }

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -327,7 +327,6 @@ abstract class AbstractMigration implements MigrationInterface
         $this->table($tableName)->drop()->save();
     }
 
-
     /**
      * Perform checks on the migration, print a warning
      * if there are potential problems.
@@ -337,7 +336,8 @@ abstract class AbstractMigration implements MigrationInterface
      *
      * @return void
      */
-    public function preFlightCheck() {
+    public function preFlightCheck()
+    {
         if (method_exists($this, MigrationInterface::CHANGE)) {
             if (method_exists($this, MigrationInterface::UP) ||
                 method_exists($this, MigrationInterface::DOWN) ) {

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -380,6 +380,7 @@ class Manager
             ' <info>' . $migration->getVersion() . ' ' . $migration->getName() . ':</info>' .
             ' <comment>' . ($direction === MigrationInterface::UP ? 'migrating' : 'reverting') . '</comment>'
         );
+        $migration->preFlightCheck();
 
         // Execute the migration and log the time elapsed.
         $start = microtime(true);

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -248,4 +248,12 @@ interface MigrationInterface
      * @return \Phinx\Db\Table
      */
     public function table($tableName, $options);
+
+    /**
+     * Perform checks on the migration, print a warning
+     * if there are potential problems.
+     *
+     * @return void
+     */
+    public function preFlightCheck();
 }


### PR DESCRIPTION
The presence of the change() method ignores individual up() or down()
methods, but there is no warning to end users.  The preFlightCheck for
AbstractMigration allows the opportunity to warn about potential
conflicts.

Fixes #1329