### PR TITLE
Throw an error if there are pending changes when migration completes

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -147,6 +147,15 @@ class Table
     }
 
     /**
+     * Does the table have pending actions?
+     *
+     * @return bool
+     */
+    public function hasPendingActions() {
+        return count($this->actions->getActions()) > 0 || count($this->data) > 0;
+    }
+
+    /**
      * Does the table exist?
      *
      * @return bool

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -350,7 +350,7 @@ abstract class AbstractMigration implements MigrationInterface
      *
      * Right now, the only check is whether all changes were committed
      *
-     * @param string|null $direction
+     * @param string|null $direction direction of migration
      *
      * @return void
      */
@@ -360,7 +360,5 @@ abstract class AbstractMigration implements MigrationInterface
                 throw new \RuntimeException('Migration has pending actions after execution!');
             }
         }
-
-        return true;
     }
 }

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -77,6 +77,13 @@ abstract class AbstractMigration implements MigrationInterface
     protected $isMigratingUp = true;
 
     /**
+     * List of all the table objects created by this migration
+     *
+     * @var array
+     */
+    protected $tables = [];
+
+    /**
      * Class Constructor.
      *
      * @param string $environment Environment Detected
@@ -297,7 +304,9 @@ abstract class AbstractMigration implements MigrationInterface
      */
     public function table($tableName, $options = [])
     {
-        return new Table($tableName, $options, $this->getAdapter());
+        $table = new Table($tableName, $options, $this->getAdapter());
+        $this->tables[] = $table;
+        return $table;
     }
 
     /**
@@ -334,5 +343,24 @@ abstract class AbstractMigration implements MigrationInterface
                 ));
             }
         }
+    }
+
+    /**
+     * Perform checks on the migration after completion
+     *
+     * Right now, the only check is whether all changes were committed
+     *
+     * @param string|null $direction
+     *
+     * @return void
+     */
+    public function postFlightCheck($direction = null) {
+        foreach($this->tables as $table) {
+            if($table->hasPendingActions()) {
+                throw new \RuntimeException('Migration has pending actions after execution!');
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -387,6 +387,7 @@ class Manager
         $this->getEnvironment($name)->executeMigration($migration, $direction, $fake);
         $end = microtime(true);
 
+        $migration->postFlightCheck($direction);
         $this->getOutput()->writeln(
             ' ==' .
             ' <info>' . $migration->getVersion() . ' ' . $migration->getName() . ':</info>' .

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -244,4 +244,15 @@ interface MigrationInterface
      * @return void
      */
     public function preFlightCheck($direction = null);
+
+    /**
+     * Perform checks on the migration after completion
+     *
+     * Right now, the only check is whether all changes were committed
+     *
+     * @param string|null $direction direction of migration
+     *
+     * @return void
+     */
+    public function postFlightCheck($direction = null);
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -448,7 +448,8 @@ class MysqlAdapterTest extends TestCase
         $table->addColumn('default_ts', 'timestamp', ['default' => Literal::from('CURRENT_TIMESTAMP')])
               ->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
-        $this->assertEquals('CURRENT_TIMESTAMP', $rows[1]['Default']);
+        // MariaDB returns current_timestamp()
+        $this->assertTrue('CURRENT_TIMESTAMP' === $rows[1]['Default'] || 'current_timestamp()' === $rows[1]['Default']);
     }
 
     public function testAddIntegerColumnWithDefaultSigned()

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -272,6 +272,31 @@ class TableTest extends TestCase
         $this->assertEquals([], $table->getData());
     }
 
+    public function testPendingAfterAddingData()
+    {
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
+        $columns = ["column1"];
+        $data = [["value1"]];
+        $table->insert($columns, $data);
+        $this->assertEquals(true, $table->hasPendingActions());
+    }
+
+    public function testPendingAfterAddingColumn()
+    {
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->any())
+            ->method('isValidColumnType')
+            ->willReturn(true);
+        $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
+        $table->addColumn("column1", "integer", ['null' => true]);
+        $this->assertEquals(true, $table->hasPendingActions());
+    }
+
     public function testGetColumn()
     {
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -275,6 +275,48 @@ class AbstractMigrationTest extends TestCase
         );
     }
 
+    public function testPostFlightCheckFail()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->any())
+            ->method('isValidColumnType')
+            ->willReturn(true);
+
+        $migrationStub->setAdapter($adapterStub);
+
+        $table = $migrationStub->table('test_table');
+        $table->addColumn("column1", "integer", ['null' => true]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Migration has pending actions after execution!');
+        $migrationStub->postFlightCheck();
+    }
+
+    public function testPostFlightCheckSuccess()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->any())
+            ->method('isValidColumnType')
+            ->willReturn(true);
+
+        $migrationStub->setAdapter($adapterStub);
+
+        $table = $migrationStub->table('test_table');
+        $table->addColumn("column1", "integer", ['null' => true])->create();
+
+        $this->assertTrue($migrationStub->postFlightCheck());
+    }
+
     public function testDropTableDeprecated()
     {
         if (PHP_VERSION_ID < 70000) {

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -314,7 +314,10 @@ class AbstractMigrationTest extends TestCase
         $table = $migrationStub->table('test_table');
         $table->addColumn("column1", "integer", ['null' => true])->create();
 
-        $this->assertNull($migrationStub->postFlightCheck());
+        $migrationStub->postFlightCheck();
+
+        // Dummy assert to prevent the test being marked as risky
+        $this->assertTrue(true);
     }
 
     public function testDropTableDeprecated()

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -314,7 +314,7 @@ class AbstractMigrationTest extends TestCase
         $table = $migrationStub->table('test_table');
         $table->addColumn("column1", "integer", ['null' => true])->create();
 
-        $this->assertTrue($migrationStub->postFlightCheck());
+        $this->assertNull($migrationStub->postFlightCheck());
     }
 
     public function testDropTableDeprecated()


### PR DESCRIPTION
Since the mechanics of migrations changed lately to require a call to save() some of my old migrations did not actually do anything after upgrading to 0.10 but I did not notice it until my tests started failing. Finding the issues was also fairly laborous.

To make it easier I wrote a checker function that throws an exception when there are unsaved changes in a migration when the migration completes. I cannot think of any valid use case where it is not an error and therefore did not provide a way to skip the check.