### PR TITLE
Double support for Mysql

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1001,6 +1001,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                     }
                     $type = static::PHINX_TYPE_BIG_INTEGER;
                     break;
+                case 'double':
+                    $type = static::PHINX_TYPE_FLOAT;
+                    break;
                 case 'bit':
                     $type = static::PHINX_TYPE_BIT;
                     if ($limit === 64) {

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1579,4 +1579,17 @@ OUTPUT;
 
         $this->assertEquals(1, $stm->rowCount());
     }
+
+    public function testDoubleSupport() {
+        $createQuery = <<<'INPUT'
+CREATE TABLE `test` (`double_col` double NOT NULL)
+INPUT;
+        $this->adapter->execute($createQuery);
+
+        $table = new \Phinx\Db\Table('test', [], $this->adapter);
+        $columns = $table->getColumns();
+
+        $this->assertCount(1, $columns);
+        $this->assertSame(MysqlAdapter::PHINX_TYPE_FLOAT, array_pop($columns)->getType());
+    }
 }


### PR DESCRIPTION
The `MysqlAdapter` doesn't support the double column type. Phinx can't create a column with that type, but when Phinx is added to a project with existing tables it's possible.