### PR TITLE
Add Exit Status 1 on Exception

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -113,14 +113,19 @@ EOT
             $output->writeln('<comment>warning</comment> performing fake migrations');
         }
 
-        // run the migrations
-        $start = microtime(true);
-        if ($date !== null) {
-            $this->getManager()->migrateToDateTime($environment, new \DateTime($date), $fake);
-        } else {
-            $this->getManager()->migrate($environment, $version, $fake);
+        try {
+            // run the migrations
+            $start = microtime(true);
+            if ($date !== null) {
+                $this->getManager()->migrateToDateTime($environment, new \DateTime($date), $fake);
+            } else {
+                $this->getManager()->migrate($environment, $version, $fake);
+            }
+            $end = microtime(true);
+        } catch (\Throwable $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
         }
-        $end = microtime(true);
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -122,6 +122,9 @@ EOT
                 $this->getManager()->migrate($environment, $version, $fake);
             }
             $end = microtime(true);
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
         } catch (\Throwable $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             return 1;

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -123,10 +123,10 @@ EOT
             }
             $end = microtime(true);
         } catch (\Exception $e) {
-            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            $output->writeln('<error>' . $e->__toString() . '</error>');
             return 1;
         } catch (\Throwable $e) {
-            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            $output->writeln('<error>' . $e->__toString() . '</error>');
             return 1;
         }
 


### PR DESCRIPTION
As in #963 described, the bash currently gets the status code 0 if the migration fails. With this PR it will get the status code 1.
