### PR TITLE
Update Dockerfile to use php:7.1 and update composer dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0
+FROM php:7.1
 
 # system dependecies
 RUN apt-get update && apt-get install -y \

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/yaml": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.7",
+        "phpunit/phpunit": "^6.0",
         "sebastian/comparator": ">=1.2.3",
         "cakephp/cakephp-codesniffer": "^3.0"
     },


### PR DESCRIPTION
After building docker container and running phpunit within it, I got an error message saying php 7.1 is required.

After making the change and  rebuilding the container and trying again, I got an error message from phpunit, something about column counts. Turned out it only appears in phpunit 7.* so I changed version spec to >=5.7,<7.0 and reran the tests, and everything worked correctly!

Just to go the extra mile, I checked whether phinx actually works with phpunit 5.* and it turned out not to! The tests mention some phpunit 6.* features. So, in the end I changed version spec of phpunit to ^6.0, and double-checked that everything still worked correctly.