### PR TITLE
Quote column names when running CHECK command

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1171,7 +1171,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         }
         if (($values = $column->getValues()) && is_array($values)) {
-            $def .= " CHECK({$column->getName()} IN ('" . implode("', '", $values) . "'))";
+            $def .= " CHECK({$this->quoteColumnName($column->getName())} IN ('" . implode("', '", $values) . "'))";
         }
 
         $default = $column->getDefault();


### PR DESCRIPTION
Copy of: cakephp#1441 just made separate branch so other fixes wouldn't conflict comparing forked repo..

Quoting column name when doing check command for example if doing enum in sqlite and column name is reserved words such as "limit"