### PR TITLE
Remove up/down functions from abstract

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -112,20 +112,6 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * {@inheritdoc}
      */
-    public function up()
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function down()
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function setAdapter(AdapterInterface $adapter)
     {
         $this->adapter = $adapter;

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -55,20 +55,6 @@ interface MigrationInterface
     const DOWN = 'down';
 
     /**
-     * Migrate Up
-     *
-     * @return void
-     */
-    public function up();
-
-    /**
-     * Migrate Down
-     *
-     * @return void
-     */
-    public function down();
-
-    /**
      * Sets the database adapter.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -7,20 +7,6 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractMigrationTest extends TestCase
 {
-    public function testUp()
-    {
-        // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
-        $this->assertNull($migrationStub->up());
-    }
-
-    public function testDown()
-    {
-        // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
-        $this->assertNull($migrationStub->down());
-    }
-
     public function testAdapterMethods()
     {
         // stub migration


### PR DESCRIPTION
With the change from #1375, all migrations that only use change throw a warning regardless of whether or not the migration file had an up/down function. This is because those functions always exist due to the AbstractMigration file. Given that the change function is not in the AbstractMigration (or MigrationInterface), to keep things consistent (and not show this warning always), can just remove the functions.