### PR TITLE
Introduce deprecation and todo annotations in migration template

### DIFF
--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -117,12 +117,12 @@ class Environment
                         ->getWrapper('proxy', $this->getAdapter());
                     $migration->setAdapter($proxyAdapter);
                     /** @noinspection PhpUndefinedMethodInspection */
-                    $migration->change();
+                    $migration->change($direction);
                     $proxyAdapter->executeInvertedCommands();
                     $migration->setAdapter($this->getAdapter());
                 } else {
                     /** @noinspection PhpUndefinedMethodInspection */
-                    $migration->change();
+                    $migration->change($direction);
                 }
             } else {
                 $migration->{$direction}();

--- a/src/Phinx/Migration/Migration.template.php.dist
+++ b/src/Phinx/Migration/Migration.template.php.dist
@@ -3,6 +3,13 @@ $namespaceDefinition
 
 use $useClassName;
 
+/**
+ * $className migration
+ *
+ * @deprecated up() This method is deprecated and will be removed in a future release. Use change($direction).
+ * @deprecated down() This method is deprecated and will be removed in a future release. Use change($direction).
+ * @todo Refactor existing migrations from up()/down() to change($direction)
+ */
 class $className extends $baseClassName
 {
     /**
@@ -29,8 +36,10 @@ class $className extends $baseClassName
      *
      * Remember to call "create()" or "update()" and NOT "save()" when working
      * with the Table class.
+     *
+     * @param string|null $direction Will be \Phinx\Migration\MigrationInterface::UP or \Phinx\Migration\MigrationInterface::DOWN
      */
-    public function change()
+    public function change($direction = null)
     {
 
     }


### PR DESCRIPTION
Introduce deprecation of up() and down() and the support for $direction in change().
Introduce a todo for the users to refactor their existing migrations.
