### PR TITLE
add --prefer-lowest flag to composer install for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
 
 matrix:
   include:
+    - php: 5.6
+      env: PREFER_LOWEST=1
+
     - php: 7.0
       env: PHPCS=1 DEFAULT=0
 
@@ -29,7 +32,8 @@ matrix:
       env: PHPSTAN=1 DEFAULT=0
 
 before_script:
-    - if [[ $DEFAULT = 1 ]]; then travis_retry composer update --no-interaction --prefer-stable; fi
+    - if [[ $PREFER_LOWEST != 1 ]]; then travis_retry composer update --no-interaction --prefer-stable; fi
+    - if [[ $PREFER_LOWEST == 1 ]]; then travis_retry composer update --no-interaction --prefer-stable --prefer-lowest; fi
     - if [[ $DEFAULT = 1 ]]; then mysql -e 'create database phinx_testing;'; fi
     - if [[ $DEFAULT = 1 ]]; then psql -c 'create database phinx_testing;' -U postgres; fi
     - if [[ $DEFAULT = 1 ]]; then psql -c 'create extension if not exists citext;' -U postgres; fi

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "php": ">=5.6",
         "cakephp/collection": "^3.6",
         "cakephp/database": "^3.6",
+        "cakephp/datasource": "^3.6",
         "symfony/console": "^2.8|^3.0|^4.0",
         "symfony/config": "^2.8|^3.0|^4.0",
         "symfony/yaml": "^2.8|^3.0|^4.0"

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "require": {
         "php": ">=5.6",
         "cakephp/collection": "^3.6",
+        "cakephp/core": "^3.6",
         "cakephp/database": "^3.6",
         "cakephp/datasource": "^3.6",
         "symfony/console": "^2.8|^3.0|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "cakephp/core": "^3.6",
         "cakephp/database": "^3.6",
         "cakephp/datasource": "^3.6",
-        "symfony/console": "^2.8|^3.0|^4.0",
-        "symfony/config": "^2.8|^3.0|^4.0",
-        "symfony/yaml": "^2.8|^3.0|^4.0"
+        "symfony/console": "^3.4|^4.0",
+        "symfony/config": "^3.4|^4.0",
+        "symfony/yaml": "^3.4|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7,<7.0",


### PR DESCRIPTION
Adds a new job that runs `--prefer-lowest` for the lowest tested version of PHP (`5.6`) to ensure correctness of the library. Added per this comment https://github.com/cakephp/phinx/pull/1591#issuecomment-525316234 and trying to follow advice set in https://www.dereuromark.de/2019/01/04/test-composer-dependencies-with-prefer-lowest/ on adding it.

Fixes #1587