### PR TITLE
Add firing of events when migration and rollback happen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "cakephp/database": "^3.6",
         "symfony/console": "^2.8|^3.0|^4.0",
         "symfony/config": "^2.8|^3.0|^4.0",
-        "symfony/yaml": "^2.8|^3.0|^4.0"
+        "symfony/yaml": "^2.8|^3.0|^4.0",
+        "symfony/event-dispatcher": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "symfony/console": "^2.8|^3.0|^4.0",
         "symfony/config": "^2.8|^3.0|^4.0",
         "symfony/yaml": "^2.8|^3.0|^4.0",
-        "symfony/event-dispatcher": "^2.8|^3.0|^4.0"
+        "symfony/event-dispatcher": "^2.8|^3.0|^4.0",
+        "symfony/finder": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -139,6 +139,42 @@ You can also use the ``%%PHINX_CONFIG_DIR%%`` token in your path.
     paths:
         seeds: '%%PHINX_CONFIG_DIR%%/your/relative/path'
 
+Event Subscribers Paths
+----------
+
+The third option specifies the path to your event subscribers directory. Phinx uses
+``%%PHINX_CONFIG_DIR%%/db/subscribers`` by default.
+
+.. note::
+
+    ``%%PHINX_CONFIG_DIR%%`` is a special token and is automatically replaced
+    with the root directory where your ``phinx.yml`` file is stored.
+
+In order to overwrite the default ``%%PHINX_CONFIG_DIR%%/db/subscribers``, you
+need to add the following to the yaml configuration.
+
+.. code-block:: yaml
+
+    paths:
+        subscribers: /your/full/path
+
+You can also provide multiple seed paths by using an array in your configuration:
+
+.. code-block:: yaml
+
+    paths:
+        subscribers:
+            - /your/full/path1
+            - /your/full/path2
+
+
+You can also use the ``%%PHINX_CONFIG_DIR%%`` token in your path.
+
+.. code-block:: yaml
+
+    paths:
+        subscribers: '%%PHINX_CONFIG_DIR%%/your/relative/path'
+
 Environments
 ------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Contents
    migrations
    seeding
    commands
+   subscribers
    configuration
    copyright
 

--- a/docs/subscribers.rst
+++ b/docs/subscribers.rst
@@ -1,0 +1,30 @@
+.. index::
+single: Event Subscribers
+
+Commands ``migrate`` and ``rollback`` fire of events ``phinx.command.migrate`` and ``phinx.command.rollback`` accordingly. It allows developers to do some regular things after migrations and rollbacks through event subscribers.
+
+Every event subscriber must implement an interface ``\Symfony\Component\EventDispatcher\EventSubscriberInterface``. If it doesn't, then it will be skipped quietly.
+
+.. code-block:: php
+
+    <?php
+
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class ClearCache implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents()
+        {
+            return [
+                \Phinx\Console\CommandEvents::MIGRATE  => "onClearCache",
+                \Phinx\Console\CommandEvents::ROLLBACK => "onClearCache",
+            ];
+        }
+
+        public function onClearCache()
+        {
+            \\ do some things
+        }
+    }
+
+All event subscribers must be placed in the directory specified in the configuration file.

--- a/phinx.yml
+++ b/phinx.yml
@@ -1,6 +1,7 @@
 paths:
     migrations: '%%PHINX_CONFIG_DIR%%/db/migrations'
     seeds: '%%PHINX_CONFIG_DIR%%/db/seeds'
+    subscribers: '%%PHINX_CONFIG_DIR%%/db/subscribers'
 
 environments:
     default_migration_table: phinxlog

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -257,6 +257,18 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getSubscriberPaths()
+    {
+        if(!isset($this->values['paths']['subscribers'])){
+            return [];
+        }
+
+        return (array)$this->values['paths']['subscribers'];
+    }
+
+    /**
      * Gets the base class name for migrations.
      *
      * @param bool $dropNamespace Return the base migration class name without the namespace.

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -137,4 +137,11 @@ interface ConfigInterface extends \ArrayAccess
      * @return string
      */
     public function getMigrationBaseClassName($dropNamespace = true);
+
+    /**
+     * Gets paths of event subscribers
+     *
+     * @return string[]
+     */
+    public function getSubscriberPaths();
 }

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -379,6 +379,7 @@ abstract class AbstractCommand extends Command
      * Load all event subscribers
      *
      * @throws \ReflectionException
+     * @return void
      */
     protected function loadEventSubscribers()
     {

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -38,6 +38,10 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Abstract command, contains bootstrapping info
@@ -72,6 +76,11 @@ abstract class AbstractCommand extends Command
     protected $manager;
 
     /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    protected $dispatcher;
+
+    /**
      * {@inheritdoc}
      */
     protected function configure()
@@ -89,6 +98,8 @@ abstract class AbstractCommand extends Command
      */
     public function bootstrap(InputInterface $input, OutputInterface $output)
     {
+        $this->dispatcher = new EventDispatcher();
+
         if (!$this->getConfig()) {
             $this->loadConfig($input, $output);
         }

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -28,6 +28,8 @@
  */
 namespace Phinx\Console\Command;
 
+use Phinx\Console\CommandEvents;
+use Phinx\Event\GetInputEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -121,6 +123,8 @@ EOT
             $this->getManager()->migrate($environment, $version, $fake);
         }
         $end = microtime(true);
+
+        $this->dispatcher->dispatch(CommandEvents::MIGRATE, new GetInputEvent($input));
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -28,6 +28,8 @@
  */
 namespace Phinx\Console\Command;
 
+use Phinx\Console\CommandEvents;
+use Phinx\Event\GetInputEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -129,6 +131,8 @@ EOT
         $start = microtime(true);
         $this->getManager()->rollback($environment, $target, $force, $targetMustMatchVersion, $fake);
         $end = microtime(true);
+
+        $this->dispatcher->dispatch(CommandEvents::ROLLBACK, new GetInputEvent($input));
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');

--- a/src/Phinx/Console/CommandEvents.php
+++ b/src/Phinx/Console/CommandEvents.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phinx\Console;
+
+class CommandEvents
+{
+    /**
+     * The event occurs when a migration is completed
+     */
+    const MIGRATE = 'phinx.command.migrate';
+
+    /**
+     * The event occurs when rollback is completed
+     */
+    const ROLLBACK = 'phinx.command.rollback';
+}

--- a/src/Phinx/Event/GetInputEvent.php
+++ b/src/Phinx/Event/GetInputEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phinx\Event;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+class GetInputEvent extends Event
+{
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * GetInputEvent constructor.
+     *
+     * @param InputInterface $input
+     */
+    public function __construct(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+
+    /**
+     * Returns an input stream
+     *
+     * @return InputInterface
+     */
+    public function getInput()
+    {
+        return $this->input;
+    }
+}

--- a/src/Phinx/Event/GetInputEvent.php
+++ b/src/Phinx/Event/GetInputEvent.php
@@ -15,7 +15,7 @@ class GetInputEvent extends Event
     /**
      * GetInputEvent constructor.
      *
-     * @param InputInterface $input
+     * @param InputInterface $input input arguments and options
      */
     public function __construct(InputInterface $input)
     {


### PR DESCRIPTION
Sometimes we want do some things regularly after migrations or rollbacks. Before that changes we couldn't do that. But now we can make our own event subscribers and they will be called when one of the two commands call. Also we can refuse from subscribers and don't write them.