### PR TITLE
New hasTable implementation for SQLite

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -266,6 +266,17 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     }
 
     /**
+     * Quotes a database string.
+     *
+     * @param string $value  The string to quote
+     * @return string
+     */
+    protected function quoteString($value)
+    {
+        return $this->getConnection()->quote($value);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function bulkinsert(Table $table, $rows)

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -205,7 +205,11 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         $table = strtolower($info['table']);
         foreach ($schemata as $schema) {
-            $master = sprintf('%s.%s', $this->quoteColumnName($schema), 'sqlite_master');
+            if (strtolower($schema) === 'temp') {
+                $master = 'sqlite_temp_master';
+            } else {
+                $master = sprintf('%s.%s', $this->quoteColumnName($schema), 'sqlite_master');
+            }
             try {
                 $rows = $this->fetchAll(sprintf('SELECT name FROM %s WHERE type=\'table\' AND lower(name) = %s', $master, $this->quoteString($table)));
             } catch (\PDOException $e) {

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -169,17 +169,60 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     }
 
     /**
+     * @param string $tableName Table name
+     * @return array
+     */
+    protected function getSchemaName($tableName)
+    {
+        if (preg_match("/.\.([^\.]+)$/", $tableName, $match)) {
+            $table = $match[1];
+            $schema = substr($tableName, 0, strlen($tableName) - strlen($match[0]) + 1);
+            $result = ['schema' => $schema, 'table' => $table];
+        } else {
+            $result = ['schema' => '', 'table' => $tableName];
+        }
+
+        return $result;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function hasTable($tableName)
     {
-        $tables = [];
-        $rows = $this->fetchAll(sprintf('SELECT name FROM sqlite_master WHERE type=\'table\' AND name=\'%s\'', $tableName));
-        foreach ($rows as $row) {
-            $tables[] = strtolower($row[0]);
+        $info = $this->getSchemaName($tableName);
+        if ($info['schema'] === '') {
+            // if no schema is specified we search all schemata
+            $rows = $this->fetchAll('PRAGMA database_list;');
+            $schemata = [];
+            foreach ($rows as $row) {
+                $schemata[] = $row['name'];
+            }
+        } else {
+            // otherwise we search just the specified schema
+            $schemata = (array)$info['schema'];
         }
 
-        return in_array(strtolower($tableName), $tables);
+        $table = strtolower($info['table']);
+        foreach ($schemata as $schema) {
+            $master = sprintf('%s.%s', $this->quoteColumnName($schema), 'sqlite_master');
+            try {
+                $rows = $this->fetchAll(sprintf('SELECT name FROM %s WHERE type=\'table\' AND lower(name) = %s', $master, $this->quoteString($table)));
+            } catch (\PDOException $e) {
+                // an exception can occur if the schema part of the table refers to a database which is not attached
+                return false;
+            }
+
+            // this somewhat pedantic check with strtolower is performed because the SQL lower function may be redefined,
+            // and can act on all Unicode characters if the ICU extension is loaded, while SQL identifiers are only case-insensitive for ASCII
+            foreach ($rows as $row) {
+                if (strtolower($row['name']) === $table) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1172,4 +1172,53 @@ INPUT;
         $this->assertCount(1, $columns);
         $this->assertEquals(Literal::from('real'), array_pop($columns)->getType());
     }
+
+    /** @dataProvider provideTableNamesForPresenceCheck
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::hasTable
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::quoteString
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getSchemaName */
+    public function testHasTable($createName, $tableName, $exp)
+    {
+        // Test case for issue #1535
+        $conn = $this->adapter->getConnection();
+        $conn->exec('ATTACH DATABASE \':memory:\' as etc');
+        $conn->exec('ATTACH DATABASE \':memory:\' as "main.db"');
+        $conn->exec(sprintf('DROP TABLE IF EXISTS %s', $createName));
+        $this->assertFalse($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s exists when it does not', $tableName));
+        $conn->exec(sprintf('CREATE TABLE %s (a text)', $createName));
+        if ($exp == true) {
+            $this->assertTrue($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s does not exist when it does', $tableName));
+        } else {
+            $this->assertFalse($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s exists when it does not', $tableName));
+        }
+    }
+
+    public function provideTableNamesForPresenceCheck()
+    {
+        return [
+            'Ordinary table' => ['t', 't', true],
+            'Ordinary table with schema' => ['t', 'main.t', true],
+            'Temporary table' => ['temp.t', 't', true],
+            'Temporary table with schema' => ['temp.t', 'temp.t', true],
+            'Attached table' => ['etc.t', 't', true],
+            'Attached table with schema' => ['etc.t', 'etc.t', true],
+            'Attached table with unusual schema' => ['"main.db".t', 'main.db.t', true],
+            'Wrong schema 1' => ['t', 'etc.t', false],
+            'Wrong schema 2' => ['t', 'temp.t', false],
+            'Missing schema' => ['t', 'not_attached.t', false],
+            'Malicious table' => ['"\'"', '\'', true],
+            'Malicious missing table' => ['t', '\'', false],
+            'Table name case 1' => ['t', 'T', true],
+            'Table name case 2' => ['T', 't', true],
+            'Schema name case 1' => ['main.t', 'MAIN.t', true],
+            'Schema name case 2' => ['MAIN.t', 'main.t', true],
+            'Schema name case 3' => ['temp.t', 'TEMP.t', true],
+            'Schema name case 4' => ['TEMP.t', 'temp.t', true],
+            'Schema name case 5' => ['etc.t', 'ETC.t', true],
+            'Schema name case 6' => ['ETC.t', 'etc.t', true],
+            'PHP zero string 1' => ['"0"', '0', true],
+            'PHP zero string 2' => ['"0"', '0e2', false],
+            'PHP zero string 3' => ['"0e2"', '0', false]
+        ];
+    }
 }


### PR DESCRIPTION
A second attempt at fixing `SQLiteAdapter::hasTable()`.

Notably, it is able to find tables in any schema rather than only main, and is also able to find tables when the main schema is explicitly specified.

Like [SQLite itself](https://sqlite.org/lang_naming.html), if no schema is specified it will search all schemata until the table is found. This is unlike the other adapters, but is internally consistent.

This fixes #1535.