### PR TITLE
Creating new Migration - without php in command // Update Docs

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -18,7 +18,7 @@ command:
 
 .. code-block:: bash
 
-        $ php vendor/bin/phinx create MyNewMigration
+        $ vendor/bin/phinx create MyNewMigration
 
 This will create a new migration in the format
 ``YYYYMMDDHHMMSS_my_new_migration.php``, where the first 14 characters are


### PR DESCRIPTION
Hey,
as far as I know, is it not possible to create migrations with `php vendor/bin/phinx create MyNewMigration` but with `vendor/bin/phinx create MyNewMigration`

#752 