### PR TITLE
Fix #1474

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -357,7 +357,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function truncateTable($tableName)
     {
         $sql = sprintf(
-            'TRUNCATE TABLE %s',
+            'TRUNCATE TABLE %s RESTART IDENTITY',
             $this->quoteTableName($tableName)
         );
 


### PR DESCRIPTION
Hello,
By default, phinx postgres adapter does not reset autoincrement, but other adapters (like mysql) do that by default. That PR adds `RESTART IDENTITY` to truncate command in postgres adapter