### PR TITLE
Add double to valid column types

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -507,6 +507,7 @@ Column types are specified as strings and can be one of:
 -  datetime
 -  decimal
 -  float
+-  double
 -  integer
 -  smallinteger
 -  string


### PR DESCRIPTION
As introduced with #1493 und released with 0.10.7 using `double` is possible.
This PR adds it to the valid column types list.