### PR TITLE
Prevent data insertion when passing an empty array

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -595,7 +595,10 @@ class Table
 
             return $this;
         }
-        $this->data[] = $data;
+
+        if (count($data) > 0) {
+            $this->data[] = $data;
+        }
 
         return $this;
     }

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -196,6 +196,18 @@ class TableTest extends TestCase
         $this->assertEquals($expectedData, $table->getData());
     }
 
+    public function testInsertSaveEmptyData()
+    {
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
+
+        $adapterStub->expects($this->never())->method('bulkinsert');
+
+        $table->insert([])->save();
+    }
+
     public function testInsertSaveData()
     {
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')


### PR DESCRIPTION
Hello,

I found a small bug. Running:
```
$this->table('my_table')->insert([])->save();
```
will insert a row when it should not.

The above code is stupid but in my case the array passed to the insert function is a variable. I'm creating a migration to move data from old tables to new ones. In this migration, I loop on all rows of old tables, and get some column to feed into the new tables. When running against an empty database (schema only, no rows), this migration should loop on an empty array and do nothing.

Instead, I can find a new line for each table in the database, with each table id being a single space, and the other columns empty or with default values.

As a workaround I have to check if the array is empty before calling or not the `save()` method.

Thank you for your thoughts on this PR.

