### PR TITLE
docs: add MySQL `bit` type

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -515,8 +515,8 @@ Column types are specified as strings and can be one of:
 -  timestamp
 -  uuid
 
-In addition, the MySQL adapter supports ``enum``, ``set``, ``blob``, ``bit`` and ``json`` column types.
-(``json`` in MySQL 5.7 and above)
+In addition, the MySQL adapter supports ``enum``, ``set``, ``blob``, ``bit`` and ``json`` column types
+(``json`` in MySQL 5.7 and above).
 
 In addition, the Postgres adapter supports ``interval``, ``json``, ``jsonb``, ``uuid``, ``cidr``, ``inet`` and ``macaddr`` column types
 (PostgreSQL 9.3 and above).
@@ -780,9 +780,10 @@ Column types are specified as strings and can be one of:
 -  timestamp
 -  uuid
 
-In addition, the MySQL adapter supports ``enum``, ``set``, ``blob`` and ``bit`` column types.
+In addition, the MySQL adapter supports ``enum``, ``set``, ``blob``, ``bit`` and ``json`` column types
+(``json`` in MySQL 5.7 and above).
 
-In addition, the Postgres adapter supports ``json``, ``jsonb``, ``uuid``, ``cidr``, ``inet`` and ``macaddr`` column types
+In addition, the Postgres adapter supports ``interval``, ``json``, ``jsonb``, ``uuid``, ``cidr``, ``inet`` and ``macaddr`` column types
 (PostgreSQL 9.3 and above).
 
 Valid Column Options

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -515,7 +515,7 @@ Column types are specified as strings and can be one of:
 -  timestamp
 -  uuid
 
-In addition, the MySQL adapter supports ``enum``, ``set``, ``blob`` and ``json`` column types.
+In addition, the MySQL adapter supports ``enum``, ``set``, ``blob``, ``bit`` and ``json`` column types.
 (``json`` in MySQL 5.7 and above)
 
 In addition, the Postgres adapter supports ``interval``, ``json``, ``jsonb``, ``uuid``, ``cidr``, ``inet`` and ``macaddr`` column types
@@ -780,7 +780,7 @@ Column types are specified as strings and can be one of:
 -  timestamp
 -  uuid
 
-In addition, the MySQL adapter supports ``enum``, ``set`` and ``blob`` column types.
+In addition, the MySQL adapter supports ``enum``, ``set``, ``blob`` and ``bit`` column types.
 
 In addition, the Postgres adapter supports ``json``, ``jsonb``, ``uuid``, ``cidr``, ``inet`` and ``macaddr`` column types
 (PostgreSQL 9.3 and above).


### PR DESCRIPTION
#1248 added support for the MySQL column type `bit`,
but the type was not yet mentioned in the docs.

In addition, this PR aligns the currently inconsistent sections *Working With Tables* and *Working With Columns* w.r.t. the columns supported by the MySQL and Postgres adapter.