### PR TITLE
Update phpunit/phpunit requirement from >=5.7,<7.0 to >=5.7,<8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/yaml": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.7,<7.0",
+        "phpunit/phpunit": ">=5.7,<8.0",
         "sebastian/comparator": ">=1.2.3",
         "cakephp/cakephp-codesniffer": "^3.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -55,8 +55,7 @@
     </filter>
 
     <logging>
-        <log type="coverage-html" target="./tests/log/report" charset="UTF-8"
-            yui="true" highlight="true"
+        <log type="coverage-html" target="./tests/log/report"
             lowUpperBound="50" highLowerBound="80"/>
         <log type="testdox-html" target="./tests/log/testdox.html" />
     </logging>

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -40,7 +40,6 @@ class AbstractMigrationTest extends TestCase
 
         // stub output
         $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
-            ->setConstructorArgs([[]])
             ->getMock();
 
         // test methods
@@ -53,7 +52,6 @@ class AbstractMigrationTest extends TestCase
     {
         // stub input
         $inputStub = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
-            ->setConstructorArgs([[]])
             ->getMock();
 
         // stub migration
@@ -68,7 +66,6 @@ class AbstractMigrationTest extends TestCase
     {
         // stub output
         $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
-            ->setConstructorArgs([[]])
             ->getMock();
 
         // stub migration


### PR DESCRIPTION
PR to overrule #1543. PHPUnit 8+ cannot be used unless this library goes PHP 7.1+ only as typehints were added across the codebase, most notably the `setUp` and `tearDown` functions got the `void` typehint. 

On the other PR, you will probably need to tell dependabot `@dependabot ignore this dependency` until such a time as phinx is 7.1+.