### PR TITLE
Fixed pdo exception on reserved words columns

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1171,7 +1171,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         }
         if (($values = $column->getValues()) && is_array($values)) {
-            $def .= " CHECK({$column->getName()} IN ('" . implode("', '", $values) . "'))";
+            $def .= " CHECK(`{$column->getName()}` IN ('" . implode("', '", $values) . "'))";
         }
 
         $default = $column->getDefault();

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1171,7 +1171,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         }
         if (($values = $column->getValues()) && is_array($values)) {
-            $def .= " CHECK(`{$column->getName()}` IN ('" . implode("', '", $values) . "'))";
+            $def .= " CHECK({$this->quoteColumnName($column->getName())} IN ('" . implode("', '", $values) . "'))";
         }
 
         $default = $column->getDefault();


### PR DESCRIPTION
When column name is for example "limit" then we have a problem with pdo as it's recognised as reserved word. This fix adds to all column names back quote so it's recognised as column name