### PR TITLE
Fixed Command names

### DIFF
--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -35,6 +35,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Breakpoint extends AbstractCommand
 {
+    const COMMAND_NAME = 'breakpoint';
+
     /**
      * {@inheritdoc}
      */
@@ -44,8 +46,7 @@ class Breakpoint extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment.');
 
-        $this->setName($this->getName() ?: 'breakpoint')
-            ->setDescription('Manage breakpoints')
+        $this->setDescription('Manage breakpoints')
             ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to target for the breakpoint')
             ->addOption('--set', '-s', InputOption::VALUE_NONE, 'Set the breakpoint')
             ->addOption('--unset', '-u', InputOption::VALUE_NONE, 'Unset the breakpoint')

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -39,6 +39,8 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class Create extends AbstractCommand
 {
+    const COMMAND_NAME = 'create';
+
     /**
      * The name of the interface that any external template creation class is required to implement.
      */
@@ -51,8 +53,7 @@ class Create extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName($this->getName() ?: 'create')
-            ->setDescription('Create a new migration')
+        $this->setDescription('Create a new migration')
             ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the migration (in CamelCase)?')
             ->setHelp(sprintf(
                 '%sCreates a new database migration%s',

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -37,6 +37,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Init extends Command
 {
+    const COMMAND_NAME = 'init';
     const FILE_NAME = 'phinx';
 
     /**
@@ -44,8 +45,7 @@ class Init extends Command
      */
     protected function configure()
     {
-        $this->setName($this->getName() ?: 'init')
-            ->setDescription('Initialize the application for Phinx')
+        $this->setDescription('Initialize the application for Phinx')
             ->addOption('--format', '-f', InputArgument::OPTIONAL, 'What format should we use to initialize?', 'yml')
             ->addArgument('path', InputArgument::OPTIONAL, 'Which path should we initialize for Phinx?')
             ->setHelp(sprintf(

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -34,6 +34,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrate extends AbstractCommand
 {
+    const COMMAND_NAME = 'migrate';
+
     /**
      * {@inheritdoc}
      */
@@ -43,8 +45,7 @@ class Migrate extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
-        $this->setName($this->getName() ?: 'migrate')
-            ->setDescription('Migrate the database')
+        $this->setDescription('Migrate the database')
             ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to migrate to')
             ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to migrate to')
             ->addOption('--dry-run', '-x', InputOption::VALUE_NONE, 'Dump query to standard output instead of executing it')

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -34,6 +34,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Rollback extends AbstractCommand
 {
+    const COMMAND_NAME = 'rollback';
+
     /**
      * {@inheritdoc}
      */
@@ -43,8 +45,7 @@ class Rollback extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
-        $this->setName($this->getName() ?: 'rollback')
-            ->setDescription('Rollback the last or to a specific migration')
+        $this->setDescription('Rollback the last or to a specific migration')
             ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to rollback to')
             ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to rollback to')
             ->addOption('--force', '-f', InputOption::VALUE_NONE, 'Force rollback to ignore breakpoints')

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -39,6 +39,8 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class SeedCreate extends AbstractCommand
 {
+    const COMMAND_NAME = 'seed:create';
+
     /**
      * {@inheritdoc}
      */
@@ -46,8 +48,7 @@ class SeedCreate extends AbstractCommand
     {
         parent::configure();
 
-        $this->setName($this->getName() ?: 'seed:create')
-            ->setDescription('Create a new database seeder')
+        $this->setDescription('Create a new database seeder')
             ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the seeder?')
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'Specify the path in which to create this seeder')
             ->setHelp(sprintf(

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -34,6 +34,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SeedRun extends AbstractCommand
 {
+    const COMMAND_NAME = 'seed:run';
+
     /**
      * {@inheritdoc}
      */
@@ -43,8 +45,7 @@ class SeedRun extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
-        $this->setName($this->getName() ?: 'seed:run')
-            ->setDescription('Run database seeders')
+        $this->setDescription('Run database seeders')
             ->addOption('--seed', '-s', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'What is the name of the seeder?')
             ->setHelp(
                 <<<EOT

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -34,6 +34,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends AbstractCommand
 {
+    const COMMAND_NAME = 'status';
+
     /**
      * {@inheritdoc}
      */
@@ -43,8 +45,7 @@ class Status extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment.');
 
-        $this->setName($this->getName() ?: 'status')
-            ->setDescription('Show migration status')
+        $this->setDescription('Show migration status')
             ->addOption('--format', '-f', InputOption::VALUE_REQUIRED, 'The output format: text or json. Defaults to text.')
             ->setHelp(
                 <<<EOT

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -39,6 +39,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Test extends AbstractCommand
 {
+    const COMMAND_NAME = 'test';
+
     /**
      * {@inheritdoc}
      */
@@ -48,8 +50,7 @@ class Test extends AbstractCommand
 
         $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
 
-        $this->setName($this->getName() ?: 'test')
-            ->setDescription('Verify the configuration file')
+        $this->setDescription('Verify the configuration file')
             ->setHelp(
                 <<<EOT
 The <info>test</info> command verifies the YAML configuration file and optionally an environment

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -28,7 +28,15 @@
  */
 namespace Phinx\Console;
 
-use Phinx\Console\Command;
+use Phinx\Console\Command\Breakpoint;
+use Phinx\Console\Command\Create;
+use Phinx\Console\Command\Init;
+use Phinx\Console\Command\Migrate;
+use Phinx\Console\Command\Rollback;
+use Phinx\Console\Command\SeedCreate;
+use Phinx\Console\Command\SeedRun;
+use Phinx\Console\Command\Status;
+use Phinx\Console\Command\Test;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -57,15 +65,15 @@ class PhinxApplication extends Application
         parent::__construct('Phinx by CakePHP - https://phinx.org.', $version);
 
         $this->addCommands([
-            new Command\Init(),
-            new Command\Create(),
-            new Command\Migrate(),
-            new Command\Rollback(),
-            new Command\Status(),
-            new Command\Breakpoint(),
-            new Command\Test(),
-            new Command\SeedCreate(),
-            new Command\SeedRun(),
+            new Init(Init::COMMAND_NAME),
+            new Create(Create::COMMAND_NAME),
+            new Migrate(Migrate::COMMAND_NAME),
+            new Rollback(Rollback::COMMAND_NAME),
+            new Status(Status::COMMAND_NAME),
+            new Breakpoint(Breakpoint::COMMAND_NAME),
+            new Test(Test::COMMAND_NAME),
+            new SeedCreate(SeedCreate::COMMAND_NAME),
+            new SeedRun(SeedRun::COMMAND_NAME),
         ]);
     }
 

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -82,7 +82,7 @@ class BreakpointTest extends TestCase
     public function testExecute($testMethod, $commandLine, $version = null, $noVersionParameter = false)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Breakpoint());
+        $application->add(new Breakpoint(Breakpoint::COMMAND_NAME));
 
         /** @var Breakpoint $command */
         $command = $application->find('breakpoint');
@@ -164,7 +164,7 @@ class BreakpointTest extends TestCase
     public function testRemoveAllAndTargetThrowsException()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Breakpoint());
+        $application->add(new Breakpoint(Breakpoint::COMMAND_NAME));
 
         /** @var Breakpoint $command */
         $command = $application->find('breakpoint');
@@ -200,7 +200,7 @@ class BreakpointTest extends TestCase
     public function testRemoveAllSetUnsetCombinedThrowsException($commandLine)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Breakpoint());
+        $application->add(new Breakpoint(Breakpoint::COMMAND_NAME));
 
         /** @var Breakpoint $command */
         $command = $application->find('breakpoint');

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -76,7 +76,7 @@ class CreateTest extends TestCase
     public function testExecuteWithDuplicateMigrationNames()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create());
+        $application->add(new Create(Create::COMMAND_NAME));
 
         /** @var Create $command */
         $command = $application->find('create');
@@ -102,7 +102,7 @@ class CreateTest extends TestCase
     public function testExecuteWithDuplicateMigrationNamesWithNamespace()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create());
+        $application->add(new Create(Create::COMMAND_NAME));
 
         /** @var Create $command */
         $command = $application->find('create');
@@ -134,7 +134,7 @@ class CreateTest extends TestCase
     public function testSupplyingBothClassAndTemplateAtCommandLineThrowsException()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create());
+        $application->add(new Create(Create::COMMAND_NAME));
 
         /** @var Create $command $command */
         $command = $application->find('create');
@@ -158,7 +158,7 @@ class CreateTest extends TestCase
     public function testSupplyingBothClassAndTemplateInConfigThrowsException()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create());
+        $application->add(new Create(Create::COMMAND_NAME));
 
         /** @var Create $command $command */
         $command = $application->find('create');
@@ -220,7 +220,7 @@ class CreateTest extends TestCase
     public function testTemplateGeneratorsWithoutCorrectInterfaceThrowsException(array $config, array $commandLine, $exceptionMessage)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create());
+        $application->add(new Create(Create::COMMAND_NAME));
 
         /** @var Create $command $command */
         $command = $application->find('create');
@@ -284,7 +284,7 @@ class CreateTest extends TestCase
     public function testNullTemplateGeneratorsDoNotFail(array $config, array $commandLine)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create());
+        $application->add(new Create(Create::COMMAND_NAME));
 
         /** @var Create $command $command */
         $command = $application->find('create');
@@ -348,7 +348,7 @@ class CreateTest extends TestCase
     public function testSimpleTemplateGeneratorsIsCorrectlyPopulated(array $config, array $commandLine)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create());
+        $application->add(new Create(Create::COMMAND_NAME));
 
         /** @var Create $command $command */
         $command = $application->find('create');

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -22,7 +22,7 @@ class InitTest extends TestCase
     protected function writeConfig($configName = '')
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Init());
+        $application->add(new Init(Init::COMMAND_NAME));
         $command = $application->find("init");
         $commandTester = new CommandTester($command);
         $fullPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $configName;
@@ -86,7 +86,7 @@ class InitTest extends TestCase
         chdir(sys_get_temp_dir());
 
         $application = new PhinxApplication('testing');
-        $application->add(new Init());
+        $application->add(new Init(Init::COMMAND_NAME));
 
         $command = $application->find('init');
 
@@ -113,7 +113,7 @@ class InitTest extends TestCase
     {
         touch(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.yml');
         $application = new PhinxApplication('testing');
-        $application->add(new Init());
+        $application->add(new Init(Init::COMMAND_NAME));
 
         $command = $application->find('init');
 
@@ -133,7 +133,7 @@ class InitTest extends TestCase
     public function testThrowsExceptionWhenInvalidDir()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Init());
+        $application->add(new Init(Init::COMMAND_NAME));
 
         $command = $application->find('init');
 
@@ -153,7 +153,7 @@ class InitTest extends TestCase
     public function testThrowsExceptionWhenInvalidFormat()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Init());
+        $application->add(new Init(Init::COMMAND_NAME));
 
         $command = $application->find('init');
 

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -59,7 +59,7 @@ class MigrateTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Migrate());
+        $application->add(new Migrate(Migrate::COMMAND_NAME));
 
         /** @var Migrate $command */
         $command = $application->find('migrate');
@@ -85,7 +85,7 @@ class MigrateTest extends TestCase
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Migrate());
+        $application->add(new Migrate(Migrate::COMMAND_NAME));
 
         /** @var Migrate $command */
         $command = $application->find('migrate');
@@ -111,7 +111,7 @@ class MigrateTest extends TestCase
     public function testDatabaseNameSpecified()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Migrate());
+        $application->add(new Migrate(Migrate::COMMAND_NAME));
 
         /** @var Migrate $command */
         $command = $application->find('migrate');
@@ -137,7 +137,7 @@ class MigrateTest extends TestCase
     public function testFakeMigrate()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Migrate());
+        $application->add(new Migrate(Migrate::COMMAND_NAME));
 
         /** @var Migrate $command */
         $command = $application->find('migrate');

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -64,7 +64,7 @@ class RollbackTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Rollback());
+        $application->add(new Rollback(Rollback::COMMAND_NAME));
 
         /** @var Rollback $command */
         $command = $application->find('rollback');
@@ -95,7 +95,7 @@ class RollbackTest extends TestCase
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Rollback());
+        $application->add(new Rollback(Rollback::COMMAND_NAME));
 
         /** @var Rollback $command */
         $command = $application->find('rollback');
@@ -120,7 +120,7 @@ class RollbackTest extends TestCase
     public function testDatabaseNameSpecified()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Rollback());
+        $application->add(new Rollback(Rollback::COMMAND_NAME));
 
         /** @var Rollback $command */
         $command = $application->find('rollback');
@@ -145,7 +145,7 @@ class RollbackTest extends TestCase
     public function testStartTimeVersionOrder()
     {
         $application = new \Phinx\Console\PhinxApplication('testing');
-        $application->add(new Rollback());
+        $application->add(new Rollback(Rollback::COMMAND_NAME));
 
         // setup dependencies
         $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
@@ -176,8 +176,11 @@ class RollbackTest extends TestCase
         $date = '20160101';
         $target = '20160101000000';
         $rollbackStub = $this->getMockBuilder('\Phinx\Console\Command\Rollback')
-            ->setMethods(['getTargetFromDate'])
+            ->setMethods(['getName', 'getTargetFromDate'])
             ->getMock();
+        
+        $rollbackStub->method('getName')
+                    ->will($this->returnValue(Rollback::COMMAND_NAME));
 
         $rollbackStub->expects($this->once())
                     ->method('getTargetFromDate')
@@ -209,7 +212,7 @@ class RollbackTest extends TestCase
      */
     public function testGetTargetFromDate($date, $expectedTarget)
     {
-        $rollbackCommand = new Rollback();
+        $rollbackCommand = new Rollback(Rollback::COMMAND_NAME);
         $this->assertEquals($expectedTarget, $rollbackCommand->getTargetFromDate($date));
     }
 
@@ -244,7 +247,7 @@ class RollbackTest extends TestCase
      */
     public function testGetTargetFromDateThrowsException($invalidDate)
     {
-        $rollbackCommand = new Rollback();
+        $rollbackCommand = new Rollback(Rollback::COMMAND_NAME);
         $rollbackCommand->getTargetFromDate($invalidDate);
     }
 
@@ -260,7 +263,7 @@ class RollbackTest extends TestCase
     public function testStarTimeVersionOrderWithDate()
     {
         $application = new \Phinx\Console\PhinxApplication('testing');
-        $application->add(new Rollback());
+        $application->add(new Rollback(Rollback::COMMAND_NAME));
 
         // setup dependencies
         $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
@@ -287,7 +290,7 @@ class RollbackTest extends TestCase
     public function testFakeRollback()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Rollback());
+        $application->add(new Rollback(Rollback::COMMAND_NAME));
 
         /** @var Rollback $command */
         $command = $application->find('rollback');

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -64,7 +64,7 @@ class SeedCreateTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedCreate());
+        $application->add(new SeedCreate(SeedCreate::COMMAND_NAME));
 
         /** @var SeedCreate $command */
         $command = $application->find('seed:create');
@@ -90,7 +90,7 @@ class SeedCreateTest extends TestCase
     public function testExecuteWithInvalidClassName()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedCreate());
+        $application->add(new SeedCreate(SeedCreate::COMMAND_NAME));
 
         /** @var SeedCreate $command */
         $command = $application->find('seed:create');

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -60,7 +60,7 @@ class SeedRunTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedRun());
+        $application->add(new SeedRun(SeedRun::COMMAND_NAME));
 
         /** @var SeedRun $command */
         $command = $application->find('seed:run');
@@ -85,7 +85,7 @@ class SeedRunTest extends TestCase
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedRun());
+        $application->add(new SeedRun(SeedRun::COMMAND_NAME));
 
         /** @var SeedRun $command */
         $command = $application->find('seed:run');
@@ -109,7 +109,7 @@ class SeedRunTest extends TestCase
     public function testDatabaseNameSpecified()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedRun());
+        $application->add(new SeedRun(SeedRun::COMMAND_NAME));
 
         /** @var SeedRun $command */
         $command = $application->find('seed:run');
@@ -133,7 +133,7 @@ class SeedRunTest extends TestCase
     public function testExecuteMultipleSeeders()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedRun());
+        $application->add(new SeedRun(SeedRun::COMMAND_NAME));
 
         /** @var SeedRun $command */
         $command = $application->find('seed:run');

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -64,7 +64,7 @@ class StatusTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Status());
+        $application->add(new Status(Status::COMMAND_NAME));
 
         /** @var Status $command */
         $command = $application->find('status');
@@ -97,7 +97,7 @@ class StatusTest extends TestCase
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Status());
+        $application->add(new Status(Status::COMMAND_NAME));
 
         /** @var Status $command */
         $command = $application->find('status');
@@ -124,7 +124,7 @@ class StatusTest extends TestCase
     public function testFormatSpecified()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Status());
+        $application->add(new Status(Status::COMMAND_NAME));
 
         /** @var Status $command */
         $command = $application->find('status');
@@ -151,7 +151,7 @@ class StatusTest extends TestCase
     public function testExecuteVersionOrderByExecutionTime()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Status());
+        $application->add(new Status(Status::COMMAND_NAME));
 
         /** @var Status $command */
         $command = $application->find('status');


### PR DESCRIPTION
_Fix for #1585_

Symfony's Command require their name to return a string and don't allow a null
value, however in Phinx, in order to allow users to override the command names,
Commands in PhinxApplication are constructed without a name, and then in the
Command's configure method, a default name is set if getName is null.

Up until now, it worked as Symfony didn't enforce return types (types were
simply declared in PHPdoc), however for its version 5 Symfony plans to enforce
them, hence breaking Phinx commands.

To fix it, a COMMAND_NAME class constant has been introduced, and
PhinxApplication uses it when instantiating Commands.