### PR TITLE
Implement Table::change

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -539,6 +539,55 @@ Option    Description
 comment   set a text comment on the table
 ========= ===========
 
+Changing Table Options
+~~~~~~~~~~~~~~~~~~~~~~
+
+To change the options on an existing table, use the ``change()`` method.
+Options ``id`` and ``primary_key`` are used to determine the primary key on the table, same as when creating a new table.
+Also see `Creating a Table`_ for lists of additional supported options for each adapter.
+
+In the following example, a table is initially created with the default primary key, no table comment, and two columns.
+Then another column is added, and the ``change()`` method is used to remove the default primary key,
+set the 'new_id' column to be the new primary key, and add a new comment on the table.
+
+.. code-block:: php
+
+        <?php
+
+        use Phinx\Migration\AbstractMigration;
+
+        class MyNewMigration extends AbstractMigration
+        {
+            /**
+             * Migrate Up.
+             */
+            public function up()
+            {
+                $users = $this->table('users');
+                $users
+                    ->addColumn('username', 'string', ['limit' => 20])
+                    ->addColumn('password', 'string', ['limit' => 40])
+                    ->save();
+
+                $users
+                    ->addColumn('new_id', 'integer', ['null' => false])
+                    ->change([
+                        'id' => false,
+                        'primary_key' => 'new_id',
+                        'comment' => 'Some comment',
+                    ])
+                    ->save();
+            }
+
+            /**
+             * Migrate Down.
+             */
+            public function down()
+            {
+
+            }
+        }
+
 Valid Column Types
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/Phinx/Db/Action/ChangeTable.php
+++ b/src/Phinx/Db/Action/ChangeTable.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+namespace Phinx\Db\Action;
+
+use Phinx\Db\Table\Table;
+
+class ChangeTable extends Action
+{
+
+    /**
+     * The new options for the table
+     *
+     * @var array
+     */
+    protected $newOptions;
+
+    /**
+     * Constructor
+     *
+     * @param Table $table The table to be renamed
+     * @param array $newOptions The new options for the table
+     */
+    public function __construct(Table $table, array $newOptions)
+    {
+        parent::__construct($table);
+        $this->newOptions = $newOptions;
+    }
+
+    /**
+     * Return the new options for the table
+     *
+     * @return array
+     */
+    public function getNewOptions()
+    {
+        return $this->newOptions;
+    }
+}

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -225,7 +225,7 @@ abstract class AbstractAdapter implements AdapterInterface
         } catch (\Exception $exception) {
             throw new \InvalidArgumentException(
                 'There was a problem creating the schema table: ' . $exception->getMessage(),
-                $exception->getCode(),
+                intval($exception->getCode()),
                 $exception
             );
         }

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -348,6 +348,15 @@ interface AdapterInterface
     public function createTable(Table $table, array $columns = [], array $indexes = []);
 
     /**
+     * Creates the specified database table.
+     *
+     * @param \Phinx\Db\Table\Table $table Table
+     * @param array $newOptions New options for the table
+     * @return void
+     */
+    public function changeTable(Table $table, array $newOptions);
+
+    /**
      * Truncates the specified table
      *
      * @param string $tableName
@@ -389,6 +398,16 @@ interface AdapterInterface
      * @return bool
      */
     public function hasIndexByName($tableName, $indexName);
+
+    /**
+     * Checks to see if the specified primary key exists.
+     *
+     * @param string   $tableName
+     * @param string[] $columns    Column(s)
+     * @param string   $constraint Constraint name
+     * @return bool
+     */
+    public function hasPrimaryKey($tableName, $columns, $constraint = null);
 
     /**
      * Checks to see if a foreign key exists.

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -236,7 +236,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function toggleBreakpoint(MigrationInterface $migration)
     {
@@ -246,7 +246,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function resetAllBreakpoints()
     {
@@ -352,6 +352,14 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
+    public function changeTable(Table $table, array $newOptions)
+    {
+        $this->getAdapter()->changeTable($table, $newOptions);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getColumns($tableName)
     {
         return $this->getAdapter()->getColumns($tableName);
@@ -379,6 +387,14 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     public function hasIndexByName($tableName, $indexName)
     {
         return $this->getAdapter()->hasIndexByName($tableName, $indexName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    {
+        return $this->getAdapter()->hasPrimaryKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -301,6 +301,104 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
+    protected function getChangeTableInstructions(Table $table, array $newOptions)
+    {
+        $instructions = new AlterInstructions();
+
+        // Drop the existing primary key
+        $primaryKey = $this->getPrimaryKey($table->getName());
+        if ((isset($newOptions['id']) || isset($newOptions['primary_key']))
+            && !empty($primaryKey['columns']))
+        {
+            foreach ($primaryKey['columns'] as $column) {
+                $sql = sprintf(
+                    'MODIFY %s INT NOT NULL',
+                    $this->quoteColumnName($column)
+                );
+                $instructions->addAlter($sql);
+            }
+            $instructions->addAlter('DROP PRIMARY KEY');
+        }
+
+        // Set the default primary key and add associated column
+        if (isset($newOptions['id']) && $newOptions['id'] !== false) {
+            if ($newOptions['id'] === true) {
+                $newOptions['primary_key'] = 'id';
+            } else if (is_string($newOptions['id'])) {
+                // Handle id => "field_name" to support AUTO_INCREMENT
+                $newOptions['primary_key'] = $newOptions['id'];
+            } else {
+                throw new \InvalidArgumentException(sprintf(
+                    "Invalid value for option 'id': %s",
+                    json_encode($newOptions['id'])
+                ));
+            }
+
+            if ($this->hasColumn($table->getName(), $newOptions['primary_key'])) {
+                throw new \RuntimeException(sprintf(
+                    "Tried to create primary key column %s for table %s, but that column already exists",
+                    $this->quoteColumnName($newOptions['primary_key']),
+                    $this->quoteTableName($table->getName())
+                ));
+            }
+
+            $column = new Column();
+            $column
+                ->setName($newOptions['primary_key'])
+                ->setType('integer')
+                ->setSigned(isset($newOptions['signed']) ? $newOptions['signed'] : true)
+                ->setIdentity(true);
+            $instructions->merge($this->getAddColumnInstructions($table, $column));
+        }
+
+        // Add the primary key(s)
+        if (isset($newOptions['primary_key']) && $newOptions['primary_key'] !== false) {
+            $sql = 'ADD PRIMARY KEY (';
+            if (is_string($newOptions['primary_key'])) { // handle primary_key => 'id'
+                $sql .= $this->quoteColumnName($newOptions['primary_key']);
+            } else if (is_array($newOptions['primary_key'])) { // handle primary_key => array('tag_id', 'resource_id')
+                $sql .= implode(',', array_map([$this, 'quoteColumnName'], $newOptions['primary_key']));
+            } else {
+                throw new \InvalidArgumentException(sprintf(
+                    "Invalid value for option 'primary_key': %s",
+                    json_encode($newOptions['primary_key'])
+                ));
+            }
+            $sql .= ')';
+            $instructions->addAlter($sql);
+        }
+
+        // process table engine (default to InnoDB)
+        $optionsStr = 'ENGINE = InnoDB';
+        if (isset($newOptions['engine'])) {
+            $optionsStr = sprintf('ENGINE = %s', $newOptions['engine']);
+        }
+        // process table collation
+        if (isset($newOptions['collation'])) {
+            $charset = explode('_', $newOptions['collation']);
+            $optionsStr .= sprintf(' CHARACTER SET %s', $charset[0]);
+            $optionsStr .= sprintf(' COLLATE %s', $newOptions['collation']);
+        }
+        // set the table comment
+        if (array_key_exists('comment', $newOptions)) {
+            // passing 'null' is to remove table comment
+            $newComment = ($newOptions['comment'] !== null)
+                ? $newOptions['comment']
+                : '';
+            $optionsStr .= sprintf(" COMMENT=%s ", $this->getConnection()->quote($newComment));
+        }
+        // set the table row format
+        if (isset($newOptions['row_format'])) {
+            $optionsStr .= sprintf(" ROW_FORMAT=%s ", $newOptions['row_format']);
+        }
+        $instructions->addAlter($optionsStr);
+
+        return $instructions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getRenameTableInstructions($tableName, $newTableName)
     {
         $sql = sprintf(
@@ -579,6 +677,58 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             "The specified index name '%s' does not exist",
             $indexName
         ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    {
+        $primaryKey = $this->getPrimaryKey($tableName);
+
+        if (empty($primaryKey['constraint'])) {
+            return false;
+        }
+
+        if ($constraint) {
+            return ($primaryKey['constraint'] === $constraint);
+        } else {
+            if (is_string($columns)) {
+                $columns = [$columns]; // str to array
+            }
+            $missingColumns = array_diff($columns, $primaryKey['columns']);
+            return empty($missingColumns);
+        }
+    }
+
+    /**
+     * Get the primary key from a particular table.
+     *
+     * @param string $tableName Table Name
+     * @return array
+     */
+    public function getPrimaryKey($tableName)
+    {
+        $rows = $this->fetchAll(sprintf(
+            "SELECT
+                k.constraint_name,
+                k.column_name
+            FROM information_schema.table_constraints t
+            JOIN information_schema.key_column_usage k
+                USING(constraint_name,table_name)
+            WHERE t.constraint_type='PRIMARY KEY'
+                AND t.table_name='%s'",
+            $tableName
+        ));
+
+        $primaryKey = [
+            'columns' => [],
+        ];
+        foreach ($rows as $row) {
+            $primaryKey['constraint'] = $row['constraint_name'];
+            $primaryKey['columns'][] = $row['column_name'];
+        }
+        return $primaryKey;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -40,6 +40,9 @@ use Phinx\Db\Action\RenameColumn;
 use Phinx\Db\Action\RenameTable;
 use Phinx\Db\Plan\Intent;
 use Phinx\Db\Plan\Plan;
+use Phinx\Db\Table\Column;
+use Phinx\Db\Table\ForeignKey;
+use Phinx\Db\Table\Index;
 use Phinx\Db\Table\Table;
 use Phinx\Migration\IrreversibleMigrationException;
 
@@ -140,5 +143,139 @@ class ProxyAdapter extends AdapterWrapper
     {
         $plan = new Plan($this->getInvertedCommands());
         $plan->executeInverse($this->getAdapter());
+    }
+
+    /**
+     * Renames the specified database table.
+     *
+     * @param string $tableName Table Name
+     * @param string $newName New Name
+     * @return void
+     */
+    public function renameTable($tableName, $newName)
+    {
+        // TODO: Implement renameTable() method.
+    }
+
+    /**
+     * Drops the specified database table.
+     *
+     * @param string $tableName Table Name
+     * @return void
+     */
+    public function dropTable($tableName)
+    {
+        // TODO: Implement dropTable() method.
+    }
+
+    /**
+     * Adds the specified column to a database table.
+     *
+     * @param \Phinx\Db\Table $table Table
+     * @param Column $column Column
+     * @return void
+     */
+    public function addColumn(\Phinx\Db\Table $table, Column $column)
+    {
+        // TODO: Implement addColumn() method.
+    }
+
+    /**
+     * Renames the specified column.
+     *
+     * @param string $tableName Table Name
+     * @param string $columnName Column Name
+     * @param string $newColumnName New Column Name
+     * @return void
+     */
+    public function renameColumn($tableName, $columnName, $newColumnName)
+    {
+        // TODO: Implement renameColumn() method.
+    }
+
+    /**
+     * Change a table column type.
+     *
+     * @param string $tableName Table Name
+     * @param string $columnName Column Name
+     * @param Column $newColumn New Column
+     * @return \Phinx\Db\Table
+     */
+    public function changeColumn($tableName, $columnName, Column $newColumn)
+    {
+        // TODO: Implement changeColumn() method.
+    }
+
+    /**
+     * Drops the specified column.
+     *
+     * @param string $tableName Table Name
+     * @param string $columnName Column Name
+     * @return void
+     */
+    public function dropColumn($tableName, $columnName)
+    {
+        // TODO: Implement dropColumn() method.
+    }
+
+    /**
+     * Adds the specified index to a database table.
+     *
+     * @param \Phinx\Db\Table $table Table
+     * @param Index $index Index
+     * @return void
+     */
+    public function addIndex(\Phinx\Db\Table $table, Index $index)
+    {
+        // TODO: Implement addIndex() method.
+    }
+
+    /**
+     * Drops the specified index from a database table.
+     *
+     * @param string $tableName
+     * @param mixed $columns Column(s)
+     * @return void
+     */
+    public function dropIndex($tableName, $columns)
+    {
+        // TODO: Implement dropIndex() method.
+    }
+
+    /**
+     * Drops the index specified by name from a database table.
+     *
+     * @param string $tableName
+     * @param string $indexName
+     * @return void
+     */
+    public function dropIndexByName($tableName, $indexName)
+    {
+        // TODO: Implement dropIndexByName() method.
+    }
+
+    /**
+     * Adds the specified foreign key to a database table.
+     *
+     * @param \Phinx\Db\Table $table
+     * @param ForeignKey $foreignKey
+     * @return void
+     */
+    public function addForeignKey(\Phinx\Db\Table $table, ForeignKey $foreignKey)
+    {
+        // TODO: Implement addForeignKey() method.
+    }
+
+    /**
+     * Drops the specified foreign key from a database table.
+     *
+     * @param string $tableName
+     * @param string[] $columns Column(s)
+     * @param string $constraint Constraint name
+     * @return void
+     */
+    public function dropForeignKey($tableName, $columns, $constraint = null)
+    {
+        // TODO: Implement dropForeignKey() method.
     }
 }

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -32,6 +32,7 @@ use Phinx\Db\Action\AddColumn;
 use Phinx\Db\Action\AddForeignKey;
 use Phinx\Db\Action\AddIndex;
 use Phinx\Db\Action\ChangeColumn;
+use Phinx\Db\Action\ChangeTable;
 use Phinx\Db\Action\DropForeignKey;
 use Phinx\Db\Action\DropIndex;
 use Phinx\Db\Action\DropTable;
@@ -80,6 +81,18 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
             $table->getOptions()
         );
         parent::createTable($adapterTable, $columns, $indexes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function changeTable(Table $table, array $newOptions)
+    {
+        $adapterTable = new Table(
+            $this->getAdapterTableName($table->getName()),
+            $table->getOptions()
+        );
+        parent::changeTable($adapterTable, $newOptions);
     }
 
     /**
@@ -254,6 +267,16 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * {@inheritdoc}
      */
+    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    {
+        $adapterTableName = $this->getAdapterTableName($tableName);
+
+        return parent::hasPrimaryKey($adapterTableName, $columns, $constraint);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasForeignKey($tableName, $columns, $constraint = null)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
@@ -391,6 +414,10 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
 
                 case ($action instanceof RenameTable):
                     $actions[$k] = new RenameTable($adapterTable, $action->getNewName());
+                    break;
+
+                case ($action instanceof ChangeTable):
+                    $actions[$k] = new ChangeTable($adapterTable, $action->getNewOptions());
                     break;
 
                 default:

--- a/src/Phinx/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Phinx/Db/Adapter/TimedOutputAdapter.php
@@ -142,6 +142,17 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * {@inheritdoc}
      */
+    public function changeTable(Table $table, array $newOptions)
+    {
+        $end = $this->startCommandTimer();
+        $this->writeCommand('changeTable', [$table->getName()]);
+        parent::changeTable($table, $newOptions);
+        $end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function renameTable($tableName, $newTableName)
     {
         $adapter = $this->getAdapter();

--- a/src/Phinx/Db/Plan/Plan.php
+++ b/src/Phinx/Db/Plan/Plan.php
@@ -28,6 +28,7 @@ use Phinx\Db\Action\AddColumn;
 use Phinx\Db\Action\AddForeignKey;
 use Phinx\Db\Action\AddIndex;
 use Phinx\Db\Action\ChangeColumn;
+use Phinx\Db\Action\ChangeTable;
 use Phinx\Db\Action\CreateTable;
 use Phinx\Db\Action\DropForeignKey;
 use Phinx\Db\Action\DropIndex;
@@ -286,7 +287,8 @@ class Plan
         collection($actions)
             ->filter(function ($action) {
                 return $action instanceof DropTable
-                    || $action instanceof RenameTable;
+                    || $action instanceof RenameTable
+                    || $action instanceof ChangeTable;
             })
             ->each(function ($action) {
                 $table = $action->getTable();

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -32,6 +32,7 @@ use Phinx\Db\Action\AddColumn;
 use Phinx\Db\Action\AddForeignKey;
 use Phinx\Db\Action\AddIndex;
 use Phinx\Db\Action\ChangeColumn;
+use Phinx\Db\Action\ChangeTable;
 use Phinx\Db\Action\CreateTable;
 use Phinx\Db\Action\DropColumn;
 use Phinx\Db\Action\DropForeignKey;
@@ -177,6 +178,17 @@ class Table
     public function rename($newTableName)
     {
         $this->actions->addAction(new RenameTable($this->table, $newTableName));
+
+        return $this;
+    }
+
+    /**
+     * @param array $options
+     * @return $this
+     */
+    public function change(array $options)
+    {
+        $this->actions->addAction(new ChangeTable($this->table, $options));
 
         return $this;
     }
@@ -659,5 +671,13 @@ class Table
 
         $plan = new Plan($this->actions);
         $plan->execute($this->getAdapter());
+
+        // If a ChangeTable action was executed,
+        // also change the options on this table instance to the new ones for consistency.
+        foreach ($this->actions->getActions() as $action) {
+            if ($action instanceof ChangeTable) {
+                $this->table->setOptions($action->getNewOptions());
+            }
+        }
     }
 }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -237,6 +237,68 @@ class SQLiteAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
+    public function testChangeTableAddDefaultPK()
+    {
+        $table = new \Phinx\Db\Table('table1', ['id' => false], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $table
+            ->change(['id' => true])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['id']));
+    }
+
+    public function testChangeTableDropDefaultPK()
+    {
+        $table = new \Phinx\Db\Table('table1', ['id' => true], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $table
+            ->change(['id' => false])
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['id']));
+    }
+
+    public function testChangeTableAddCustomPK()
+    {
+        $table = new \Phinx\Db\Table('table1', ['id' => false], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $table
+            ->change(['id' => false, 'primary_key' => 'column1'])
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['id']));
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['column1']));
+    }
+
+    public function testChangeTableDropCustomPK()
+    {
+        $table = new \Phinx\Db\Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $table
+            ->change(['primary_key' => false])
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['id']));
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
+    }
+
     public function testRenameTable()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -194,6 +194,62 @@ class SqlServerAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasIndexByName('table1', 'myemailindex'));
     }
 
+    public function testChangeTableAddDefaultPK()
+    {
+        $table = new \Phinx\Db\Table('table1', ['id' => false], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->save();
+
+        $table
+            ->change(['id' => true])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['id']));
+    }
+
+    public function testChangeTableDropDefaultPK()
+    {
+        $table = new \Phinx\Db\Table('table1', ['id' => true], $this->adapter);
+        $table->save();
+
+        $table
+            ->change(['id' => false])
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['id']));
+    }
+
+    public function testChangeTableAddCustomPK()
+    {
+        $table = new \Phinx\Db\Table('table1', ['id' => false], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->save();
+
+        $table
+            ->change(['id' => false, 'primary_key' => 'column1'])
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['id']));
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['column1']));
+    }
+
+    public function testChangeTableDropCustomPK()
+    {
+        $table = new \Phinx\Db\Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->save();
+
+        $table
+            ->change(['primary_key' => false])
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['id']));
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
+    }
+
     public function testRenameTable()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -6,6 +6,7 @@ use Phinx\Db\Action\AddColumn;
 use Phinx\Db\Action\AddForeignKey;
 use Phinx\Db\Action\AddIndex;
 use Phinx\Db\Action\ChangeColumn;
+use Phinx\Db\Action\ChangeTable;
 use Phinx\Db\Action\DropForeignKey;
 use Phinx\Db\Action\DropIndex;
 use Phinx\Db\Action\DropTable;
@@ -91,6 +92,23 @@ class TablePrefixAdapterTest extends TestCase
             ));
 
         $this->adapter->createTable($table);
+    }
+
+    public function testChangeTable()
+    {
+        $table = new Table('table');
+        $newOptions = ['id' => false, 'comment' => 'comment1'];
+
+        $expectedTable = new Table('pre_table_suf');
+        $this->mock
+            ->expects($this->once())
+            ->method('changeTable')
+            ->with(
+                $this->equalTo($expectedTable),
+                $this->equalTo($newOptions)
+            );
+
+        $this->adapter->changeTable($table, $newOptions);
     }
 
     public function testRenameTable()
@@ -243,6 +261,23 @@ class TablePrefixAdapterTest extends TestCase
         $this->adapter->dropIndexByName('table', 'index');
     }
 
+    public function testHasPrimaryKey()
+    {
+        $columns = [];
+        $constraint = null;
+
+        $this->mock
+            ->expects($this->once())
+            ->method('hasPrimaryKey')
+            ->with(
+                $this->equalTo('pre_table_suf'),
+                $this->equalTo($columns),
+                $this->equalTo($constraint)
+            );
+
+        $this->adapter->hasPrimaryKey('table', $columns, $constraint);
+    }
+
     public function testHasForeignKey()
     {
         $columns = [];
@@ -329,6 +364,7 @@ class TablePrefixAdapterTest extends TestCase
             [RemoveColumn::build($table, 'acolumn')],
             [RenameColumn::build($table, 'acolumn', 'another')],
             [new RenameTable($table, 'new_name')],
+            [new ChangeTable($table, ['id' => false, 'comment' => 'comment1'])],
         ];
     }
 


### PR DESCRIPTION
Addresses requests for being able to modify the primary key, as well as the table comment and other table options. Implemented and tested for all adapters. Check migrations.rst for explanation of how it works. Feedback is welcome!

Affected issues:
https://github.com/cakephp/phinx/issues/335
https://github.com/cakephp/phinx/issues/802