### PR TITLE
Return Literal when column is not a Phinx type

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -943,7 +943,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      * @param string $sqlTypeDef
      * @throws \RuntimeException
      * @internal param string $sqlType SQL type
-     * @returns string Phinx type
+     * @return array Phinx type
      */
     public function getPhinxType($sqlTypeDef)
     {
@@ -1039,8 +1039,12 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                     break;
             }
 
-            // Call this to check if parsed type is supported.
-            $this->getSqlType($type, $limit);
+            try {
+                // Call this to check if parsed type is supported.
+                $this->getSqlType($type, $limit);
+            } catch (\RuntimeException $e) {
+                $type = Literal::from($type);
+            }
 
             $phinxType = [
                 'name' => $type,

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -933,7 +933,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
 
                 return ['name' => 'year', 'limit' => $limit];
             default:
-                throw new \RuntimeException('The type: "' . $type . '" is not supported.');
+                throw new UnsupportedColumnTypeException('Column type "' . $type . '" is not supported by MySQL.');
         }
     }
 
@@ -941,7 +941,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      * Returns Phinx type by SQL type
      *
      * @param string $sqlTypeDef
-     * @throws \RuntimeException
+     * @throws UnsupportedColumnTypeException
      * @internal param string $sqlType SQL type
      * @return array Phinx type
      */
@@ -949,7 +949,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $matches = [];
         if (!preg_match('/^([\w]+)(\(([\d]+)*(,([\d]+))*\))*(.+)*$/', $sqlTypeDef, $matches)) {
-            throw new \RuntimeException('Column type ' . $sqlTypeDef . ' is not supported');
+            throw new UnsupportedColumnTypeException('Column type "' . $sqlTypeDef . '" is not supported by MySQL.');
         } else {
             $limit = null;
             $precision = null;
@@ -1042,7 +1042,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             try {
                 // Call this to check if parsed type is supported.
                 $this->getSqlType($type, $limit);
-            } catch (\RuntimeException $e) {
+            } catch (UnsupportedColumnTypeException $e) {
                 $type = Literal::from($type);
             }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -967,7 +967,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                     return ['name' => $type];
                 }
                 // Return array type
-                throw new \RuntimeException('The type: "' . $type . '" is not supported');
+                throw new UnsupportedColumnTypeException('Column type "' . $type . '" is not supported by Postgresql.');
         }
     }
 
@@ -975,7 +975,8 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      * Returns Phinx type by SQL type
      *
      * @param string $sqlType SQL type
-     * @returns string Phinx type
+     * @return string Phinx type
+     * @throws UnsupportedColumnTypeException
      */
     public function getPhinxType($sqlType)
     {
@@ -1035,7 +1036,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case 'macaddr':
                 return static::PHINX_TYPE_MACADDR;
             default:
-                throw new \RuntimeException('The PostgreSQL type: "' . $sqlType . '" is not supported');
+                throw new UnsupportedColumnTypeException('Column type "' . $sqlType . '" is not supported by Postgresql.');
         }
     }
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1105,7 +1105,12 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                 }
             }
 
-            $this->getSqlType($type);
+            try {
+                // Call this to check if parsed type is supported.
+                $this->getSqlType($type);
+            } catch (\RuntimeException $e) {
+                $type = Literal::from($type);
+            }
 
             return [
                 'name' => $type,

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1036,7 +1036,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_POINT:
                 return ['name' => 'float'];
             default:
-                throw new \RuntimeException('The type: "' . $type . '" is not supported.');
+                throw new UnsupportedColumnTypeException('Column type "' . $type . '" is not supported by SQLite.');
         }
     }
 
@@ -1044,12 +1044,13 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      * Returns Phinx type by SQL type
      *
      * @param string $sqlTypeDef SQL type
+     * @throws UnsupportedColumnTypeException
      * @return array
      */
     public function getPhinxType($sqlTypeDef)
     {
         if (!preg_match('/^([\w]+)(\(([\d]+)*(,([\d]+))*\))*$/', $sqlTypeDef, $matches)) {
-            throw new \RuntimeException('Column type ' . $sqlTypeDef . ' is not supported');
+            throw new UnsupportedColumnTypeException('Column type "' . $sqlTypeDef . '" is not supported by SQLite.');
         } else {
             $limit = null;
             $precision = null;
@@ -1108,7 +1109,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             try {
                 // Call this to check if parsed type is supported.
                 $this->getSqlType($type);
-            } catch (\RuntimeException $e) {
+            } catch (UnsupportedColumnTypeException $e) {
                 $type = Literal::from($type);
             }
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -429,7 +429,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
         foreach ($rows as $columnInfo) {
             try {
                 $type = $this->getPhinxType($columnInfo['type']);
-            } catch (\RuntimeException $e) {
+            } catch (UnsupportedColumnTypeException $e) {
                 $type = Literal::from($columnInfo['type']);
             }
 
@@ -1034,7 +1034,7 @@ ORDER BY T.[name], I.[index_id];";
                 // Specific types (point, polygon, etc) are set at insert time.
                 return ['name' => 'geography'];
             default:
-                throw new \RuntimeException('The type: "' . $type . '" is not supported.');
+                throw new UnsupportedColumnTypeException('Column type "' . $type . '" is not supported by SqlServer.');
         }
     }
 
@@ -1042,9 +1042,9 @@ ORDER BY T.[name], I.[index_id];";
      * Returns Phinx type by SQL type
      *
      * @param string $sqlType SQL Type definition
-     * @throws \RuntimeException
+     * @throws UnsupportedColumnTypeException
      * @internal param string $sqlType SQL type
-     * @returns string Phinx type
+     * @return string Phinx type
      */
     public function getPhinxType($sqlType)
     {
@@ -1090,7 +1090,7 @@ ORDER BY T.[name], I.[index_id];";
             case 'filestream':
                 return static::PHINX_TYPE_FILESTREAM;
             default:
-                throw new \RuntimeException('The SqlServer type: "' . $sqlType . '" is not supported');
+                throw new UnsupportedColumnTypeException('Column type "' . $sqlType . '" is not supported by SqlServer.');
         }
     }
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -427,9 +427,15 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
         );
         $rows = $this->fetchAll($sql);
         foreach ($rows as $columnInfo) {
+            try {
+                $type = $this->getPhinxType($columnInfo['type']);
+            } catch (\RuntimeException $e) {
+                $type = Literal::from($columnInfo['type']);
+            }
+
             $column = new Column();
             $column->setName($columnInfo['name'])
-                   ->setType($this->getPhinxType($columnInfo['type']))
+                   ->setType($type)
                    ->setNull($columnInfo['null'] !== 'NO')
                    ->setDefault($this->parseDefault($columnInfo['default']))
                    ->setIdentity($columnInfo['identity'] === '1')

--- a/src/Phinx/Db/Adapter/UnsupportedColumnTypeException.php
+++ b/src/Phinx/Db/Adapter/UnsupportedColumnTypeException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phinx\Db\Adapter;
+
+/**
+ * Exception thrown when a column type doesn't match a Phinx type.
+ *
+ * @author Martijn Gastkemper <martijngastkemper@gmail.com>
+ */
+class UnsupportedColumnTypeException extends \RuntimeException
+{
+
+}

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1580,4 +1580,15 @@ OUTPUT;
 
         $this->assertEquals(1, $stm->rowCount());
     }
+
+    public function testLiteralSupport() {
+        $createQuery = <<<'INPUT'
+CREATE TABLE `test` (`double_col` double NOT NULL)
+INPUT;
+        $this->adapter->execute($createQuery);
+        $table = new \Phinx\Db\Table('test', [], $this->adapter);
+        $columns = $table->getColumns();
+        $this->assertCount(1, $columns);
+        $this->assertEquals(Literal::from('double'), array_pop($columns)->getType());
+    }
 }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\PostgresAdapter;
+use Phinx\Db\Adapter\UnsupportedColumnTypeException;
 use Phinx\Db\Table\Column;
 use Phinx\Util\Literal;
 use PHPUnit\Framework\TestCase;
@@ -1162,8 +1163,8 @@ class PostgresAdapterTest extends TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The type: "idontexist" is not supported
+     * @expectedException \Phinx\Db\Adapter\UnsupportedColumnTypeException
+     * @expectedExceptionMessage Column type "idontexist" is not supported by Postgresql.
      */
     public function testInvalidSqlType()
     {

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -3,7 +3,6 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\SQLiteAdapter;
-use Phinx\Db\Table;
 use Phinx\Util\Literal;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -740,8 +739,8 @@ class SQLiteAdapterTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Column type ?int? is not supported
+     * @expectedException \Phinx\Db\Adapter\UnsupportedColumnTypeException
+     * @expectedExceptionMessage Column type "?int?" is not supported by SQLite.
      */
     public function testPhinxTypeNotValidTypeRegex()
     {

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -656,7 +656,7 @@ class SqlServerAdapterTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage The type: "idontexist" is not supported
+     * @expectedExceptionMessage Column type "idontexist" is not supported by SqlServer.
      */
     public function testInvalidSqlType()
     {

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\SqlServerAdapter;
+use Phinx\Util\Literal;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -890,5 +891,16 @@ class SqlServerAdapterTest extends TestCase
             ->execute();
 
         $stm->closeCursor();
+    }
+
+    public function testLiteralSupport() {
+        $createQuery = <<<'INPUT'
+CREATE TABLE test (smallmoney_col smallmoney)
+INPUT;
+        $this->adapter->execute($createQuery);
+        $table = new \Phinx\Db\Table('test', [], $this->adapter);
+        $columns = $table->getColumns();
+        $this->assertCount(1, $columns);
+        $this->assertEquals(Literal::from('smallmoney'), array_pop($columns)->getType());
     }
 }


### PR DESCRIPTION
This is an alternative for PR #1432 and adds support for all relevant DBMS adapters.