### PR TITLE
remove unused use statement for Phinx\Db\Action\DropColumn;

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -35,7 +35,6 @@ use Phinx\Db\Action\ChangeColumn;
 use Phinx\Db\Action\ChangeComment;
 use Phinx\Db\Action\ChangePrimaryKey;
 use Phinx\Db\Action\CreateTable;
-use Phinx\Db\Action\DropColumn;
 use Phinx\Db\Action\DropForeignKey;
 use Phinx\Db\Action\DropIndex;
 use Phinx\Db\Action\DropTable;


### PR DESCRIPTION
Phinx\Db\Action\DropColumn doesn't exist, remove the use statement in Phinx\Db\Table