### PR TITLE
Update Dockerfile to use php:7.1 and update composer dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0
+FROM php:7.1
 
 # system dependecies
 RUN apt-get update && apt-get install -y \

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/yaml": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": ">=5.7,<7.0",
         "sebastian/comparator": ">=1.2.3",
         "cakephp/cakephp-codesniffer": "^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/yaml": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.7",
+        "phpunit/phpunit": "^6.0",
         "sebastian/comparator": ">=1.2.3",
         "cakephp/cakephp-codesniffer": "^3.0"
     },


### PR DESCRIPTION
* when running phpunit in docker, it asks for php 7.1, so changed php version in dockerfile to 7.1
* after rebuilding the container, phpunit gives warnings about column counts, which appear in phpunit 7.*, so added <7.0 to phpunit version spec
* after composer update, everything works correctly
