### PR TITLE
Cache names of created tables for exists check

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -267,7 +267,8 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Adds user-created tables (e.g. not phinxlog) to a cached list
      */
-    public function addCreatedTable($tableName) {
+    public function addCreatedTable($tableName)
+    {
         if (substr_compare($tableName, 'phinxlog', -strlen('phinxlog')) !== 0) {
             $this->createdTables[] = $tableName;
         }
@@ -276,7 +277,8 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Updates the name of the cached table
      */
-    public function updateCreatedTableName($tableName, $newTableName) {
+    public function updateCreatedTableName($tableName, $newTableName)
+    {
         if (($key = array_search($tableName, $this->createdTables)) !== false) {
             $this->createdTables[$key] = $newTableName;
         }
@@ -285,7 +287,8 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Removes table from the cached created list
      */
-    public function removeCreatedTable($tableName) {
+    public function removeCreatedTable($tableName)
+    {
         if (($key = array_search($tableName, $this->createdTables)) !== false) {
             unset($this->createdTables[$key]);
         }
@@ -296,7 +299,8 @@ abstract class AbstractAdapter implements AdapterInterface
      * 
      * @return bool
      */
-    public function hasCreatedTable($tableName) {
+    public function hasCreatedTable($tableName)
+    {
         return in_array($tableName, $this->createdTables);
     }
 }

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -266,6 +266,9 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      * Adds user-created tables (e.g. not phinxlog) to a cached list
+     *
+     * @param string $tableName The name of the table
+     * @return void
      */
     public function addCreatedTable($tableName)
     {
@@ -276,16 +279,24 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      * Updates the name of the cached table
+     *
+     * @param string $tableName Original name of the table
+     * @param string $newTableName New name of the table
+     * @return void
      */
     public function updateCreatedTableName($tableName, $newTableName)
     {
-        if (($key = array_search($tableName, $this->createdTables)) !== false) {
+        $key = array_search($tableName, $this->createdTables);
+        if ($key !== false) {
             $this->createdTables[$key] = $newTableName;
         }
     }
 
     /**
      * Removes table from the cached created list
+     *
+     * @param string $tableName The name of the table
+     * @return void
      */
     public function removeCreatedTable($tableName)
     {
@@ -297,6 +308,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Check if the table is in the cached list of created tables
      *
+     * @param string $tableName The name of the table
      * @return bool
      */
     public function hasCreatedTable($tableName)

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -296,7 +296,7 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      * Check if the table is in the cached list of created tables
-     * 
+     *
      * @return bool
      */
     public function hasCreatedTable($tableName)

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -263,4 +263,40 @@ abstract class AbstractAdapter implements AdapterInterface
 
         return ($input && $input->hasOption('dry-run')) ? (bool)$input->getOption('dry-run') : false;
     }
+
+    /**
+     * Adds user-created tables (e.g. not phinxlog) to a cached list
+     */
+    public function addCreatedTable($tableName) {
+        if (substr_compare($tableName, 'phinxlog', -strlen('phinxlog')) !== 0) {
+            $this->createdTables[] = $tableName;
+        }
+    }
+
+    /**
+     * Updates the name of the cached table
+     */
+    public function updateCreatedTableName($tableName, $newTableName) {
+        if (($key = array_search($tableName, $this->createdTables)) !== false) {
+            $this->createdTables[$key] = $newTableName;
+        }
+    }
+
+    /**
+     * Removes table from the cached created list
+     */
+    public function removeCreatedTable($tableName) {
+        if (($key = array_search($tableName, $this->createdTables)) !== false) {
+            unset($this->createdTables[$key]);
+        }
+    }
+
+    /**
+     * Check if the table is in the cached list of created tables
+     * 
+     * @return bool
+     */
+    public function hasCreatedTable($tableName) {
+        return in_array($tableName, $this->createdTables);
+    }
 }

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -300,7 +300,8 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function removeCreatedTable($tableName)
     {
-        if (($key = array_search($tableName, $this->createdTables)) !== false) {
+        $key = array_search($tableName, $this->createdTables);
+        if ($key !== false) {
             unset($this->createdTables[$key]);
         }
     }

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -56,6 +56,11 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $output;
 
     /**
+     * @var string[]
+     */
+    protected $createdTables = [];
+
+    /**
      * @var string
      */
     protected $schemaTableName = 'phinxlog';

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -270,7 +270,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $tableName The name of the table
      * @return void
      */
-    public function addCreatedTable($tableName)
+    protected function addCreatedTable($tableName)
     {
         if (substr_compare($tableName, 'phinxlog', -strlen('phinxlog')) !== 0) {
             $this->createdTables[] = $tableName;
@@ -284,7 +284,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $newTableName New name of the table
      * @return void
      */
-    public function updateCreatedTableName($tableName, $newTableName)
+    protected function updateCreatedTableName($tableName, $newTableName)
     {
         $key = array_search($tableName, $this->createdTables);
         if ($key !== false) {
@@ -298,7 +298,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $tableName The name of the table
      * @return void
      */
-    public function removeCreatedTable($tableName)
+    protected function removeCreatedTable($tableName)
     {
         $key = array_search($tableName, $this->createdTables);
         if ($key !== false) {
@@ -312,7 +312,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $tableName The name of the table
      * @return bool
      */
-    public function hasCreatedTable($tableName)
+    protected function hasCreatedTable($tableName)
     {
         return in_array($tableName, $this->createdTables);
     }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -195,7 +195,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
-        if (in_array($tableName, $this->createdTables)) {
+        if ($this->hasCreatedTable($tableName)) {
             return true;
         }
 
@@ -302,9 +302,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         // execute the sql
         $this->execute($sql);
 
-        if (substr_compare($table->getName(), 'phinxlog', -strlen('phinxlog')) !== 0) {
-            $this->createdTables[] = $table->getName();
-        }
+        $this->addCreatedTable($table->getName());
     }
 
     /**
@@ -362,6 +360,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getRenameTableInstructions($tableName, $newTableName)
     {
+        $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
             'RENAME TABLE %s TO %s',
             $this->quoteTableName($tableName),
@@ -376,6 +375,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getDropTableInstructions($tableName)
     {
+        $this->removeCreatedTable($tableName);
         $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
 
         return new AlterInstructions([], [$sql]);

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -195,6 +195,10 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
+        if (in_array($tableName, $this->createdTables)) {
+            return true;
+        }
+
         $options = $this->getOptions();
 
         $exists = $this->fetchRow(sprintf(
@@ -297,6 +301,10 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
 
         // execute the sql
         $this->execute($sql);
+
+        if (substr_compare($table->getName(), 'phinxlog', -strlen('phinxlog')) !== 0) {
+            $this->createdTables[] = $table->getName();
+        }
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -167,7 +167,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
-        if (in_array($tableName, $this->createdTables)) {
+        if ($this->hasCreatedTable($tableName)) {
             return true;
         }
 
@@ -267,9 +267,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $this->execute($sql);
         }
 
-        if (substr_compare($table->getName(), 'phinxlog', -strlen('phinxlog')) !== 0) {
-            $this->createdTables[] = $table->getName();
-        }
+        $this->addCreatedTable($table->getName());
     }
 
     /**
@@ -340,6 +338,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getRenameTableInstructions($tableName, $newTableName)
     {
+        $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
             'ALTER TABLE %s RENAME TO %s',
             $this->quoteTableName($tableName),
@@ -354,6 +353,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getDropTableInstructions($tableName)
     {
+        $this->removeCreatedTable($tableName);
         $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
 
         return new AlterInstructions([], [$sql]);

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -167,6 +167,10 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
+        if (in_array($tableName, $this->createdTables)) {
+            return true;
+        }
+
         $parts = $this->getSchemaName($tableName);
         $result = $this->getConnection()->query(
             sprintf(
@@ -261,6 +265,10 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 $this->getConnection()->quote($options['comment'])
             );
             $this->execute($sql);
+        }
+
+        if (substr_compare($table->getName(), 'phinxlog', -strlen('phinxlog')) !== 0) {
+            $this->createdTables[] = $table->getName();
         }
     }
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -335,7 +335,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
-        return $this->resolveTable($tableName)['exists'];
+        return in_array($tableName, $this->createdTables) || $this->resolveTable($tableName)['exists'];
     }
 
     /**
@@ -399,6 +399,10 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         foreach ($indexes as $index) {
             $this->addIndex($table, $index);
+        }
+
+        if (substr_compare($table->getName(), 'phinxlog', -strlen('phinxlog')) !== 0) {
+            $this->createdTables[] = $table->getName();
         }
     }
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -335,7 +335,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
-        return in_array($tableName, $this->createdTables) || $this->resolveTable($tableName)['exists'];
+        return $this->hasCreatedTable($tableName) || $this->resolveTable($tableName)['exists'];
     }
 
     /**
@@ -401,9 +401,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $this->addIndex($table, $index);
         }
 
-        if (substr_compare($table->getName(), 'phinxlog', -strlen('phinxlog')) !== 0) {
-            $this->createdTables[] = $table->getName();
-        }
+        $this->addCreatedTable($table->getName());
     }
 
     /**
@@ -452,6 +450,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getRenameTableInstructions($tableName, $newTableName)
     {
+        $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
             'ALTER TABLE %s RENAME TO %s',
             $this->quoteTableName($tableName),
@@ -466,6 +465,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getDropTableInstructions($tableName)
     {
+        $this->removeCreatedTable($tableName);
         $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
 
         return new AlterInstructions([], [$sql]);

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -199,6 +199,10 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
+        if (in_array($tableName, $this->createdTables)) {
+            return true;
+        }
+
         $result = $this->fetchRow(sprintf('SELECT count(*) as [count] FROM information_schema.tables WHERE table_name = \'%s\';', $tableName));
 
         return $result['count'] > 0;
@@ -267,6 +271,10 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
 
         // execute the sql
         $this->execute($sql);
+
+        if (substr_compare($table->getName(), 'phinxlog', -strlen('phinxlog')) !== 0) {
+            $this->createdTables[] = $table->getName();
+        }
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -199,7 +199,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
-        if (in_array($tableName, $this->createdTables)) {
+        if ($this->hasCreatedTable($tableName)) {
             return true;
         }
 
@@ -272,9 +272,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
         // execute the sql
         $this->execute($sql);
 
-        if (substr_compare($table->getName(), 'phinxlog', -strlen('phinxlog')) !== 0) {
-            $this->createdTables[] = $table->getName();
-        }
+        $this->addCreatedTable($table->getName());
     }
 
     /**
@@ -357,6 +355,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getRenameTableInstructions($tableName, $newTableName)
     {
+        $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
             'EXEC sp_rename \'%s\', \'%s\'',
             $tableName,
@@ -371,6 +370,7 @@ class SqlServerAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getDropTableInstructions($tableName)
     {
+        $this->removeCreatedTable($tableName);
         $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
 
         return new AlterInstructions([], [$sql]);

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1572,6 +1572,34 @@ OUTPUT;
         $this->assertEquals(0, $res[0]['COUNT(*)']);
     }
 
+    public function testDumpCreateTableAndThenInsert()
+    {
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $table = new \Phinx\Db\Table('table1', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
+
+        $table->addColumn('column1', 'string')
+            ->addColumn('column2', 'integer')
+            ->save();
+        
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table->insert([
+            'column1' => 'id1',
+            'column2' => 1
+        ])->save();
+
+        $expectedOutput = <<<'OUTPUT'
+CREATE TABLE `table1` (`column1` VARCHAR(255) NOT NULL, `column2` INT(11) NOT NULL, PRIMARY KEY (`column1`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
+INSERT INTO `table1` (`column1`, `column2`) VALUES ('id1', 1);
+OUTPUT;
+        $actualOutput = $consoleOutput->fetch();
+        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
+    }
+    
     /**
      * Tests interaction with the query builder
      *

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1879,6 +1879,36 @@ OUTPUT;
         $this->assertEquals(0, $res[0]['count']);
     }
 
+    public function testDumpCreateTableAndThenInsert()
+    {
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $table = new \Phinx\Db\Table('schema1.table1', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
+
+        $table->addColumn('column1', 'string')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $expectedOutput = 'C';
+
+        $table = new \Phinx\Db\Table('schema1.table1', [], $this->adapter);
+        $table->insert([
+            'column1' => 'id1',
+            'column2' => 1
+        ])->save();
+
+        $expectedOutput = <<<'OUTPUT'
+CREATE TABLE "schema1"."table1" ("column1" CHARACTER VARYING (255) NOT NULL, "column2" INTEGER NOT NULL, CONSTRAINT "table1_pkey" PRIMARY KEY ("column1"));
+INSERT INTO "schema1"."table1" ("column1", "column2") VALUES ('id1', 1);
+OUTPUT;
+        $actualOutput = $consoleOutput->fetch();
+        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
+    }
+
     /**
      * Tests interaction with the query builder
      *

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -880,7 +880,7 @@ class SqlServerAdapterTest extends TestCase
 CREATE TABLE [table1] ([column1] NVARCHAR (255)   NOT NULL , [column2] INT   NOT NULL , CONSTRAINT PK_table1 PRIMARY KEY ([column1]));
 INSERT INTO [table1] ([column1], [column2]) VALUES ('id1', 1);
 OUTPUT;
-        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = str_replace("\r\n", "\n", $consoleOutput->fetch());
         $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
     }
 


### PR DESCRIPTION
Fixes #1569 where because running under dry-run meant that the table was never actually created subsequent checks for existence of the table would fail, and an extra invalid `CREATE TABLE` statement would end up getting inserted into the dry-run log.

I'm not 100% satisfied with how this looks, but unsure of how might improve things and reduce the amount of copy/paste of things. It'll also still fail in the case where someone would directly call `execute()` with a create/drop/rename query.