### PR TITLE
ISSUE-1038 Postgresql - seeding boolean column

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -228,6 +228,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         $columns = array_keys($row);
         $sql .= '(' . implode(', ', array_map([$this, 'quoteColumnName'], $columns)) . ')';
 
+        foreach ($row as $column => $value) {
+            if (is_bool($value)) {
+                $row[$column] = $this->castToBool($value);
+            }
+        }
+
         if ($this->isDryRunEnabled()) {
             $sql .= ' VALUES (' . implode(', ', array_map([$this, 'quoteValue'], $row)) . ');';
             $this->output->writeln($sql);
@@ -287,7 +293,11 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
 
             foreach ($rows as $row) {
                 foreach ($row as $v) {
-                    $vals[] = $v;
+                    if (is_bool($v)) {
+                        $vals[] = $this->castToBool($v);
+                    } else {
+                        $vals[] = $v;
+                    }
                 }
             }
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1463,6 +1463,30 @@ class PostgresAdapterTest extends TestCase
         $this->assertEquals('test', $rows[2]['column3']);
     }
 
+    public function testBulkInsertBoolean()
+    {
+        $data = [
+            [
+                'column1' => true,
+            ],
+            [
+                'column1' => false,
+            ],
+            [
+                'column1' => null,
+            ],
+        ];
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table->addColumn('column1', 'boolean', ['null' => true])
+            ->insert($data)
+            ->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+        $this->assertSame(true, $rows[0]['column1']);
+        $this->assertSame(false, $rows[1]['column1']);
+        $this->assertSame(null, $rows[2]['column1']);
+    }
+
     public function testInsertData()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
@@ -1485,6 +1509,31 @@ class PostgresAdapterTest extends TestCase
         $this->assertEquals('value2', $rows[1]['column1']);
         $this->assertEquals(1, $rows[0]['column2']);
         $this->assertEquals(2, $rows[1]['column2']);
+    }
+
+    public function testInsertBoolean()
+    {
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table->addColumn('column1', 'boolean', ['null' => true])
+            ->addColumn('column2', 'text', ['null' => true])
+            ->insert([
+                [
+                    'column1' => true,
+                    'column2' => 'value',
+                ],
+                [
+                    'column1' => false,
+                ],
+                [
+                    'column1' => null,
+                ],
+            ])
+            ->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+        $this->assertSame(true, $rows[0]['column1']);
+        $this->assertSame(false, $rows[1]['column1']);
+        $this->assertSame(null, $rows[2]['column1']);
     }
 
     public function testInsertDataWithSchema()


### PR DESCRIPTION
Postgresql - seeding boolean column gets: Invalid text representation for false value

https://github.com/cakephp/phinx/issues/1038