### PR TITLE
Add semicolon for transaction sql lines for --dry-run

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -155,7 +155,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function beginTransaction()
     {
-        $this->execute('START TRANSACTION');
+        $this->execute('START TRANSACTION;');
     }
 
     /**
@@ -163,7 +163,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function commitTransaction()
     {
-        $this->execute('COMMIT');
+        $this->execute('COMMIT;');
     }
 
     /**
@@ -171,7 +171,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function rollbackTransaction()
     {
-        $this->execute('ROLLBACK');
+        $this->execute('ROLLBACK;');
     }
 
     /**

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -155,7 +155,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function beginTransaction()
     {
-        $this->execute('START TRANSACTION;');
+        $this->execute('START TRANSACTION');
     }
 
     /**
@@ -163,7 +163,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function commitTransaction()
     {
-        $this->execute('COMMIT;');
+        $this->execute('COMMIT');
     }
 
     /**
@@ -171,7 +171,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function rollbackTransaction()
     {
-        $this->execute('ROLLBACK;');
+        $this->execute('ROLLBACK');
     }
 
     /**
@@ -293,7 +293,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         }
 
         $sql .= ') ' . $optionsStr;
-        $sql = rtrim($sql) . ';';
+        $sql = rtrim($sql);
 
         // execute the sql
         $this->execute($sql);

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -158,7 +158,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function execute($sql)
     {
-        $sql = rtrim($sql, ' \r\n\t\0\x0B;') . ';';
+        $sql = rtrim($sql, "; \t\n\r\0\x0B") . ';';
         $this->verboseLog($sql);
 
         if ($this->isDryRunEnabled()) {

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -158,6 +158,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function execute($sql)
     {
+        $sql = rtrim($sql, ' \r\n\t\0\x0B;') . ';';
         $this->verboseLog($sql);
 
         if ($this->isDryRunEnabled()) {

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -114,7 +114,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function beginTransaction()
     {
-        $this->execute('BEGIN');
+        $this->execute('BEGIN;');
     }
 
     /**
@@ -122,7 +122,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function commitTransaction()
     {
-        $this->execute('COMMIT');
+        $this->execute('COMMIT;');
     }
 
     /**
@@ -130,7 +130,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function rollbackTransaction()
     {
-        $this->execute('ROLLBACK');
+        $this->execute('ROLLBACK;');
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -235,23 +235,21 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         }
 
         $sql .= ')';
+        $this->execute($sql);
 
         // process column comments
         if (!empty($this->columnsWithComments)) {
             foreach ($this->columnsWithComments as $column) {
-                $sql .= $this->getColumnCommentSqlDefinition($column, $table->getName());
+                $this->execute($this->getColumnCommentSqlDefinition($column, $table->getName()));
             }
         }
 
         // set the indexes
         if (!empty($indexes)) {
             foreach ($indexes as $index) {
-                $sql .= $this->getIndexSqlDefinition($index, $table->getName());
+                $this->execute($this->getIndexSqlDefinition($index, $table->getName()));
             }
         }
-
-        // execute the sql
-        $this->execute($sql);
 
         // process table comments
         if (isset($options['comment'])) {

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -114,7 +114,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function beginTransaction()
     {
-        $this->execute('BEGIN;');
+        $this->execute('BEGIN');
     }
 
     /**
@@ -122,7 +122,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function commitTransaction()
     {
-        $this->execute('COMMIT;');
+        $this->execute('COMMIT');
     }
 
     /**
@@ -130,7 +130,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function rollbackTransaction()
     {
-        $this->execute('ROLLBACK;');
+        $this->execute('ROLLBACK');
     }
 
     /**
@@ -234,7 +234,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $sql = rtrim($sql, ', '); // no primary keys
         }
 
-        $sql .= ');';
+        $sql .= ')';
 
         // process column comments
         if (!empty($this->columnsWithComments)) {
@@ -1245,7 +1245,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function createSchema($schemaName = 'public')
     {
         // from postgres 9.3 we can use "CREATE SCHEMA IF NOT EXISTS schema_name"
-        $sql = sprintf('CREATE SCHEMA %s;', $this->quoteSchemaName($schemaName));
+        $sql = sprintf('CREATE SCHEMA %s', $this->quoteSchemaName($schemaName));
         $this->execute($sql);
     }
 
@@ -1276,7 +1276,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function dropSchema($schemaName)
     {
-        $sql = sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", $this->quoteSchemaName($schemaName));
+        $sql = sprintf("DROP SCHEMA IF EXISTS %s CASCADE", $this->quoteSchemaName($schemaName));
         $this->execute($sql);
     }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -249,7 +249,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         // set the indexes
         if (!empty($indexes)) {
             foreach ($indexes as $index) {
-               $queries[] = $this->getIndexSqlDefinition($index, $table->getName());
+                $queries[] = $this->getIndexSqlDefinition($index, $table->getName());
             }
         }
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -159,7 +159,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     public function beginTransaction()
     {
-        $this->execute('BEGIN TRANSACTION');
+        $this->execute('BEGIN TRANSACTION;');
     }
 
     /**
@@ -167,7 +167,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     public function commitTransaction()
     {
-        $this->execute('COMMIT TRANSACTION');
+        $this->execute('COMMIT TRANSACTION;');
     }
 
     /**
@@ -175,7 +175,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     public function rollbackTransaction()
     {
-        $this->execute('ROLLBACK TRANSACTION');
+        $this->execute('ROLLBACK TRANSACTION;');
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -159,7 +159,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     public function beginTransaction()
     {
-        $this->execute('BEGIN TRANSACTION;');
+        $this->execute('BEGIN TRANSACTION');
     }
 
     /**
@@ -167,7 +167,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     public function commitTransaction()
     {
-        $this->execute('COMMIT TRANSACTION;');
+        $this->execute('COMMIT TRANSACTION');
     }
 
     /**
@@ -175,7 +175,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     public function rollbackTransaction()
     {
-        $this->execute('ROLLBACK TRANSACTION;');
+        $this->execute('ROLLBACK TRANSACTION');
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1591,8 +1591,8 @@ OUTPUT;
         $this->adapter->rollbackTransaction();
 
         $actualOutput = $consoleOutput->fetch();
-        $this->assertStringStartsWith("START TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
-        $this->assertStringEndsWith("COMMIT;\nROLLBACK;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
+        $this->assertStringStartsWith("START TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
+        $this->assertStringEndsWith("COMMIT;\nROLLBACK;\n", $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1572,6 +1572,29 @@ OUTPUT;
         $this->assertEquals(0, $res[0]['COUNT(*)']);
     }
 
+    public function testDumpTransaction()
+    {
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $this->adapter->beginTransaction();
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+
+        $table->addColumn('column1', 'string')
+            ->addColumn('column2', 'integer')
+            ->addColumn('column3', 'string', ['default' => 'test'])
+            ->save();
+        $this->adapter->commitTransaction();
+        $this->adapter->rollbackTransaction();
+
+        $actualOutput = $consoleOutput->fetch();
+        $this->assertStringStartsWith("START TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
+        $this->assertStringEndsWith("COMMIT;\nROLLBACK;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
+    }
+
     /**
      * Tests interaction with the query builder
      *

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -165,6 +165,6 @@ class PdoAdapterTest extends TestCase
 
         $this->adapter->execute('SELECT 1');
 
-        $this->assertSame('SELECT 1', $pdo->getExecutedSqlForTest());
+        $this->assertSame('SELECT 1;', $pdo->getExecutedSqlForTest());
     }
 }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -167,4 +167,15 @@ class PdoAdapterTest extends TestCase
 
         $this->assertSame('SELECT 1;', $pdo->getExecutedSqlForTest());
     }
+
+    public function testExecuteRightTrimsSemiColons()
+    {
+        $pdo = new PdoAdapterTestPDOMockWithExecChecks();
+
+        $this->adapter->setConnection($pdo);
+
+        $this->adapter->execute('SELECT 1;;');
+
+        $this->assertSame('SELECT 1;', $pdo->getExecutedSqlForTest());
+    }
 }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1898,8 +1898,8 @@ OUTPUT;
         $this->adapter->rollbackTransaction();
 
         $actualOutput = $consoleOutput->fetch();
-        $this->assertStringStartsWith("BEGIN;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
-        $this->assertStringEndsWith("COMMIT;\nROLLBACK;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
+        $this->assertStringStartsWith("BEGIN;\n", $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
+        $this->assertStringEndsWith("COMMIT;\nROLLBACK;\n", $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1879,6 +1879,29 @@ OUTPUT;
         $this->assertEquals(0, $res[0]['count']);
     }
 
+    public function testDumpTransaction()
+    {
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $this->adapter->beginTransaction();
+        $table = new \Phinx\Db\Table('schema1.table1', [], $this->adapter);
+
+        $table->addColumn('column1', 'string')
+            ->addColumn('column2', 'integer')
+            ->addColumn('column3', 'string', ['default' => 'test'])
+            ->save();
+        $this->adapter->commitTransaction();
+        $this->adapter->rollbackTransaction();
+
+        $actualOutput = $consoleOutput->fetch();
+        $this->assertStringStartsWith("BEGIN;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
+        $this->assertStringEndsWith("COMMIT;\nROLLBACK;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
+    }
+
     /**
      * Tests interaction with the query builder
      *

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -872,7 +872,7 @@ class SqlServerAdapterTest extends TestCase
         $this->adapter->commitTransaction();
         $this->adapter->rollbackTransaction();
 
-        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = str_replace("\r\n", "\n", $consoleOutput->fetch());
         $this->assertStringStartsWith("BEGIN TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
         $this->assertStringEndsWith("COMMIT TRANSACTION;\nROLLBACK TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
     }

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -873,8 +873,8 @@ class SqlServerAdapterTest extends TestCase
         $this->adapter->rollbackTransaction();
 
         $actualOutput = str_replace("\r\n", "\n", $consoleOutput->fetch());
-        $this->assertStringStartsWith("BEGIN TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
-        $this->assertStringEndsWith("COMMIT TRANSACTION;\nROLLBACK TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t drump the transaction to the output');
+        $this->assertStringStartsWith("BEGIN TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
+        $this->assertStringEndsWith("COMMIT TRANSACTION;\nROLLBACK TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
     }
 
     /**


### PR DESCRIPTION
Fixes #1567. 

Using `--dry-run` was lacking the semi-colon at the end of any of the commands for transactions for MySQL, PostgreSQL, and SQLServer. This PR adds the missing semi-colons, and add tests to ensure proper behavior.