### PR TITLE
Don't complain about methods defined in parent

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -340,9 +340,18 @@ abstract class AbstractMigration implements MigrationInterface
      */
     public function preFlightCheck($direction = null)
     {
-        if (method_exists($this, MigrationInterface::CHANGE)) {
-            if (method_exists($this, MigrationInterface::UP) ||
-                method_exists($this, MigrationInterface::DOWN) ) {
+        $abstractBaseClassname = 'Phinx\Migration\AbstractMigration';
+        $refl   = new \ReflectionClass($this);
+        $change = $refl->getMethod('change');
+        if ($change->getDeclaringClass()->getName() != $abstractBaseClassname) {
+            //up() down() and change() are always defined
+            //at the AbstractMigration level.
+            //determine if we have overridden up or down via the subclass
+            $up   = $refl->getMethod('up');
+            $down = $refl->getMethod('down');
+
+            if ($up->getDeclaringClass()->getName()   != $abstractBaseClassname ||
+                $down->getDeclaringClass()->getName() != $abstractBaseClassname) {
                 $this->output->writeln(sprintf(
                     '<comment>warning</comment> Migration contains both change() and/or up()/down() methods.  <options=bold>Ignoring up() and down()</>.'
                 ));


### PR DESCRIPTION
The preFlightCheck ended up always throwing errors because up, down,
and change are *always* defined in AbstractMigration.  We can use
reflection instead of method_exists to check if up/down/change was
defined in the child migraiton class or not.