### PR TITLE
New implementation of getColumns for SQLite

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -450,10 +450,9 @@ PCRE_PATTERN;
         // reconstitute the string, trimming whitespace as well as parentheses
         $vClean = trim(implode('', $matches));
         $vBare = rtrim(ltrim($vClean, $trimChars . '('), $trimChars . ')');
-        if (preg_match('/^true|false$/i', $vBare)) {
-            // boolean literal
-            return filter_var($vClean, \FILTER_VALIDATE_BOOLEAN);
-        } elseif (preg_match('/^CURRENT_(?:DATE|TIME|TIMESTAMP)$/i', $vBare)) {
+
+        // match the string against one of several patterns
+        if (preg_match('/^CURRENT_(?:DATE|TIME|TIMESTAMP)$/i', $vBare)) {
             // magic date or time
             return strtoupper($vBare);
         } elseif (preg_match('/^\'(?:[^\']|\'\')*\'$/i', $vBare)) {
@@ -477,6 +476,9 @@ PCRE_PATTERN;
         } elseif (preg_match('/^null$/i', $vBare)) {
             // null literal
             return null;
+        } elseif (preg_match('/^true|false$/i', $vBare)) {
+            // boolean literal
+            return filter_var($vClean, \FILTER_VALIDATE_BOOLEAN);
         } else {
             // any other expression: return the expression with parentheses, but without comments
             return Expression::from($vClean);

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -438,8 +438,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                 \[[^\]]*\]|                     # SQL Server identifier
                 --[^\r\n]*|                     # Single-line comment
                 \/\*(?:\*(?!\/)|[^\*])*\*\/|    # Multi-line comment
-               [^\/\-]+|                        # Other non-special characters
-               .                                # Anything else
+                [^\/\-]+|                       # Non-special characters
+                .                               # Any other single character
             /sx
 PCRE_PATTERN;
         preg_match_all($pattern, $v, $matches);

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -125,20 +125,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function databaseVersionAtLeast($ver)
     {
-        $ver = array_map('intval', explode('.', $ver));
         $actual = $this->query('SELECT sqlite_version()')->fetchColumn();
-        $actual = array_map('intval', explode('.', $actual));
-        $actual = array_pad($actual, sizeof($ver), 0);
-
-        for ($a = 0; $a < sizeof($ver); $a++) {
-            if ($actual[$a] < $ver[$a]) {
-                return false;
-            } elseif ($actual[$a] > $ver[$a]) {
-                return true;
-            }
-        }
-
-        return true;
+        return version_compare($actual, $ver, '>=');
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -599,7 +599,7 @@ PCRE_PATTERN;
 
         foreach ($rows as $columnInfo) {
             $column = new Column();
-            $type = $this->getPhinxType(strtolower($columnInfo['type']));  // FIXME: this should not be lowercased, but the current implementation of getPhinxType requires it
+            $type = $this->getPhinxType($columnInfo['type']);
             $default = $this->parseDefaultValue($columnInfo['dflt_value'], $type['name']);
             
             $column->setName($columnInfo['name'])

--- a/src/Phinx/Util/Expression.php
+++ b/src/Phinx/Util/Expression.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Phinx\Util;
+
+class Expression
+{
+    /**
+     * @var string The expression
+     */
+    private $value;
+
+    /**
+     * @param string $value The expression
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string Returns the expression
+     */
+    public function __toString()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value The expression
+     *
+     * @return self
+     */
+    public static function from($value)
+    {
+        return new self($value);
+    }
+}

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -568,45 +568,6 @@ class SQLiteAdapterTest extends TestCase
         ];
     }
 
-    /**
-     *
-     * @dataProvider columnsProvider
-     *
-     * @param string $colName
-     * @param string $type
-     * @param array $options
-     * @param string|null $actualType
-     */
-    public function testGetColumnsOld($colName, $type, $options, $actualType = null)
-    {
-        // TODO: This test-set should be obsolete, but there are no other tests covering all the same lines of getPhinxType and getSqlType in this branch
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
-        $table->addColumn($colName, $type, $options)->save();
-
-        $columns = $this->adapter->getColumns('t');
-        $this->assertCount(2, $columns);
-        $this->assertEquals($colName, $columns[1]->getName());
-
-        $this->assertEquals($actualType ?: $type, $columns[1]->getType());
-
-        if (isset($options['limit'])) {
-            $this->assertEquals($options['limit'], $columns[1]->getLimit());
-        }
-
-        // SQLiteAdapter doesn't return enum values.
-        if (isset($options['values']) && $type !== 'enum') {
-            $this->assertEquals($options['values'], $columns[1]->getValues());
-        }
-
-        if (isset($options['precision'])) {
-            $this->assertEquals($options['precision'], $columns[1]->getPrecision());
-        }
-
-        if (isset($options['scale'])) {
-            $this->assertEquals($options['scale'], $columns[1]->getScale());
-        }
-    }
-
     public function testAddIndex()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1644,6 +1644,13 @@ INPUT;
         ];
     }
 
+    /** @dataProvider provideDatabaseVersionStrings
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::databaseVersionAtLeast */
+    public function testDatabaseVersionAtLeast($ver, $exp)
+    {
+        $this->assertSame($exp, $this->adapter->databaseVersionAtLeast($ver));
+    }
+
     public function provideDatabaseVersionStrings()
     {
         return [

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1179,8 +1179,7 @@ INPUT;
     /** @dataProvider provideTableNamesForPresenceCheck
      *  @covers \Phinx\Db\Adapter\SQLiteAdapter::hasTable
      *  @covers \Phinx\Db\Adapter\SQLiteAdapter::quoteString
-     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getSchemaName
-     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::resolveTable */
+     *  @covers \Phinx\Db\Adapter\SQLiteAdapter::getSchemaName */
     public function testHasTable($createName, $tableName, $exp)
     {
         // Test case for issue #1535

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -581,7 +581,7 @@ class SQLiteAdapterTest extends TestCase
      */
     public function testGetColumnsOld($colName, $type, $options, $actualType = null)
     {
-        // TODO: This test should be obsolete, but there are not other tests covering getPhinxType or getSqlType in this branch
+        // TODO: This test-set should be obsolete, but there are no other tests covering all the same lines of getPhinxType and getSqlType in this branch
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
         $table->addColumn($colName, $type, $options)->save();
 
@@ -1525,7 +1525,7 @@ INPUT;
             'Explicit null LC'       => ['create table t(a integer default null)', null],
             'Explicit null UC'       => ['create table t(a integer default NULL)', null],
             'Explicit null MC'       => ['create table t(a integer default nuLL)', null],
-            'Extra parentheses'      => ['create table t(a integer default ( null ))', null],
+            'Extra parentheses'      => ['create table t(a integer default ( ( null ) ))', null],
             'Comment 1'              => ["create table t(a integer default ( /* this is perfectly fine */ null ))", null],
             'Comment 2'              => ["create table t(a integer default ( /* this\nis\nperfectly\nfine */ null ))", null],
             'Line comment 1'         => ["create table t(a integer default ( -- this is perfectly fine, too\n null ))", null],
@@ -1567,7 +1567,7 @@ INPUT;
             'Float 8'                => ['create table t(a float default 1e+0)', 1.0],
             'Float 9'                => ['create table t(a float default 1e+1)', 10.0],
             'Float 10'               => ['create table t(a float default 1e-1)', 0.1],
-            'Float 10'               => ['create table t(a float default 1E-1)', 0.1],
+            'Float 11'               => ['create table t(a float default 1E-1)', 0.1],
             'Blob literal 1'         => ['create table t(a float default x\'ff\')', Expression::from('x\'ff\'')],
             'Blob literal 2'         => ['create table t(a float default X\'FF\')', Expression::from('X\'FF\'')],
             'Arbitrary expression'   => ['create table t(a float default ((2) + (2)))', Expression::from('(2) + (2)')],
@@ -1596,12 +1596,12 @@ INPUT;
     public function provideBooleanDefaultValues()
     {
         return [
-            'True LC'                => ['create table t(a boolean default true)', true],
-            'True UC'                => ['create table t(a boolean default TRUE)', true],
-            'True MC'                => ['create table t(a boolean default TRue)', true],
-            'False LC'               => ['create table t(a boolean default false)', false],
-            'False UC'               => ['create table t(a boolean default FALSE)', false],
-            'False MC'               => ['create table t(a boolean default FALse)', false],
+            'True LC'  => ['create table t(a boolean default true)', true],
+            'True UC'  => ['create table t(a boolean default TRUE)', true],
+            'True MC'  => ['create table t(a boolean default TRue)', true],
+            'False LC' => ['create table t(a boolean default false)', false],
+            'False UC' => ['create table t(a boolean default FALSE)', false],
+            'False MC' => ['create table t(a boolean default FALse)', false],
         ];
     }
 }

--- a/tests/Phinx/Util/ExpressionTest.php
+++ b/tests/Phinx/Util/ExpressionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Test\Phinx\Util;
+
+use Phinx\Util\Expression;
+use PHPUnit\Framework\TestCase;
+
+class ExpressionTest extends TestCase
+{
+    public function testToString()
+    {
+        $str = 'test1';
+        $instance = new Expression($str);
+        $this->assertEquals($str, (string)$instance);
+    }
+
+    public function testFrom()
+    {
+        $str = 'test1';
+        $instance = Expression::from($str);
+        $this->assertInstanceOf('\Phinx\Util\Expression', $instance);
+        $this->assertEquals($str, (string)$instance);
+    }
+}


### PR DESCRIPTION
This change constitutes a new implementation of `SQLiteAdapter::getColumns()`. The method itself is not significantly changed, but it now calls out to two new methods: one which correctly identify a table's identity column (if any), and another which correctly interprets default-value expressions. Specifically, the following expressions are recognized and converted to applicable PHP types:

- String literals
- Integers and hexadecimal numbers
- Floats
- `NULL`
- `CURRENT_DATE`, `CURRENT_TIME`, and `CURRENT_TIMESTAMP`
- `TRUE` and `FALSE` (for SQLite 3.24 and later)

Anything else (including blob literals, for now) is wrapped in an instance of the new `Expression` class, a companion to the existing `Literal` class.

~Note that the existing tests for `getColumns()` have been retained as they appear to provide coverage for `getPhinxType()` and `getSqlType()`. Merging PR #1551 would make these tests obsolete. Note also that merging PR #1551 would require a change at line 542 in this patch, as indicated by the `FIXME`.~

Merging this patch should allow PR #1463 to be merged.

Fixes #1550.