### PR TITLE
v Treat schema name renaming a table

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -339,7 +339,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         $sql = sprintf(
             'ALTER TABLE %s RENAME TO %s',
             $this->quoteTableName($tableName),
-            $this->quoteColumnName($newTableName)
+            $this->quoteTableName($newTableName)
         );
 
         return new AlterInstructions([], [$sql]);


### PR DESCRIPTION
There is a bug in the current PgSQL table renaming:
1. You can't specify a schema for a new table name.
2. Rollback will find the table in a 'public' schema.