### PR TITLE
SQLite Adapter does not respect LIMIT on CHAR typed columns

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -46,6 +46,7 @@ use Phinx\Util\Literal;
 class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 {
     protected $definitionsWithLimits = [
+        'CHAR',
         'CHARACTER',
         'VARCHAR',
         'VARYING CHARACTER',


### PR DESCRIPTION
Hello I found this bug with the SQLite Adapter it doesn't respect a limit on CHAR typed columns

Without the fix performing a migration like this
```
$table = $this->table('my_table', ['id' => false]);
$table->addColumn('char_col', 'char', ['limit' => 32])->create();
```
Results in
```
sqlite> pragma table_info(my_table);
0|char_col|CHAR|0||0
```

After fix the same migration results in
```
0|char_col|CHAR(32)|0||0
```