### PR TITLE
New hasPrimaryKey and hasForeignKey implementations for SQLite

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -811,13 +811,11 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $columns = array_map('strtolower', (array)$columns);
         $primaryKey = array_map('strtolower', $this->getPrimaryKey($tableName));
 
-        if (array_diff($primaryKey, $columns)) {
+        if (array_diff($primaryKey, $columns) || array_diff($columns, $primaryKey)) {
             return false;
-        } elseif (array_diff($columns, $primaryKey)) {
-            return false;
-        } else {
-            return true;
         }
+        
+        return true;
     }
 
     /**
@@ -855,13 +853,10 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         foreach ($foreignKeys as $key) {
             $key = array_map('strtolower', $key);
-            if (array_diff($key, $columns)) {
+            if (array_diff($key, $columns) || array_diff($columns, $key)) {
                 continue;
-            } elseif (array_diff($columns, $key)) {
-                continue;
-            } else {
-                return true;
             }
+            return true;
         }
 
         return false;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -170,9 +170,10 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
     /**
      * @param string $tableName Table name
+     * @param boolean $quoted Whether to return the schema name and table name escaped and quoted. If quoted, the schema (if any) will also be appended with a dot
      * @return array
      */
-    protected function getSchemaName($tableName)
+    protected function getSchemaName($tableName, $quoted = false)
     {
         if (preg_match("/.\.([^\.]+)$/", $tableName, $match)) {
             $table = $match[1];
@@ -182,7 +183,25 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $result = ['schema' => '', 'table' => $tableName];
         }
 
+        if ($quoted) {
+            $result['schema'] = strlen($result['schema']) ? $this->quoteColumnName($result['schema']) . '.' : '';
+            $result['table'] = $this->quoteColumnName($result['table']);
+        }
+
         return $result;
+    }
+
+    /**
+     * Retrieves information about a given table from one of the SQLite pragmas
+     *
+     * @param string $tableName The table to query
+     * @param string $pragma The pragma to query
+     * @return array
+     */
+    protected function getTableInfo($tableName, $pragma = 'table_info')
+    {
+        $info = $this->getSchemaName($tableName, true);
+        return $this->fetchAll(sprintf('PRAGMA %s%s(%s)', $info['schema'], $pragma, $info['table']));
     }
 
     /**
@@ -304,7 +323,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $primaryKey = $this->getPrimaryKey($table->getName());
         if (!empty($primaryKey)) {
             $instructions->merge(
-                $this->getDropPrimaryKeyInstructions($table, $primaryKey)
+                // FIXME: array access is a hack to make this incomplete implementation work with a correct getPrimaryKey implementation
+                $this->getDropPrimaryKeyInstructions($table, $primaryKey[0])
             );
         }
 
@@ -784,60 +804,41 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasPrimaryKey($tableName, $columns, $constraint = null)
     {
-        $primaryKey = $this->getPrimaryKey($tableName);
-
-        if (empty($primaryKey)) {
-            return false;
+        if (!is_null($constraint)) {
+            throw new \InvalidArgumentException('SQLite does not support named constraints.');
         }
 
-        $missingColumns = array_diff((array)$columns, (array)$primaryKey);
+        $columns = array_map('strtolower', (array)$columns);
+        $primaryKey = array_map('strtolower', $this->getPrimaryKey($tableName));
 
-        return empty($missingColumns);
+        if (array_diff($primaryKey, $columns)) {
+            return false;
+        } elseif (array_diff($columns, $primaryKey)) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     /**
      * Get the primary key from a particular table.
      *
      * @param string $tableName Table Name
-     * @return string|null
+     * @return string[]
      */
     protected function getPrimaryKey($tableName)
     {
-        $rows = $this->fetchAll(
-            "SELECT sql, tbl_name
-              FROM (
-                    SELECT sql sql, type type, tbl_name tbl_name, name name
-                      FROM sqlite_master
-                     UNION ALL
-                    SELECT sql, type, tbl_name, name
-                      FROM sqlite_temp_master
-                   )
-             WHERE type != 'meta'
-               AND sql NOTNULL
-               AND name NOT LIKE 'sqlite_%'
-             ORDER BY substr(type, 2, 1), name"
-        );
+        $primaryKey = [];
+
+        $rows = $this->getTableInfo($tableName);
 
         foreach ($rows as $row) {
-            if ($row['tbl_name'] === $tableName) {
-                if (strpos($row['sql'], 'PRIMARY KEY') !== false) {
-                    preg_match_all("/PRIMARY KEY\s*\(`([^`]+)`\)/", $row['sql'], $matches);
-                    foreach ($matches[1] as $match) {
-                        if (!empty($match)) {
-                            return $match;
-                        }
-                    }
-                    preg_match_all("/`([^`]+)`\s+\w+(\(\d+\))?((\s+NOT)?\s+NULL)?\s+PRIMARY KEY/", $row['sql'], $matches);
-                    foreach ($matches[1] as $match) {
-                        if (!empty($match)) {
-                            return $match;
-                        }
-                    }
-                }
+            if ($row['pk'] > 0) {
+                $primaryKey[$row['pk'] - 1] = $row['name'];
             }
         }
 
-        return null;
+        return $primaryKey;
     }
 
     /**
@@ -845,9 +846,25 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasForeignKey($tableName, $columns, $constraint = null)
     {
+        if (!is_null($constraint)) {
+            throw new \InvalidArgumentException('SQLite does not support named constraints.');
+        }
+
+        $columns = array_map('strtolower', (array)$columns);
         $foreignKeys = $this->getForeignKeys($tableName);
 
-        return !array_diff((array)$columns, $foreignKeys);
+        foreach ($foreignKeys as $key) {
+            $key = array_map('strtolower', $key);
+            if (array_diff($key, $columns)) {
+                continue;
+            } elseif (array_diff($columns, $key)) {
+                continue;
+            } else {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -859,30 +876,14 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     protected function getForeignKeys($tableName)
     {
         $foreignKeys = [];
-        $rows = $this->fetchAll(
-            "SELECT sql, tbl_name
-              FROM (
-                    SELECT sql sql, type type, tbl_name tbl_name, name name
-                      FROM sqlite_master
-                     UNION ALL
-                    SELECT sql, type, tbl_name, name
-                      FROM sqlite_temp_master
-                   )
-             WHERE type != 'meta'
-               AND sql NOTNULL
-               AND name NOT LIKE 'sqlite_%'
-             ORDER BY substr(type, 2, 1), name"
-        );
+
+        $rows = $this->getTableInfo($tableName, 'foreign_key_list');
 
         foreach ($rows as $row) {
-            if ($row['tbl_name'] === $tableName) {
-                if (strpos($row['sql'], 'REFERENCES') !== false) {
-                    preg_match_all("/\(`([^`]*)`\) REFERENCES/", $row['sql'], $matches);
-                    foreach ($matches[1] as $match) {
-                        $foreignKeys[] = $match;
-                    }
-                }
+            if (!isset($foreignKeys[$row['id']])) {
+                $foreignKeys[$row['id']] = [];
             }
+            $foreignKeys[$row['id']][$row['seq']] = $row['from'];
         }
 
         return $foreignKeys;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -249,19 +249,6 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     }
 
     /**
-     * Retrieves information about a given table from one of the SQLite pragmas
-     *
-     * @param string $tableName The table to query
-     * @param string $pragma The pragma to query
-     * @return array
-     */
-    protected function getTableInfo($tableName, $pragma = 'table_info')
-    {
-        $info = $this->getSchemaName($tableName, true);
-        return $this->fetchAll(sprintf('PRAGMA %s%s(%s)', $info['schema'], $pragma, $info['table']));
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function createTable(Table $table, array $columns = [], array $indexes = [])

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1221,4 +1221,114 @@ INPUT;
             'PHP zero string 3' => ['"0e2"', '0', false]
         ];
     }
+
+    /** @dataProvider providePrimaryKeysToCheck
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getSchemaName
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getTableInfo
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::hasPrimaryKey
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getPrimaryKey */
+    public function testHasPrimaryKey($tableDef, $key, $exp)
+    {
+        $this->assertFalse($this->adapter->hasTable('t'), 'Dirty test fixture');
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $this->assertSame($exp, $this->adapter->hasPrimaryKey('t', $key));
+    }
+
+    public function providePrimaryKeysToCheck()
+    {
+        return [
+            ['create table t(a integer)', 'a', false],
+            ['create table t(a integer)', [], true],
+            ['create table t(a integer primary key)', 'a', true],
+            ['create table t(a integer primary key)', [], false],
+            ['create table t(a integer PRIMARY KEY)', 'a', true],
+            ['create table t(`a` integer PRIMARY KEY)', 'a', true],
+            ['create table t("a" integer PRIMARY KEY)', 'a', true],
+            ['create table t([a] integer PRIMARY KEY)', 'a', true],
+            ['create table t(`a` integer PRIMARY KEY)', 'a', true],
+            ['create table t(\'a\' integer PRIMARY KEY)', 'a', true],
+            ['create table t(`a.a` integer PRIMARY KEY)', 'a.a', true],
+            ['create table t(a integer primary key)', ['a'], true],
+            ['create table t(a integer primary key)', ['a', 'b'], false],
+            ['create table t(a integer, primary key(a))', 'a', true],
+            ['create table t(a integer, primary key("a"))', 'a', true],
+            ['create table t(a integer, primary key([a]))', 'a', true],
+            ['create table t(a integer, primary key(`a`))', 'a', true],
+            ['create table t(a integer, b integer primary key)', 'a', false],
+            ['create table t(a integer, b text primary key)', 'b', true],
+            ['create table t(a integer, b integer default 2112 primary key)', ['a'], false],
+            ['create table t(a integer, b integer primary key)', ['b'], true],
+            ['create table t(a integer, b integer primary key)', ['b', 'b'], true], // duplicate column is collapsed
+            ['create table t(a integer, b integer, primary key(a,b))', ['b', 'a'], true],
+            ['create table t(a integer, b integer, primary key(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, primary key(a,b))', 'a', false],
+            ['create table t(a integer, b integer, primary key(a,b))', ['a'], false],
+            ['create table t(a integer, b integer, primary key(a,b))', ['a', 'b', 'c'], false],
+            ['create table t(a integer, b integer, primary key(a,b))', ['a', 'B'], true],
+            ['create table t(a integer, "B" integer, primary key(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, constraint t_pk primary key(a,b))', ['a', 'b'], true],
+            ['create table t(a integer); create temp table t(a integer primary key)', 'a', true],
+            ['create temp table t(a integer primary key)', 'a', true],
+            ['create table t("0" integer primary key)', ['0'], true],
+            ['create table t("0" integer primary key)', ['0e0'], false],
+            ['create table t("0e0" integer primary key)', ['0'], false],
+            ['create table not_t(a integer)', 'a', false] // test checks table t which does not exist
+        ];
+    }
+
+    /** @covers \Phinx\Db\Adapter\SQLiteAdapter::hasPrimaryKey */
+    public function testHasNamedPrimaryKey()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->adapter->hasPrimaryKey('t', [], 'named_constraint');
+    }
+
+    /** @dataProvider provideForeignKeysToCheck
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getSchemaName
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getTableInfo
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::hasForeignKey
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getForeignKeys */
+    public function testHasForeignKey($tableDef, $key, $exp)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec('CREATE TABLE other(a integer, b integer, c integer)');
+        $conn->exec($tableDef);
+        $this->assertSame($exp, $this->adapter->hasForeignKey('t', $key));
+    }
+
+    public function provideForeignKeysToCheck()
+    {
+        return [
+            ['create table t(a integer)', 'a', false],
+            ['create table t(a integer)', [], false],
+            ['create table t(a integer primary key)', 'a', false],
+            ['create table t(a integer references other(a))', 'a', true],
+            ['create table t(a integer references other(b))', 'a', true],
+            ['create table t(a integer references other(b))', ['a'], true],
+            ['create table t(a integer references other(b))', ['a', 'a'], true], // duplicate column is collapsed
+            ['create table t(a integer, foreign key(a) references other(a))', 'a', true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', 'a', false],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['b', 'a'], true],
+            ['create table t(a integer, "B" integer, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'B'], true],
+            ['create table t(a integer, b integer, c integer, foreign key(a,b,c) references other(a,b,c))', ['a', 'b'], false],
+            ['create table t(a integer, foreign key(a) references other(a))', ['a', 'b'], false],
+            ['create table t(a integer references other(a), b integer references other(b))', ['a', 'b'], false],
+            ['create table t(a integer references other(a), b integer references other(b))', ['a', 'b'], false],
+            ['create table t(a integer); create temp table t(a integer references other(a))', ['a'], true],
+            ['create temp table t(a integer references other(a))', ['a'], true],
+            ['create table t("0" integer references other(a))', '0', true],
+            ['create table t("0" integer references other(a))', '0e0', false],
+            ['create table t("0e0" integer references other(a))', '0', false],
+        ];
+    }
+
+    /** @covers \Phinx\Db\Adapter\SQLiteAdapter::hasForeignKey */
+    public function testHasNamedForeignKey()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->adapter->hasForeignKey('t', [], 'named_constraint');
+    }
 }


### PR DESCRIPTION
Corrected implementations of `SQLiteAdapter::hasPrimaryKey()` and `SQLiteAdapter::hasForeignKey()`. They were changed in the following ways:

- Avoids haphazard SQL scraping
- Reports correctly on composite primary keys
- Reports correctly on composite foreign keys
- Reports correctly on subsets of composite keys
- Fully case-insensitive
- Fails noisily when a named constraint is queried

Fixes #1538 and  fixes #1539.