### PR TITLE
Correct docs for the status exit codes.

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -191,8 +191,10 @@ status. You can use this command to determine which migrations have been run.
 
 This command exits with code 0 if the database is up-to-date (ie. all migrations are up) or one of the following codes otherwise:
 
-* 1: There is at least one down migration.
 * 2: There is at least one missing migration.
+* 3: There is at least one down migration.
+
+An exit code of 1 means an application error has occurred.
 
 The Seed Create Command
 -----------------------


### PR DESCRIPTION
In #806 the exit code for a down migration changed from **1** to **3**.  This PR corrects the documentation.