### PR TITLE
Fixed Bug #596, #123 - changeColumn resets the nullable option if not specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ tests/log
 ./db
 ./migrations
 
+bin/db/
+bin/phinx.yml
+
 # sphinx generates HTML files for the documentation here
 docs/_build
 

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -72,7 +72,7 @@ class ChangeColumn extends Action
      * @param mixed $options Additional options for the column
      * @return ChangeColumn
      */
-    public static function build(Table $table, $columnName, $type = null, $options = [], $adapter)
+    public static function build(Table $table, $columnName, $type = null, $options = [], $adapter = null)
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -72,11 +72,12 @@ class ChangeColumn extends Action
      * @param mixed $options Additional options for the column
      * @return ChangeColumn
      */
-    public static function build(Table $table, $columnName, $type = null, $options = [])
+    public static function build(Table $table, $columnName, $type = null, $options = [], $adapter)
     {
         $column = new Column();
         $column->setName($columnName);
         $column->setType($type);
+        $column->fetchExistingColumnOptions($table->getName(), $adapter);
         $column->setOptions($options); // map options to column methods
 
         return new static($table, $columnName, $column);

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -369,7 +369,7 @@ class Table
         if ($newColumnType instanceof Column) {
             $action = new ChangeColumn($this->table, $columnName, $newColumnType);
         } else {
-            $action = ChangeColumn::build($this->table, $columnName, $newColumnType, $options);
+            $action = ChangeColumn::build($this->table, $columnName, $newColumnType, $options, $this->getAdapter());
         }
         $this->actions->addAction($action);
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -644,6 +644,34 @@ class Column
     }
 
     /**
+     * Fetch Existing Column Options, and can be used to change column schema
+     */
+    public function fetchExistingColumnOptions($tableName, $adapter) 
+    {
+        $table = new \Phinx\Db\Table($tableName, [], $adapter);
+        $retrievedColumnDetails = $table->getColumn($this->name);
+
+        $this->type = $retrievedColumnDetails->type;
+        $this->limit = $retrievedColumnDetails->limit;
+        $this->null = $retrievedColumnDetails->null;
+        $this->default = $retrievedColumnDetails->default;
+        $this->identity = $retrievedColumnDetails->identity;
+        $this->scale = $retrievedColumnDetails->scale;
+        $this->after = $retrievedColumnDetails->after;
+        $this->update = $retrievedColumnDetails->update;
+        $this->comment = $retrievedColumnDetails->comment;
+
+        $this->signed = $retrievedColumnDetails->signed;
+        $this->timezone = $retrievedColumnDetails->timezone;
+        $this->properties = $retrievedColumnDetails->properties;
+        $this->collation = $retrievedColumnDetails->collation;
+        $this->encoding = $retrievedColumnDetails->encoding;
+        $this->values = $retrievedColumnDetails->values;    
+    
+        return $this;
+    }
+
+    /**
      * Utility method that maps an array of column options to this objects methods.
      *
      * @param array $options Options
@@ -655,6 +683,7 @@ class Column
         $aliasOptions = $this->getAliasedOptions();
 
         foreach ($options as $option => $value) {
+            
             if (isset($aliasOptions[$option])) {
                 // proxy alias -> option
                 $option = $aliasOptions[$option];

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -647,7 +647,7 @@ class Column
      * Fetch Existing Column Options, and can be used to change column schema
      *
      * @param string $tableName of current column
-     * @param AdapterInterface current adapter for accessing db
+     * @param AdapterInterface $adapter current adapter for accessing db
      * @return $this
      */
     public function fetchExistingColumnOptions($tableName, $adapter) 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -645,6 +645,10 @@ class Column
 
     /**
      * Fetch Existing Column Options, and can be used to change column schema
+     *
+     * @param string $tableName of current column
+     * @param AdapterInterface current adapter for accessing db
+     * @return $this
      */
     public function fetchExistingColumnOptions($tableName, $adapter) 
     {
@@ -683,7 +687,7 @@ class Column
         $aliasOptions = $this->getAliasedOptions();
 
         foreach ($options as $option => $value) {
-            
+
             if (isset($aliasOptions[$option])) {
                 // proxy alias -> option
                 $option = $aliasOptions[$option];


### PR DESCRIPTION
Fetching column options before performing changeColumn Action