### PR TITLE
Add setPrecisionAndScale

### DIFF
--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -372,6 +372,21 @@ class Column
     }
 
     /**
+     * Sets the column precision and scale for decimal.
+     *
+     * @param int $precision
+     * @param int $scale
+     * @return \Phinx\Db\Table\Column
+     */
+    public function setPrecisionAndScale($precision, $scale)
+    {
+        $this->precision = $precision;
+        $this->scale = $scale;
+
+        return $this;
+    }
+
+    /**
      * Sets the column comment.
      *
      * @param string $comment

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -326,9 +326,12 @@ class Column
     }
 
     /**
-     * Sets the column precision for decimal.
+     * Sets the number precision for decimal or float column.
      *
-     * @param int $precision
+     * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
+     * and the column could store value from -999.99 to 999.99.
+     *
+     * @param int $precision Number precision
      * @return \Phinx\Db\Table\Column
      */
     public function setPrecision($precision)
@@ -339,7 +342,10 @@ class Column
     }
 
     /**
-     * Gets the column precision for decimal.
+     * Gets the number precision for decimal or float column.
+     *
+     * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
+     * and the column could store value from -999.99 to 999.99.
      *
      * @return int
      */
@@ -349,9 +355,12 @@ class Column
     }
 
     /**
-     * Sets the column scale for decimal.
+     * Sets the number scale for decimal or float column.
      *
-     * @param int $scale
+     * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
+     * and the column could store value from -999.99 to 999.99.
+     *
+     * @param int $scale Number scale
      * @return \Phinx\Db\Table\Column
      */
     public function setScale($scale)
@@ -362,7 +371,10 @@ class Column
     }
 
     /**
-     * Gets the column scale for decimal.
+     * Gets the number scale for decimal or float column.
+     *
+     * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
+     * and the column could store value from -999.99 to 999.99.
      *
      * @return int
      */
@@ -372,10 +384,13 @@ class Column
     }
 
     /**
-     * Sets the column precision and scale for decimal.
+     * Sets the number precision and scale for decimal or float column.
      *
-     * @param int $precision Column precision
-     * @param int $scale Column scale
+     * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
+     * and the column could store value from -999.99 to 999.99.
+     *
+     * @param int $precision Number precision
+     * @param int $scale Number scale
      * @return \Phinx\Db\Table\Column
      */
     public function setPrecisionAndScale($precision, $scale)

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -374,8 +374,8 @@ class Column
     /**
      * Sets the column precision and scale for decimal.
      *
-     * @param int $precision
-     * @param int $scale
+     * @param int $precision Column precision
+     * @param int $scale Column scale
      * @return \Phinx\Db\Table\Column
      */
     public function setPrecisionAndScale($precision, $scale)


### PR DESCRIPTION
Precision and scale usually used together. Add setter to set both parameters at once, so they look like in SQL datatype `DECIMAL(11, 3)`. This also helps prevent from mixing precision and scale.