### PR TITLE
Added the possibility to change the default SRID for geometry type

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1119,7 +1119,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 $buffer[] = sprintf(
                     '(%s,%s)',
                     strtoupper($sqlType['type']),
-                    $sqlType['srid']
+                    $column->getSrid() ?: $sqlType['srid']
                 );
             } elseif (in_array($sqlType['name'], ['time', 'timestamp'])) {
                 if (is_numeric($column->getPrecision())) {

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -112,6 +112,11 @@ class Column
     protected $encoding;
 
     /**
+     * @var integer
+     */
+    protected $srid = null;
+
+    /**
      * @var array
      */
     protected $values;
@@ -606,6 +611,29 @@ class Column
     }
 
     /**
+     * Sets the column SRID.
+     *
+     * @param int $srid
+     * @return \Phinx\Db\Table\Column
+     */
+    public function setSrid($srid)
+    {
+        $this->srid = $srid;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column SRID.
+     *
+     * @return int
+     */
+    public function getSrid()
+    {
+        return $this->srid;
+    }
+
+    /**
      * Gets all allowed options. Each option must have a corresponding `setFoo` method.
      *
      * @return array
@@ -627,6 +655,7 @@ class Column
             'values',
             'collation',
             'encoding',
+            'srid',
         ];
     }
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -613,7 +613,7 @@ class Column
     /**
      * Sets the column SRID.
      *
-     * @param int $srid
+     * @param int $srid SRID
      * @return \Phinx\Db\Table\Column
      */
     public function setSrid($srid)


### PR DESCRIPTION
Main problem was I couldn't change the default SRID sent to geometry type columns.

Currently when using PostgresAdapter plus geometry type columns, all of them will have SRID 4326 and that can't be changed.

My PR adds a new option (srid) while adding columns so user can choose between leaving the default unchanged or not.

```php
  $table->addColumn('column_name', 'geometry', ['srid' => 4674])->save();
```

P.S.: Didn't write PHP Unit tests because this would need PostGIS extension enabled on Postgres.