### PR TITLE
Allow primary key change on non-integer columns

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -866,7 +866,20 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         $tableName = $table->getName();
         $instructions->addPostStep(function ($state) use ($column) {
-            $sql = preg_replace("/(`$column`)\s+\w+\s+((NOT )?NULL)/", '$1 INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT', $state['createSQL'], 1);
+            $matchPattern = "/(`$column`)\s+(\w+(\(\d+\))?)\s+((NOT )?NULL)/";
+
+            if (preg_match($matchPattern, $state['createSQL'], $matches)) {
+                if (isset($matches[2])) {
+                    if ($matches[2] === 'INTEGER') {
+                        $replace = '$1 INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT';
+                    } else {
+                        $replace = '$1 $2 NOT NULL PRIMARY KEY';
+                    }
+                }
+
+                $sql = preg_replace($matchPattern, $replace, $state['createSQL'], 1);
+            }
+
             $this->execute($sql);
 
             return $state;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -867,7 +867,9 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $tableName = $table->getName();
         $instructions->addPostStep(function ($state) use ($column) {
             $matchPattern = "/(`$column`)\s+(\w+(\(\d+\))?)\s+((NOT )?NULL)/";
-
+            
+            $sql = $state['createSQL'];
+            
             if (preg_match($matchPattern, $state['createSQL'], $matches)) {
                 if (isset($matches[2])) {
                     if ($matches[2] === 'INTEGER') {
@@ -875,9 +877,9 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                     } else {
                         $replace = '$1 $2 NOT NULL PRIMARY KEY';
                     }
-                }
-
-                $sql = preg_replace($matchPattern, $replace, $state['createSQL'], 1);
+                    
+                    $sql = preg_replace($matchPattern, $replace, $state['createSQL'], 1);
+                }                
             }
 
             $this->execute($sql);

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -879,7 +879,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                     }
                     
                     $sql = preg_replace($matchPattern, $replace, $state['createSQL'], 1);
-                }                
+                }
             }
 
             $this->execute($sql);


### PR DESCRIPTION
Problem exists when we want to change primary key of non-integer column. Match doesn't work so no primary key added. With this change if "creation" SQL is not with INTEGER then we parse all data from column, for example my_primary VARCHAR(100) NOT NULL will be changed to my_primary VARCHAR(100) PRIMARY KEY. (now it does not preg_match, would preg_match my_primary VARCHAR NOT NULL and change to INTEGER AUTOINCREMENT..)

Pseudo-reproduction:
1st migration:
$this->table('sometable', ['primary_key' => 'abc']);

2nd:
$this->table('sometable')->changePrimaryKey('dfg'); <- dfg is varchar

This is backwards compatible change if integers is passed without limitations and autoincrement is still there (probably it was intended?)