### PR TITLE
Add development version of CakePHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ addons:
   postgresql: "9.2"
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ env:
 
 matrix:
   include:
-    - php: 7
+    - php: 7.3
       env: PHPCS=1 DEFAULT=0
 
-    - php: 7.1
+    - php: 7.3
       env: PHPSTAN=1 DEFAULT=0
 
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,11 +47,11 @@ install:
         echo extension=php_intl.dll >> php.ini
         echo extension=php_fileinfo.dll >> php.ini
 
-        Invoke-WebRequest -Uri https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.2.0/php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -OutFile pdosqlsrv.zip
-        7z x pdosqlsrv.zip -oC:\php\ext php_pdo_sqlsrv.dll > nul
+        appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.2.0/php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip
+        7z x php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -oC:\php\ext php_pdo_sqlsrv.dll > nul
 
-        Invoke-WebRequset -Uri https://windows.php.net/downloads/pecl/releases/sqlsrv/5.2.0/php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -OutFile sqlsrv.zip
-        7z x sqlsrv.zip -oC:\php\ext php_sqlsrv.dll > nul
+        appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/sqlsrv/5.2.0/php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip
+        7z x php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -oC:\php\ext php_sqlsrv.dll > nul
         echo extension=php_pdo_sqlsrv.dll >> php.ini
         echo extension=php_sqlsrv.dll >> php.ini
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 build: false
 shallow_clone: false
-platform: 'x86'
+platform: 'x64'
 clone_folder: C:\projects\phinx
 environment:
   TESTS_PHINX_DB_ADAPTER_SQLSRV_ENABLED: true
@@ -28,32 +28,34 @@ cache:
   - C:\php -> .appveyor.yml
 
 init:
-    - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+    - SET PATH=C:\Program Files\OpenSSL;c:\php;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
-    - SET PHP=1
     - SET ANSICON=121x90 (121x90)
 
 install:
   - ps: |
       # Check if installation is cached
       if (!(Test-Path C:\php)) {
-        appveyor-retry cinst --params '""/InstallDir:C:\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+        # Windows Update Service is disabled in AppVeyor, enable to install PHP dependencies
+        Set-Service wuauserv -StartupType Manual
+        cinst --no-progress --params '""/InstallDir:C:\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+
         cd C:\php
-        copy /Y php.ini-production php.ini
-        echo date.timezone="UTC" >> php.ini
-        echo extension_dir=ext >> php.ini
-        echo extension=php_openssl.dll >> php.ini
-        echo extension=php_mbstring.dll >> php.ini
-        echo extension=php_intl.dll >> php.ini
-        echo extension=php_fileinfo.dll >> php.ini
+        copy php.ini-production php.ini
+        Add-Content php.ini date.timezone="UTC"
+        Add-Content php.ini extension_dir=ext
+        Add-Content php.ini extension=php_openssl.dll
+        Add-Content php.ini extension=php_mbstring.dll
+        Add-Content php.ini extension=php_intl.dll
+        Add-Content php.ini extension=php_fileinfo.dll
 
-        appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.2.0/php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip
-        7z x php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -oC:\php\ext php_pdo_sqlsrv.dll > nul
+        Invoke-WebRequest -UserAgent "AppVeyor" https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.2.0/php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -OutFile php_pdo_sqlsrv.zip
+        7z x php_pdo_sqlsrv.zip -oC:\php\ext php_pdo_sqlsrv.dll -aoa > $null
 
-        appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/sqlsrv/5.2.0/php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip
-        7z x php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -oC:\php\ext php_sqlsrv.dll > nul
-        echo extension=php_pdo_sqlsrv.dll >> php.ini
-        echo extension=php_sqlsrv.dll >> php.ini
+        Invoke-WebRequest -UserAgent "AppVeyor" https://windows.php.net/downloads/pecl/releases/sqlsrv/5.2.0/php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -OutFile php_sqlsrv.zip
+        7z x php_sqlsrv.zip -oC:\php\ext php_sqlsrv.dll -aoa > $null
+        Add-Content php.ini extension=php_pdo_sqlsrv.dll
+        Add-Content php.ini extension=php_sqlsrv.dll
       }
 
   - cd C:\projects\phinx
@@ -61,7 +63,7 @@ install:
   - IF %dependencies%==lowest php composer.phar update --prefer-lowest --no-progress -n
   - IF %dependencies%==current php composer.phar install --no-progress
   - IF %dependencies%==highest php composer.phar update --no-progress -n
-  - composer show
+  - php composer.phar show
 
 test_script:
   - sqlcmd -S localhost,1433 -U sa -P Password12! -Q "create database phinxtesting;"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
   TESTS_PHINX_DB_ADAPTER_SQLSRV_PASSWORD: Password12!
   TESTS_PHINX_DB_ADAPTER_SQLSRV_DATABASE: phinxtesting
   TESTS_PHINX_DB_ADAPTER_SQLSRV_PORT: 1433
+  php_ver_target: 7.2
   matrix:
       - dependencies: highest
         db: 2012
@@ -21,7 +22,8 @@ services:
   - mssql2012sp1
 
 cache:
-    - '%LOCALAPPDATA%\Composer\files -> composer.lock'
+  - '%LOCALAPPDATA%\Composer\files -> composer.lock'
+  - C:\php -> .appveyor.yml
 
 init:
     - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
@@ -30,27 +32,37 @@ init:
     - SET ANSICON=121x90 (121x90)
 
 install:
-    - IF EXIST c:\tools\php (SET PHP=0)
-    - curl -fsS https://windows.php.net/downloads/releases/archives/%php_zip% -o php.zip
-    - curl -fsS %sqlsrv%  -o sqlsrv.exe
-    - 7z x php.zip -oc:\tools\php
-    - 7z x sqlsrv.exe -oc:\tools\php\ext
-    - cd c:\tools\php
-    - IF %PHP%==1 copy php.ini-production php.ini /Y
-    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
-    - IF %PHP%==1 echo extension_dir=ext >> php.ini
-    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_sqlsrv_%php_ddl%.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_pdo_sqlsrv_%php_ddl%.dll >> php.ini
-    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
-    - curl -fsS https://getcomposer.org/composer.phar  -o composer.phar
-    - cd c:\projects\phinx
-    - IF %dependencies%==lowest composer update --prefer-lowest --no-progress --profile -n
-    - IF %dependencies%==current composer install --no-progress --profile
-    - IF %dependencies%==highest composer update --no-progress --profile -n
-    - composer show
+  - ps: |
+      # Check if installation is cached
+      if (!(Test-Path C:\php)) {
+        appveyor-retry cinst --params '""/InstallDir:C:\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+        cd C:\php
+        copy php.ini-production php.ini /Y
+        echo date.timezone="UTC" >> php.ini
+        echo extension_dir=ext >> php.ini
+        echo extension=php_openssl.dll >> php.ini
+        echo extension=php_mbstring.dll >> php.ini
+        echo extension=php_intl.dll >> php.ini
+        echo extension=php_fileinfo.dll >> php.ini
+
+        curl -fsS https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.2.0/php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -o pdosqlsrv.zip
+        7z x pdosqlsrv.zip -oC:\php\ext php_pdo_sqlsrv.dll > nul
+        curl -fsS https://windows.php.net/downloads/pecl/releases/sqlsrv/5.2.0/php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -o sqlsrv.zip
+        7z x sqlsrv.zip -oC:\php\ext php_sqlsrv.dll > nul
+        echo extension=php_pdo_sqlsrv.dll >> php.ini
+        echo extension=php_sqlsrv.dll >> php.ini
+
+        curl -fsS https://windows.php.net/downloads/pecl/releases/wincache/2.0.0.8/php_wincache-2.0.0.8-7.2-nts-vc15-x64.zip -o wincache.zip
+        7z x wincache.zip -oC:\php\ext php_wincache.dll > nul
+        echo wincache.enablecli = 1 >> php.ini
+      }
+
+  - cd c:\projects\phinx
+  - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
+  - IF %dependencies%==lowest php composer.phar update --prefer-lowest --no-progress -n
+  - IF %dependencies%==current php composer.phar install --no-progress
+  - IF %dependencies%==highest php composer.phar update --no-progress -n
+  - composer show
 
 test_script:
   - sqlcmd -S localhost,1433 -U sa -P Password12! -Q "create database phinxtesting;"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,8 @@ services:
 
 cache:
   - '%LOCALAPPDATA%\Composer\files -> composer.lock'
+  - C:\ProgramData\chocolatey\bin -> .appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> .appveyor.yml
   - C:\php -> .appveyor.yml
 
 init:
@@ -37,7 +39,7 @@ install:
       if (!(Test-Path C:\php)) {
         appveyor-retry cinst --params '""/InstallDir:C:\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
         cd C:\php
-        copy php.ini-production php.ini /Y
+        copy /Y php.ini-production php.ini
         echo date.timezone="UTC" >> php.ini
         echo extension_dir=ext >> php.ini
         echo extension=php_openssl.dll >> php.ini
@@ -45,19 +47,16 @@ install:
         echo extension=php_intl.dll >> php.ini
         echo extension=php_fileinfo.dll >> php.ini
 
-        curl -fsS https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.2.0/php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -o pdosqlsrv.zip
+        Invoke-WebRequest -Uri https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/5.2.0/php_pdo_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -OutFile pdosqlsrv.zip
         7z x pdosqlsrv.zip -oC:\php\ext php_pdo_sqlsrv.dll > nul
-        curl -fsS https://windows.php.net/downloads/pecl/releases/sqlsrv/5.2.0/php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -o sqlsrv.zip
+
+        Invoke-WebRequset -Uri https://windows.php.net/downloads/pecl/releases/sqlsrv/5.2.0/php_sqlsrv-5.2.0-7.2-nts-vc15-x64.zip -OutFile sqlsrv.zip
         7z x sqlsrv.zip -oC:\php\ext php_sqlsrv.dll > nul
         echo extension=php_pdo_sqlsrv.dll >> php.ini
         echo extension=php_sqlsrv.dll >> php.ini
-
-        curl -fsS https://windows.php.net/downloads/pecl/releases/wincache/2.0.0.8/php_wincache-2.0.0.8-7.2-nts-vc15-x64.zip -o wincache.zip
-        7z x wincache.zip -oC:\php\ext php_wincache.dll > nul
-        echo wincache.enablecli = 1 >> php.ini
       }
 
-  - cd c:\projects\phinx
+  - cd C:\projects\phinx
   - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
   - IF %dependencies%==lowest php composer.phar update --prefer-lowest --no-progress -n
   - IF %dependencies%==current php composer.phar install --no-progress

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,8 @@
         "homepage": "https://github.com/cakephp/phinx/graphs/contributors"
     }],
     "require": {
-        "php": ">=5.6",
-        "cakephp/collection": "^3.6",
-        "cakephp/database": "^3.6",
+        "php": ">=7.2",
+        "cakephp/cakephp": "4.x-dev as 4.0.0",
         "symfony/console": "^2.8|^3.0|^4.0",
         "symfony/config": "^2.8|^3.0|^4.0",
         "symfony/yaml": "^2.8|^3.0|^4.0"
@@ -56,5 +55,6 @@
         "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests ./app",
         "test": "phpunit --colors=always"
     },
-    "bin": ["bin/phinx"]
+    "bin": ["bin/phinx"],
+    "minimum-stability": "dev"
 }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1270,11 +1270,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         ] + $options;
 
         $driver = new MysqlDriver($options);
-        if (method_exists($driver, 'setConnection')) {
-            $driver->setConnection($this->connection);
-        } else {
-            $driver->connection($this->connection);
-        }
+        $driver->setConnection($this->connection);
 
         return new Connection(['driver' => $driver] + $options);
     }

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1399,11 +1399,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
 
         $driver = new PostgresDriver($options);
 
-        if (method_exists($driver, 'setConnection')) {
-            $driver->setConnection($this->connection);
-        } else {
-            $driver->connection($this->connection);
-        }
+        $driver->setConnection($this->connection);
 
         return new Connection(['driver' => $driver] + $options);
     }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1508,11 +1508,7 @@ PCRE_PATTERN;
         }
 
         $driver = new SqliteDriver($options);
-        if (method_exists($driver, 'setConnection')) {
-            $driver->setConnection($this->connection);
-        } else {
-            $driver->connection($this->connection);
-        }
+        $driver->setConnection($this->connection);
 
         return new Connection(['driver' => $driver] + $options);
     }

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1271,12 +1271,7 @@ SQL;
         ] + $options;
 
         $driver = new SqlServerDriver($options);
-
-        if (method_exists($driver, 'setConnection')) {
-            $driver->setConnection($this->connection);
-        } else {
-            $driver->connection($this->connection);
-        }
+        $driver->setConnection($this->connection);
 
         return new Connection(['driver' => $driver] + $options);
     }


### PR DESCRIPTION
There aren't package splits yet for 4.x-dev so we will have to pull in the entire thing. This will enable cakephp/migrations to make progress, and update travis to no longer test against PHP 5 or EOL PHP 7.