### PR TITLE
Add feature to be able to define a boostrap script

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -354,3 +354,14 @@ When rolling back or printing the status of migrations, Phinx orders the execute
 
 * ``creation`` (the default): migrations are ordered by their creation time, which is also part of their filename.
 * ``execution``: migrations are ordered by their execution time, also known as start time.
+
+Bootstrap Path
+---------------
+
+You can provide a path to a `bootstrap` php file that will included before any commands phinx commands are run. Note that
+setting External Variables to modify the config will not work because the config has already been parsed by this point.
+
+.. code-block:: yaml
+
+    paths:
+        bootstrap: 'phinx-bootstrap.php'

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -339,6 +339,11 @@ class Config implements ConfigInterface, NamespaceAwareInterface
         return $versionOrder == self::VERSION_ORDER_CREATION_TIME;
     }
 
+    /**
+     * Get the bootstrap file path
+     *
+     * @return string
+     */
     public function getBootstrapFile()
     {
         if (!isset($this->values['paths']['bootstrap'])) {

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -342,7 +342,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * Get the bootstrap file path
      *
-     * @return string
+     * @return string|false
      */
     public function getBootstrapFile()
     {

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -339,6 +339,15 @@ class Config implements ConfigInterface, NamespaceAwareInterface
         return $versionOrder == self::VERSION_ORDER_CREATION_TIME;
     }
 
+    public function getBootstrapFile()
+    {
+        if (!isset($this->values['paths']['bootstrap'])) {
+            return false;
+        }
+
+        return $this->values['paths']['bootstrap'];
+    }
+
     /**
      * Replace tokens in the specified array.
      *

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -131,6 +131,13 @@ interface ConfigInterface extends \ArrayAccess
     public function isVersionOrderCreationTime();
 
     /**
+     * Get the bootstrap file path
+     *
+     * @return string|false
+     */
+    public function getBootstrapFile();
+
+    /**
      * Gets the base class name for migrations.
      *
      * @param bool $dropNamespace Return the base migration class name without the namespace.

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -95,6 +95,11 @@ abstract class AbstractCommand extends Command
 
         $this->loadManager($input, $output);
 
+        if ($bootstrap = $this->getConfig()->getBootstrapFile()) {
+            $output->writeln('<info>using bootstrap</info> .' . str_replace(getcwd(), '', realpath($bootstrap)) . ' ');
+            Util::loadPhpFile($bootstrap);
+        }
+
         // report the paths
         $paths = $this->getConfig()->getMigrationPaths();
 

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -224,6 +224,8 @@ class Util
 
     /**
      * Takes the path to a php file and attempts to include it if readable
+     *
+     * @return string
      */
     public static function loadPhpFile($filename)
     {

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -221,4 +221,27 @@ class Util
     {
         return glob($path, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
     }
+
+    /**
+     * Takes the path to a php file and attempts to include it if readable
+     */
+    public static function loadPhpFile($filename)
+    {
+        $filePath = realpath($filename);
+
+        /**
+         * I lifed this from phpunits FileLoader class
+         *
+         * @see https://github.com/sebastianbergmann/phpunit/pull/2751
+         */
+        $isReadable = @\fopen($filePath, 'r') !== false;
+
+        if (!$filePath || !$isReadable) {
+            throw new \Exception(sprintf("Cannot open file %s \n", $filename));
+        }
+
+        include_once $filePath;
+
+        return $filePath;
+    }
 }


### PR DESCRIPTION
## Overview
This fixes #611. The implementation is a bit different than what is described in the issue. This is global for all environments and run before any command but after config is parsed.

### New configuration option
I've added under the configuration paths a new `bootstrap` path which would be a path to a php file to run before commands run. Similar to how phpunit can define a bootstrap file.
```yaml
#phinx.yaml 
paths:
    bootstrap: 'phinx-bootstrap.php'
```

This configuration option is checked and if found will simply do a php `include_once` on the file. Wasn't sure how you'd want to handle error handling. So I just have it blow up if anything goes wrong. Let me know if you have better suggestions on what to show users if the bootstrap is borked.

I'm happy to add the appropriate unit tests around the code just wanted to check if you guys were still interested in this change or would want it implemented differently?

I created https://github.com/Nilithus/phinx-bootstrap-tester to do simple tests on what I wrote.

Thanks for you consideration! Let me know if I should change anything.