### PR TITLE
Tell Composer the JSON extension is required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ phpunit.xml
 
 # sqlite test database
 phinx_testing.sqlite3
-/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ phpunit.xml
 
 # sqlite test database
 phinx_testing.sqlite3
+/nbproject/private/

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,8 @@
+build:
+  environment:
+    pecl_extensions:
+      - json
+
 checks:
   php: true
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,8 @@
 build:
   environment:
-    pecl_extensions:
-      - json
+    php:
+      pecl_extensions:
+        - json
 
 checks:
   php: true

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     }],
     "require": {
         "php": ">=5.6",
+        "ext-json": "*",
         "cakephp/collection": "^3.6",
         "cakephp/database": "^3.6",
         "symfony/console": "^2.8|^3.0|^4.0",


### PR DESCRIPTION
As per #1490, this asks Composer to check whether the JSON extension is used. It seems to be used in the Phinx core to read its own `composer.json` file.

Not all PHP installations - particularly Alpine - can guarantee that this extension is loaded.
