### PR TITLE
Boolean fields couldn't have default NULL

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -496,7 +496,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {
             $default = $this->castToBool($default);
-        } elseif ($columnType === static::PHINX_TYPE_BOOLEAN) {
+        } elseif ($default !== null && $columnType === static::PHINX_TYPE_BOOLEAN) {
             $default = $this->castToBool((bool)$default);
         }
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -433,10 +433,12 @@ class MysqlAdapterTest extends TestCase
         $table->save();
         $table->addColumn('default_true', 'boolean', ['default' => true])
               ->addColumn('default_false', 'boolean', ['default' => false])
+              ->addColumn('default_null', 'boolean', ['default' => null, 'null' => true])
               ->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
         $this->assertEquals('1', $rows[1]['Default']);
         $this->assertEquals('0', $rows[2]['Default']);
+        $this->assertNull($rows[3]['Default']);
     }
 
     public function testAddColumnWithDefaultLiteral()

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -343,6 +343,7 @@ class PostgresAdapterTest extends TestCase
         $table->save();
         $table->addColumn('default_true', 'boolean', ['default' => true])
               ->addColumn('default_false', 'boolean', ['default' => false])
+              ->addColumn('default_null', 'boolean', ['default' => null, 'null' => true])
               ->save();
         $columns = $this->adapter->getColumns('table1');
         foreach ($columns as $column) {
@@ -353,6 +354,9 @@ class PostgresAdapterTest extends TestCase
             if ($column->getName() == 'default_false') {
                 $this->assertNotNull($column->getDefault());
                 $this->assertEquals('false', $column->getDefault());
+            }
+            if ($column->getName() == 'default_null') {
+                $this->assertNull($column->getDefault());
             }
         }
     }


### PR DESCRIPTION
`$table->addColumn('column1', 'boolean', ['default' => null, 'null' => true])` was added as `column1 tinyint(1) NOT NULL DEFAULT 0`