### PR TITLE
Fixed #1481 Bug when getScale

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1117,7 +1117,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $sqlType = $this->getSqlType($column->getType(), $column->getLimit());
             $def = strtoupper($sqlType['name']);
         }
-        if ($column->getPrecision() && $column->getScale()) {
+        if ($column->getPrecision() && $column->getScale() >= 0) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         } elseif (isset($sqlType['limit'])) {
             $def .= '(' . $sqlType['limit'] . ')';


### PR DESCRIPTION
When add COlumn:
```php
'decimal', [
                    'precision' => 30,
                    'scale' => 0,
                ]
``` 
in line 1120 no set DECIMAL(30, 0) because the getScale() == '0'