### PR TITLE
Fix box configuration to work with humbug/box

### DIFF
--- a/box.json
+++ b/box.json
@@ -8,8 +8,7 @@
     "directories": ["src","app"],
     "files": [
         "LICENSE",
-        "phinx.yml",
-        "composer.json"
+        "phinx.yml"
     ],
     "finder": [
         {
@@ -30,5 +29,6 @@
     "git-version": "git_tag",
     "main": "bin/phinx",
     "output": "phinx-@git-version@.phar",
-    "stub": true
+    "stub": true,
+    "exclude-composer-files": false
 }


### PR DESCRIPTION
With regards to #1520:

Considering humbug/box (https://github.com/humbug/box) is now the actively maintained app for building phars, I updated the box.json configuration so that working phars can be generated.  

The existing box.json was not working at all as humbug/box excludes composer.json from the root unless you explicitly set a flag to tell it not to.