### PR TITLE
Fix for issue #1535

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -266,6 +266,17 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     }
 
     /**
+     * Quotes a database string.
+     *
+     * @param string $value  The string to quote
+     * @return mixed
+     */
+    protected function quoteString($value)
+    {
+        return $this->getConnection()->quote($value);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function bulkinsert(Table $table, $rows)

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -252,7 +252,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param mixed $value  The value to quote
      * @return mixed
      */
-    private function quoteValue($value)
+    protected function quoteValue($value)
     {
         if (is_numeric($value)) {
             return $value;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -208,7 +208,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             return false;
         }
 
-        // this somewhat pedantic check with strtolower is performed because the SQL lower function may be redefined, 
+        // this somewhat pedantic check with strtolower is performed because the SQL lower function may be redefined,
         // and can act on all Unicode characters if the ICU extension is loaded, while SQL identifiers are only case-insensitive for ASCII
         foreach ($rows as $row) {
             if (strtolower($row['name']) == $table) {

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -99,9 +99,9 @@ class SQLiteAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s exists when it does not', $tableName));
         $conn->exec(sprintf('CREATE TABLE %s (a text)', $createName));
         if ($exp == true) {
-            $this->assertTrue($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s does not exist when it should', $tableName));
+            $this->assertTrue($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s does not exist when it does', $tableName));
         } else {
-            $this->assertFalse($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s exists when it should not', $tableName));
+            $this->assertFalse($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s exists when it does not', $tableName));
         }
     }
 
@@ -118,7 +118,18 @@ class SQLiteAdapterTest extends TestCase
             'Wrong schema' => ['t', 'etc.t', false],
             'Missing schema' => ['t', 'not_attached.t', false],
             'Malicious table' => ['"\'"', '\'', true],
-            'Malicious missing table' => ['t', '\'', false]
+            'Malicious missing table' => ['t', '\'', false],
+            'Table name case 1' => ['t', 'T', true],
+            'Table name case 2' => ['T', 't', true],
+            'Schema name case 1' => ['main.t', 'MAIN.t', true],
+            'Schema name case 2' => ['MAIN.t', 'main.t', true],
+            'Schema name case 3' => ['temp.t', 'TEMP.t', true],
+            'Schema name case 4' => ['TEMP.t', 'temp.t', true],
+            'Schema name case 5' => ['etc.t', 'ETC.t', true],
+            'Schema name case 6' => ['ETC.t', 'etc.t', true],
+            'PHP zero string 1' => ['"0"', '0', true],
+            'PHP zero string 2' => ['"0"', '0e2', false],
+            'PHP zero string 3' => ['"0e2"', '0', false]
         ];
     }
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -117,7 +117,8 @@ class SQLiteAdapterTest extends TestCase
             'Attached table with unusual schema' => ['"main.db".t', 'main.db.t', true],
             'Wrong schema' => ['t', 'etc.t', false],
             'Missing schema' => ['t', 'not_attached.t', false],
-            'Malicious table' => ['t', '\'', false]
+            'Malicious table' => ['\'', '\'', true],
+            'Malicious missing table' => ['t', '\'', false]
         ];
     }
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -117,7 +117,7 @@ class SQLiteAdapterTest extends TestCase
             'Attached table with unusual schema' => ['"main.db".t', 'main.db.t', true],
             'Wrong schema' => ['t', 'etc.t', false],
             'Missing schema' => ['t', 'not_attached.t', false],
-            'Malicious table' => ['\'', '\'', true],
+            'Malicious table' => ['"\'"', '\'', true],
             'Malicious missing table' => ['t', '\'', false]
         ];
     }


### PR DESCRIPTION
Enhances `SQLiteAdapter::hasTable()` so that it can find tables in any already-attached database, including temporary tables when explicitly asked for. 

Also fixes a quoting issue the original implementation had: table names containing `'` would previously cause the method to error out. This required changing the `PdoAdapter::quoteValue()` method visibility to `protected`.