### PR TITLE
Introduce `--set` and `--unset` options for breakpoints.

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -31,6 +31,10 @@ or ``-r`` for short.
 
         $ phinx breakpoint -e development -r
 
+You can set or unset (rather than just toggle) the breakpoint on the most
+recent migration (or on a specific migration when combined with the
+``--target`` or ``-t`` parameter) by using ``-set`` or ``--unset``.
+
 Breakpoints are visible when you run the ``status`` command.
 
 The Create Command

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -46,11 +46,13 @@ class Breakpoint extends AbstractCommand
 
         $this->setName($this->getName() ?: 'breakpoint')
             ->setDescription('Manage breakpoints')
-            ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to set or clear a breakpoint against')
+            ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to target for the breakpoint')
+            ->addOption('--set', '-s', InputOption::VALUE_NONE, 'Set the breakpoint')
+            ->addOption('--unset', '-u', InputOption::VALUE_NONE, 'Unset the breakpoint')
             ->addOption('--remove-all', '-r', InputOption::VALUE_NONE, 'Remove all breakpoints')
             ->setHelp(
                 <<<EOT
-The <info>breakpoint</info> command allows you to set or clear a breakpoint against a specific target to inhibit rollbacks beyond a certain target.
+The <info>breakpoint</info> command allows you to toggle, set, or unset a breakpoint against a specific target to inhibit rollbacks beyond a certain target.
 If no target is supplied then the most recent migration will be used.
 You cannot specify un-migrated targets
 
@@ -75,6 +77,8 @@ EOT
         $environment = $input->getOption('environment');
         $version = $input->getOption('target');
         $removeAll = $input->getOption('remove-all');
+        $set = $input->getOption('set');
+        $unset = $input->getOption('unset');
 
         if ($environment === null) {
             $environment = $this->getConfig()->getDefaultEnvironment();
@@ -87,9 +91,19 @@ EOT
             throw new \InvalidArgumentException('Cannot toggle a breakpoint and remove all breakpoints at the same time.');
         }
 
-        // Remove all breakpoints
+        if (($set && $unset) || ($set && $removeAll) || ($unset && $removeAll)){
+            throw new \InvalidArgumentException('Cannot use more than one of --set, --clear, or --remove-all at the same time.');
+        }
+
         if ($removeAll) {
+            // Remove all breakpoints.
             $this->getManager()->removeBreakpoints($environment);
+        } elseif ($set) {
+            // Set the breakpoint.
+            $this->getManager()->setBreakpoint($environment, $version);
+        } elseif ($unset) {
+            // Unset the breakpoint.
+            $this->getManager()->unsetBreakpoint($environment, $version);
         } else {
             // Toggle the breakpoint.
             $this->getManager()->toggleBreakpoint($environment, $version);

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -91,7 +91,7 @@ EOT
             throw new \InvalidArgumentException('Cannot toggle a breakpoint and remove all breakpoints at the same time.');
         }
 
-        if (($set && $unset) || ($set && $removeAll) || ($unset && $removeAll)){
+        if (($set && $unset) || ($set && $removeAll) || ($unset && $removeAll)) {
             throw new \InvalidArgumentException('Cannot use more than one of --set, --clear, or --remove-all at the same time.');
         }
 

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -185,6 +185,24 @@ interface AdapterInterface
     public function resetAllBreakpoints();
 
     /**
+     * Set a migration breakpoint.
+     *
+     * @param \Phinx\Migration\MigrationInterface $migration
+     *
+     * @return \Phinx\Db\Adapter\AdapterInterface
+     */
+    public function setBreakpoint(MigrationInterface $migration);
+
+    /**
+     * Unset a migration breakpoint.
+     *
+     * @param \Phinx\Migration\MigrationInterface $migration
+     *
+     * @return \Phinx\Db\Adapter\AdapterInterface
+     */
+    public function unsetBreakpoint(MigrationInterface $migration);
+
+    /**
      * Does the schema table exist?
      *
      * @deprecated use hasTable instead.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -187,7 +187,7 @@ interface AdapterInterface
     /**
      * Set a migration breakpoint.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration
+     * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint set
      *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
@@ -196,7 +196,7 @@ interface AdapterInterface
     /**
      * Unset a migration breakpoint.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration
+     * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint unset
      *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -256,6 +256,26 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
+    public function setBreakpoint(MigrationInterface $migration)
+    {
+        $this->getAdapter()->setBreakpoint($migration);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unsetBreakpoint(MigrationInterface $migration)
+    {
+        $this->getAdapter()->unsetBreakpoint($migration);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasSchemaTable()
     {
         return $this->getAdapter()->hasSchemaTable();

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -432,6 +432,47 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * {@inheritdoc}
      */
+    public function setBreakpoint(MigrationInterface $migration)
+    {
+        return $this->markBreakpoint($migration, true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unsetBreakpoint(MigrationInterface $migration)
+    {
+        return $this->markBreakpoint($migration, false);
+    }
+
+    /**
+     * Mark a migration breakpoint.
+     *
+     * @param \Phinx\Migration\MigrationInterface $migration
+     * @param bool $stat
+     *
+     * @return \Phinx\Db\Adapter\AdapterInterface
+     */
+    protected function markBreakpoint(MigrationInterface $migration, bool $state)
+    {
+        $this->query(
+            sprintf(
+                'UPDATE %1$s SET %2$s = %3$s, %4$s = %4$s WHERE %5$s = \'%6$s\';',
+                $this->getSchemaTableName(),
+                $this->quoteColumnName('breakpoint'),
+                $this->castToBool($state),
+                $this->quoteColumnName('start_time'),
+                $this->quoteColumnName('version'),
+                $migration->getVersion()
+            )
+        );
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function createSchema($schemaName = 'public')
     {
         throw new BadMethodCallException('Creating a schema is not supported');

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -448,8 +448,8 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * Mark a migration breakpoint.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration
-     * @param bool $state
+     * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint
+     * @param bool $state The required state of the breakpoint
      *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -453,7 +453,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    protected function markBreakpoint(MigrationInterface $migration, bool $state)
+    protected function markBreakpoint(MigrationInterface $migration, $state)
     {
         $this->query(
             sprintf(

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -449,7 +449,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Mark a migration breakpoint.
      *
      * @param \Phinx\Migration\MigrationInterface $migration
-     * @param bool $stat
+     * @param bool $state
      *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -990,9 +990,9 @@ class Manager
     /**
      * Toggles the breakpoint for a specific version.
      *
-     * @param string $environment
-     * @param int|null $version
-     * @param int $mark
+     * @param string $environment The required environment
+     * @param int|null $version The version of the target migration
+     * @param int $mark The state of the breakpoint as defined by self::BREAKPOINT_xxxx constants.
      *
      * @return void
      */
@@ -1049,7 +1049,7 @@ class Manager
     /**
      * Remove all breakpoints
      *
-     * @param string $environment
+     * @param string $environment The required environment
      * @return void
      */
     public function removeBreakpoints($environment)
@@ -1063,8 +1063,8 @@ class Manager
     /**
      * Set the breakpoint for a specific version.
      *
-     * @param string $environment
-     * @param int|null $version
+     * @param string $environment The required environment
+     * @param int|null $version The version of the target migration
      *
      * @return void
      */
@@ -1076,8 +1076,8 @@ class Manager
     /**
      * Unset the breakpoint for a specific version.
      *
-     * @param string $environment
-     * @param int|null $version
+     * @param string $environment The required environment
+     * @param int|null $version The version of the target migration
      *
      * @return void
      */

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -1057,8 +1057,7 @@ class Manager
         $this->getOutput()->writeln(sprintf(
             ' %d breakpoints cleared.',
             $this->getEnvironment($environment)->getAdapter()->resetAllBreakpoints()
-        )
-        );
+        ));
     }
 
     /**

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -44,7 +44,7 @@ class BreakpointTest extends TestCase
         $this->config = new Config(
             [
                 'paths' => [
-                    'migrations' => sys_get_temp_dir() . DIRECTORY_SEPARATOR.'migrations',
+                    'migrations' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations',
                 ],
                 'environments' => [
                     'default_migration_table' => 'phinxlog',

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -40,11 +40,11 @@ class BreakpointTest extends TestCase
 
     protected function setUp()
     {
-        @mkdir(sys_get_temp_dir().DIRECTORY_SEPARATOR.'migrations', 0777, true);
+        @mkdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations', 0777, true);
         $this->config = new Config(
             [
                 'paths' => [
-                    'migrations' => sys_get_temp_dir().DIRECTORY_SEPARATOR.'migrations',
+                    'migrations' => sys_get_temp_dir() . DIRECTORY_SEPARATOR.'migrations',
                 ],
                 'environments' => [
                     'default_migration_table' => 'phinxlog',
@@ -62,7 +62,7 @@ class BreakpointTest extends TestCase
         );
 
         foreach ($this->config->getMigrationPaths() as $path) {
-            foreach (glob($path.'/*.*') as $migration) {
+            foreach (glob($path . '/*.*') as $migration) {
                 unlink($migration);
             }
         }

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -223,19 +223,19 @@ class BreakpointTest extends TestCase
     public function provideCombinedParametersToCauseException()
     {
         return [
-            'Remove with Set'=> [
+            'Remove with Set' => [
                 [
                     '--remove-all' => true,
                     '--set' => true,
                 ]
             ],
-            'Remove with Unset'=> [
+            'Remove with Unset' => [
                 [
                     '--remove-all' => true,
                     '--unset' => true,
                 ]
             ],
-            'Set with Unset'=> [
+            'Set with Unset' => [
                 [
                     '--set' => true,
                     '--unset' => true,

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Test\Phinx\Console\Command;
+
+use InvalidArgumentException;
+use Phinx\Config\Config;
+use Phinx\Config\ConfigInterface;
+use Phinx\Console\Command\Breakpoint;
+use Phinx\Console\PhinxApplication;
+use Phinx\Migration\Manager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class BreakpointTest extends TestCase
+{
+    /**
+     * @var ConfigInterface|array
+     */
+    protected $config = [];
+
+    /**
+     * @var InputInterface $input
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface $output
+     */
+    protected $output;
+
+    /**
+     * Default Test Environment
+     */
+    const DEFAULT_TEST_ENVIRONMENT = 'development';
+
+    protected function setUp()
+    {
+        @mkdir(sys_get_temp_dir().DIRECTORY_SEPARATOR.'migrations', 0777, true);
+        $this->config = new Config(
+            [
+                'paths' => [
+                    'migrations' => sys_get_temp_dir().DIRECTORY_SEPARATOR.'migrations',
+                ],
+                'environments' => [
+                    'default_migration_table' => 'phinxlog',
+                    'default_database' => 'development',
+                    'development' => [
+                        'adapter' => 'mysql',
+                        'host' => 'fakehost',
+                        'name' => 'development',
+                        'user' => '',
+                        'pass' => '',
+                        'port' => 3006,
+                    ],
+                ],
+            ]
+        );
+
+        foreach ($this->config->getMigrationPaths() as $path) {
+            foreach (glob($path.'/*.*') as $migration) {
+                unlink($migration);
+            }
+        }
+
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
+    }
+
+    /**
+     * @param string $testMethod
+     * @param array $commandLine
+     * @param int|null $version
+     * @param bool $noVersionParameter
+     *
+     * @dataProvider provideBreakpointTests
+     */
+    public function testExecute($testMethod, $commandLine, $version = null, $noVersionParameter = false)
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Breakpoint());
+
+        /** @var Breakpoint $command */
+        $command = $application->find('breakpoint');
+
+        // mock the manager class
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+        if ($noVersionParameter) {
+            $managerStub->expects($this->once())
+                ->method($testMethod)
+                ->with(self::DEFAULT_TEST_ENVIRONMENT);
+        } else {
+            $managerStub->expects($this->once())
+                ->method($testMethod)
+                ->with(self::DEFAULT_TEST_ENVIRONMENT, $version);
+        }
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+
+        $commandLine = array_merge(['command' => $command->getName()], $commandLine);
+        $commandTester->execute($commandLine, ['decorated' => false]);
+    }
+
+    public function provideBreakpointTests()
+    {
+        return [
+            'Toggle Breakpoint' => [
+                'toggleBreakpoint',
+                [],
+            ],
+            'Set Breakpoint without a target' => [
+                'setBreakpoint',
+                [
+                    '--set' => true,
+                ],
+            ],
+            'Set Breakpoint with a target' => [
+                'setBreakpoint',
+                [
+                    '--set' => true,
+                    '--target' => '123456',
+                ],
+                '123456',
+            ],
+            'Unset Breakpoint without a target' => [
+                'unsetBreakpoint',
+                [
+                    '--unset' => true,
+                ],
+            ],
+            'Unset Breakpoint with a target' => [
+                'unsetBreakpoint',
+                [
+                    '--unset' => true,
+                    '--target' => '123456',
+                ],
+                '123456',
+            ],
+            'Remove Breakpoints' => [
+                'removeBreakpoints',
+                [
+                    '--remove-all' => true,
+                ],
+                null,
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Cannot toggle a breakpoint and remove all breakpoints at the same time.
+     */
+    public function testRemoveAllAndTargetThrowsException()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Breakpoint());
+
+        /** @var Breakpoint $command */
+        $command = $application->find('breakpoint');
+
+        // mock the manager class
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute(
+            [
+                'command' => $command->getName(),
+                '--remove-all' => true,
+                '--target' => '123456',
+            ],
+            ['decorated' => false]
+        );
+    }
+
+    /**
+     * @param array $commandLine
+     *
+     * @dataProvider provideCombinedParametersToCauseException
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Cannot use more than one of --set, --clear, or --remove-all at the same time.
+     */
+    public function testRemoveAllSetUnsetCombinedThrowsException($commandLine)
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Breakpoint());
+
+        /** @var Breakpoint $command */
+        $command = $application->find('breakpoint');
+
+        // mock the manager class
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+
+        $commandLine = array_merge(['command' => $command->getName()], $commandLine);
+        $commandTester->execute($commandLine, ['decorated' => false]);
+    }
+
+    public function provideCombinedParametersToCauseException()
+    {
+        return [
+            'Remove with Set'=> [
+                [
+                    '--remove-all' => true,
+                    '--set' => true,
+                ]
+            ],
+            'Remove with Unset'=> [
+                [
+                    '--remove-all' => true,
+                    '--unset' => true,
+                ]
+            ],
+            'Set with Unset'=> [
+                [
+                    '--set' => true,
+                    '--unset' => true,
+                ]
+            ],
+        ];
+    }
+}

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5681,9 +5681,7 @@ class ManagerTest extends TestCase
         $this->assertEquals(0, end($originalVersions)['breakpoint']);
 
         // Wait until the second has changed.
-        $now = time();
-        while ($now == time()) {
-        }
+        sleep(1);
 
         // Toggle the breakpoint on most recent migration
         $this->manager->toggleBreakpoint('production', null);
@@ -5703,9 +5701,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        $now = time();
-        while ($now == time()) {
-        }
+        sleep(1);
 
         // Toggle the breakpoint on most recent migration
         $this->manager->toggleBreakpoint('production', null);
@@ -5725,9 +5721,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        $now = time();
-        while ($now == time()) {
-        }
+        sleep(1);
 
         // Reset all breakpoints and toggle the most recent migration twice
         $this->manager->removeBreakpoints('production');
@@ -5749,9 +5743,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        $now = time();
-        while ($now == time()) {
-        }
+        sleep(1);
 
         // Set the breakpoint on the latest migration
         $this->manager->setBreakpoint('production', null);
@@ -5771,9 +5763,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        $now = time();
-        while ($now == time()) {
-        }
+        sleep(1);
 
         // Set the breakpoint on the first migration
         $this->manager->setBreakpoint('production', reset($originalVersions)['version']);
@@ -5793,9 +5783,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        $now = time();
-        while ($now == time()) {
-        }
+        sleep(1);
 
         // Unset the breakpoint on the latest migration
         $this->manager->unsetBreakpoint('production', null);
@@ -5815,9 +5803,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        $now = time();
-        while ($now == time()) {
-        }
+        sleep(1);
 
         // Unset the breakpoint on the first migration
         $this->manager->unsetBreakpoint('production', reset($originalVersions)['version']);

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5681,7 +5681,7 @@ class ManagerTest extends TestCase
         $this->assertEquals(0, end($originalVersions)['breakpoint']);
 
         // Wait until the second has changed.
-        time_sleep_until(time() + 1);
+        sleep(1);
 
         // Toggle the breakpoint on most recent migration
         $this->manager->toggleBreakpoint('production', null);
@@ -5701,7 +5701,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        time_sleep_until(time() + 1);
+        sleep(1);
 
         // Toggle the breakpoint on most recent migration
         $this->manager->toggleBreakpoint('production', null);
@@ -5721,7 +5721,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        time_sleep_until(time() + 1);
+        sleep(1);
 
         // Reset all breakpoints and toggle the most recent migration twice
         $this->manager->removeBreakpoints('production');
@@ -5743,7 +5743,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        time_sleep_until(time() + 1);
+        sleep(1);
 
         // Set the breakpoint on the latest migration
         $this->manager->setBreakpoint('production', null);
@@ -5763,7 +5763,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        time_sleep_until(time() + 1);
+        sleep(1);
 
         // Set the breakpoint on the first migration
         $this->manager->setBreakpoint('production', reset($originalVersions)['version']);
@@ -5783,7 +5783,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        time_sleep_until(time() + 1);
+        sleep(1);
 
         // Unset the breakpoint on the latest migration
         $this->manager->unsetBreakpoint('production', null);
@@ -5803,7 +5803,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        time_sleep_until(time() + 1);
+        sleep(1);
 
         // Unset the breakpoint on the first migration
         $this->manager->unsetBreakpoint('production', reset($originalVersions)['version']);

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5681,7 +5681,7 @@ class ManagerTest extends TestCase
         $this->assertEquals(0, end($originalVersions)['breakpoint']);
 
         // Wait until the second has changed.
-        sleep(1);
+        time_sleep_until(time() + 1);
 
         // Toggle the breakpoint on most recent migration
         $this->manager->toggleBreakpoint('production', null);
@@ -5701,7 +5701,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        sleep(1);
+        time_sleep_until(time() + 1);
 
         // Toggle the breakpoint on most recent migration
         $this->manager->toggleBreakpoint('production', null);
@@ -5721,7 +5721,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        sleep(1);
+        time_sleep_until(time() + 1);
 
         // Reset all breakpoints and toggle the most recent migration twice
         $this->manager->removeBreakpoints('production');
@@ -5743,7 +5743,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        sleep(1);
+        time_sleep_until(time() + 1);
 
         // Set the breakpoint on the latest migration
         $this->manager->setBreakpoint('production', null);
@@ -5763,7 +5763,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        sleep(1);
+        time_sleep_until(time() + 1);
 
         // Set the breakpoint on the first migration
         $this->manager->setBreakpoint('production', reset($originalVersions)['version']);
@@ -5783,7 +5783,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        sleep(1);
+        time_sleep_until(time() + 1);
 
         // Unset the breakpoint on the latest migration
         $this->manager->unsetBreakpoint('production', null);
@@ -5803,7 +5803,7 @@ class ManagerTest extends TestCase
         }
 
         // Wait until the second has changed.
-        sleep(1);
+        time_sleep_until(time() + 1);
 
         // Unset the breakpoint on the first migration
         $this->manager->unsetBreakpoint('production', reset($originalVersions)['version']);


### PR DESCRIPTION
This enhances the current breakpoint feature and provides greater control
over the state of a breakpoint, without the need to have any prior
knowledge of the state of the breakpoints.