### PR TITLE
Use existing protected static defaultName for console commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "php": ">=5.6",
         "cakephp/collection": "^3.6",
         "cakephp/database": "^3.6",
-        "symfony/console": "^2.8|^3.0|^4.0",
-        "symfony/config": "^2.8|^3.0|^4.0",
-        "symfony/yaml": "^2.8|^3.0|^4.0"
+        "symfony/console": "^3.4|^4.0",
+        "symfony/config": "^3.4|^4.0",
+        "symfony/yaml": "^3.4|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7,<7.0",

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -35,7 +35,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Breakpoint extends AbstractCommand
 {
-    const COMMAND_NAME = 'breakpoint';
+    protected static $defaultName = 'breakpoint';
 
     /**
      * {@inheritdoc}

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -39,7 +39,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class Create extends AbstractCommand
 {
-    const COMMAND_NAME = 'create';
+    protected static $defaultName = 'create';
 
     /**
      * The name of the interface that any external template creation class is required to implement.

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -37,7 +37,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Init extends Command
 {
-    const COMMAND_NAME = 'init';
+    protected static $defaultName = 'init';
     const FILE_NAME = 'phinx';
 
     /**

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -34,7 +34,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrate extends AbstractCommand
 {
-    const COMMAND_NAME = 'migrate';
+    protected static $defaultName = 'migrate';
 
     /**
      * {@inheritdoc}

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -34,7 +34,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Rollback extends AbstractCommand
 {
-    const COMMAND_NAME = 'rollback';
+    protected static $defaultName = 'rollback';
 
     /**
      * {@inheritdoc}

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -39,7 +39,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class SeedCreate extends AbstractCommand
 {
-    const COMMAND_NAME = 'seed:create';
+    protected static $defaultName = 'seed:create';
 
     /**
      * {@inheritdoc}

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -34,7 +34,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SeedRun extends AbstractCommand
 {
-    const COMMAND_NAME = 'seed:run';
+    protected static $defaultName = 'seed:run';
 
     /**
      * {@inheritdoc}

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -34,7 +34,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends AbstractCommand
 {
-    const COMMAND_NAME = 'status';
+    protected static $defaultName = 'status';
 
     /**
      * {@inheritdoc}

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -39,7 +39,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Test extends AbstractCommand
 {
-    const COMMAND_NAME = 'test';
+    protected static $defaultName = 'test';
 
     /**
      * {@inheritdoc}

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -65,15 +65,15 @@ class PhinxApplication extends Application
         parent::__construct('Phinx by CakePHP - https://phinx.org.', $version);
 
         $this->addCommands([
-            new Init(Init::COMMAND_NAME),
-            new Create(Create::COMMAND_NAME),
-            new Migrate(Migrate::COMMAND_NAME),
-            new Rollback(Rollback::COMMAND_NAME),
-            new Status(Status::COMMAND_NAME),
-            new Breakpoint(Breakpoint::COMMAND_NAME),
-            new Test(Test::COMMAND_NAME),
-            new SeedCreate(SeedCreate::COMMAND_NAME),
-            new SeedRun(SeedRun::COMMAND_NAME),
+            new Init(),
+            new Create(),
+            new Migrate(),
+            new Rollback(),
+            new Status(),
+            new Breakpoint(),
+            new Test(),
+            new SeedCreate(),
+            new SeedRun(),
         ]);
     }
 

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -82,7 +82,7 @@ class BreakpointTest extends TestCase
     public function testExecute($testMethod, $commandLine, $version = null, $noVersionParameter = false)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Breakpoint(Breakpoint::COMMAND_NAME));
+        $application->add(new Breakpoint());
 
         /** @var Breakpoint $command */
         $command = $application->find('breakpoint');
@@ -164,7 +164,7 @@ class BreakpointTest extends TestCase
     public function testRemoveAllAndTargetThrowsException()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Breakpoint(Breakpoint::COMMAND_NAME));
+        $application->add(new Breakpoint());
 
         /** @var Breakpoint $command */
         $command = $application->find('breakpoint');
@@ -200,7 +200,7 @@ class BreakpointTest extends TestCase
     public function testRemoveAllSetUnsetCombinedThrowsException($commandLine)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Breakpoint(Breakpoint::COMMAND_NAME));
+        $application->add(new Breakpoint());
 
         /** @var Breakpoint $command */
         $command = $application->find('breakpoint');

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -76,7 +76,7 @@ class CreateTest extends TestCase
     public function testExecuteWithDuplicateMigrationNames()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create(Create::COMMAND_NAME));
+        $application->add(new Create());
 
         /** @var Create $command */
         $command = $application->find('create');
@@ -102,7 +102,7 @@ class CreateTest extends TestCase
     public function testExecuteWithDuplicateMigrationNamesWithNamespace()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create(Create::COMMAND_NAME));
+        $application->add(new Create());
 
         /** @var Create $command */
         $command = $application->find('create');
@@ -134,7 +134,7 @@ class CreateTest extends TestCase
     public function testSupplyingBothClassAndTemplateAtCommandLineThrowsException()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create(Create::COMMAND_NAME));
+        $application->add(new Create());
 
         /** @var Create $command $command */
         $command = $application->find('create');
@@ -158,7 +158,7 @@ class CreateTest extends TestCase
     public function testSupplyingBothClassAndTemplateInConfigThrowsException()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create(Create::COMMAND_NAME));
+        $application->add(new Create());
 
         /** @var Create $command $command */
         $command = $application->find('create');
@@ -220,7 +220,7 @@ class CreateTest extends TestCase
     public function testTemplateGeneratorsWithoutCorrectInterfaceThrowsException(array $config, array $commandLine, $exceptionMessage)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create(Create::COMMAND_NAME));
+        $application->add(new Create());
 
         /** @var Create $command $command */
         $command = $application->find('create');
@@ -284,7 +284,7 @@ class CreateTest extends TestCase
     public function testNullTemplateGeneratorsDoNotFail(array $config, array $commandLine)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create(Create::COMMAND_NAME));
+        $application->add(new Create());
 
         /** @var Create $command $command */
         $command = $application->find('create');
@@ -348,7 +348,7 @@ class CreateTest extends TestCase
     public function testSimpleTemplateGeneratorsIsCorrectlyPopulated(array $config, array $commandLine)
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Create(Create::COMMAND_NAME));
+        $application->add(new Create());
 
         /** @var Create $command $command */
         $command = $application->find('create');

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -22,7 +22,7 @@ class InitTest extends TestCase
     protected function writeConfig($configName = '')
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Init(Init::COMMAND_NAME));
+        $application->add(new Init());
         $command = $application->find("init");
         $commandTester = new CommandTester($command);
         $fullPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $configName;
@@ -86,7 +86,7 @@ class InitTest extends TestCase
         chdir(sys_get_temp_dir());
 
         $application = new PhinxApplication('testing');
-        $application->add(new Init(Init::COMMAND_NAME));
+        $application->add(new Init());
 
         $command = $application->find('init');
 
@@ -113,7 +113,7 @@ class InitTest extends TestCase
     {
         touch(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.yml');
         $application = new PhinxApplication('testing');
-        $application->add(new Init(Init::COMMAND_NAME));
+        $application->add(new Init());
 
         $command = $application->find('init');
 
@@ -133,7 +133,7 @@ class InitTest extends TestCase
     public function testThrowsExceptionWhenInvalidDir()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Init(Init::COMMAND_NAME));
+        $application->add(new Init());
 
         $command = $application->find('init');
 
@@ -153,7 +153,7 @@ class InitTest extends TestCase
     public function testThrowsExceptionWhenInvalidFormat()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Init(Init::COMMAND_NAME));
+        $application->add(new Init());
 
         $command = $application->find('init');
 

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -59,7 +59,7 @@ class MigrateTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Migrate(Migrate::COMMAND_NAME));
+        $application->add(new Migrate());
 
         /** @var Migrate $command */
         $command = $application->find('migrate');
@@ -85,7 +85,7 @@ class MigrateTest extends TestCase
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Migrate(Migrate::COMMAND_NAME));
+        $application->add(new Migrate());
 
         /** @var Migrate $command */
         $command = $application->find('migrate');
@@ -111,7 +111,7 @@ class MigrateTest extends TestCase
     public function testDatabaseNameSpecified()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Migrate(Migrate::COMMAND_NAME));
+        $application->add(new Migrate());
 
         /** @var Migrate $command */
         $command = $application->find('migrate');
@@ -137,7 +137,7 @@ class MigrateTest extends TestCase
     public function testFakeMigrate()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Migrate(Migrate::COMMAND_NAME));
+        $application->add(new Migrate());
 
         /** @var Migrate $command */
         $command = $application->find('migrate');

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -64,7 +64,7 @@ class RollbackTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Rollback(Rollback::COMMAND_NAME));
+        $application->add(new Rollback());
 
         /** @var Rollback $command */
         $command = $application->find('rollback');
@@ -95,7 +95,7 @@ class RollbackTest extends TestCase
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Rollback(Rollback::COMMAND_NAME));
+        $application->add(new Rollback());
 
         /** @var Rollback $command */
         $command = $application->find('rollback');
@@ -120,7 +120,7 @@ class RollbackTest extends TestCase
     public function testDatabaseNameSpecified()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Rollback(Rollback::COMMAND_NAME));
+        $application->add(new Rollback());
 
         /** @var Rollback $command */
         $command = $application->find('rollback');
@@ -145,7 +145,7 @@ class RollbackTest extends TestCase
     public function testStartTimeVersionOrder()
     {
         $application = new \Phinx\Console\PhinxApplication('testing');
-        $application->add(new Rollback(Rollback::COMMAND_NAME));
+        $application->add(new Rollback());
 
         // setup dependencies
         $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
@@ -175,19 +175,8 @@ class RollbackTest extends TestCase
 
         $date = '20160101';
         $target = '20160101000000';
-        $rollbackStub = $this->getMockBuilder('\Phinx\Console\Command\Rollback')
-            ->setMethods(['getName', 'getTargetFromDate'])
-            ->getMock();
-        
-        $rollbackStub->method('getName')
-                    ->will($this->returnValue(Rollback::COMMAND_NAME));
 
-        $rollbackStub->expects($this->once())
-                    ->method('getTargetFromDate')
-                    ->with($date)
-                    ->will($this->returnValue($target));
-
-        $application->add($rollbackStub);
+        $application->add(new Rollback());
 
         // setup dependencies
         $command = $application->find('rollback');
@@ -212,7 +201,7 @@ class RollbackTest extends TestCase
      */
     public function testGetTargetFromDate($date, $expectedTarget)
     {
-        $rollbackCommand = new Rollback(Rollback::COMMAND_NAME);
+        $rollbackCommand = new Rollback();
         $this->assertEquals($expectedTarget, $rollbackCommand->getTargetFromDate($date));
     }
 
@@ -247,7 +236,7 @@ class RollbackTest extends TestCase
      */
     public function testGetTargetFromDateThrowsException($invalidDate)
     {
-        $rollbackCommand = new Rollback(Rollback::COMMAND_NAME);
+        $rollbackCommand = new Rollback();
         $rollbackCommand->getTargetFromDate($invalidDate);
     }
 
@@ -263,7 +252,7 @@ class RollbackTest extends TestCase
     public function testStarTimeVersionOrderWithDate()
     {
         $application = new \Phinx\Console\PhinxApplication('testing');
-        $application->add(new Rollback(Rollback::COMMAND_NAME));
+        $application->add(new Rollback());
 
         // setup dependencies
         $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
@@ -290,7 +279,7 @@ class RollbackTest extends TestCase
     public function testFakeRollback()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Rollback(Rollback::COMMAND_NAME));
+        $application->add(new Rollback());
 
         /** @var Rollback $command */
         $command = $application->find('rollback');

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -64,7 +64,7 @@ class SeedCreateTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedCreate(SeedCreate::COMMAND_NAME));
+        $application->add(new SeedCreate());
 
         /** @var SeedCreate $command */
         $command = $application->find('seed:create');
@@ -90,7 +90,7 @@ class SeedCreateTest extends TestCase
     public function testExecuteWithInvalidClassName()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedCreate(SeedCreate::COMMAND_NAME));
+        $application->add(new SeedCreate());
 
         /** @var SeedCreate $command */
         $command = $application->find('seed:create');

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -60,7 +60,7 @@ class SeedRunTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedRun(SeedRun::COMMAND_NAME));
+        $application->add(new SeedRun());
 
         /** @var SeedRun $command */
         $command = $application->find('seed:run');
@@ -85,7 +85,7 @@ class SeedRunTest extends TestCase
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedRun(SeedRun::COMMAND_NAME));
+        $application->add(new SeedRun());
 
         /** @var SeedRun $command */
         $command = $application->find('seed:run');
@@ -109,7 +109,7 @@ class SeedRunTest extends TestCase
     public function testDatabaseNameSpecified()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedRun(SeedRun::COMMAND_NAME));
+        $application->add(new SeedRun());
 
         /** @var SeedRun $command */
         $command = $application->find('seed:run');
@@ -133,7 +133,7 @@ class SeedRunTest extends TestCase
     public function testExecuteMultipleSeeders()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new SeedRun(SeedRun::COMMAND_NAME));
+        $application->add(new SeedRun());
 
         /** @var SeedRun $command */
         $command = $application->find('seed:run');

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -64,7 +64,7 @@ class StatusTest extends TestCase
     public function testExecute()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Status(Status::COMMAND_NAME));
+        $application->add(new Status());
 
         /** @var Status $command */
         $command = $application->find('status');
@@ -97,7 +97,7 @@ class StatusTest extends TestCase
     public function testExecuteWithEnvironmentOption()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Status(Status::COMMAND_NAME));
+        $application->add(new Status());
 
         /** @var Status $command */
         $command = $application->find('status');
@@ -124,7 +124,7 @@ class StatusTest extends TestCase
     public function testFormatSpecified()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Status(Status::COMMAND_NAME));
+        $application->add(new Status());
 
         /** @var Status $command */
         $command = $application->find('status');
@@ -151,7 +151,7 @@ class StatusTest extends TestCase
     public function testExecuteVersionOrderByExecutionTime()
     {
         $application = new PhinxApplication('testing');
-        $application->add(new Status(Status::COMMAND_NAME));
+        $application->add(new Status());
 
         /** @var Status $command */
         $command = $application->find('status');


### PR DESCRIPTION
From the comments in #1588, namely:

> Another solution could be to use the `$defaultName` static property, which serves a similar need directly in `symfony/console`

_Originally posted by @stof in https://github.com/cakephp/phinx/pull/1588#issuecomment-525334319_

> @stof do you like to open a PR with using `defaultName` ?
> it is good idea

_Originally posted by @saeideng in https://github.com/cakephp/phinx/pull/1588#issuecomment-525458265_

This uses the `$defaultName` static variable available in Symfony\Console (https://github.com/symfony/console/blob/6b101586a5938f1a5958ef0d6ca598755b6d6ea8/Command/Command.php#L32-L35) to set a name for the command to be used if a different name is not passed in the constructor.

Note, this does requiring bumping the dependencies for symfony/console to 3.4 as that is where `$defaultName` was added. I also removed the RollbackMockStub in the one test as I'm not sure why it was there and there was no difference in the test output.