### PR TITLE
Do not print out status table when specifying --format json

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       - dependencies: highest
         db: 2012
         php_ddl: 56_nts
-        php_zip: php-5.6.28-nts-Win32-VC11-x86.zip
+        php_zip: php-5.6.40-nts-Win32-VC11-x86.zip
         db_dsn: 'sqlserver://sa:Password12!@.\SQL2012SP1/phinxtesting?MultipleActiveResultSets=false'
         sqlsrv: https://download.microsoft.com/download/C/D/B/CDB0A3BB-600E-42ED-8D5E-E4630C905371/SQLSRV32.EXE
 

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -100,8 +100,8 @@ class Manager
     /**
      * Prints the specified environment's migration status.
      *
-     * @param string $environment
-     * @param null $format
+     * @param string $environment environment to print status of
+     * @param string|null $format format to print status in (either text, json, or null)
      * @return int 0 if all migrations are up, or an error code
      */
     public function printStatus($environment, $format = null)
@@ -114,6 +114,10 @@ class Manager
         $missingCount = 0;
         $pendingMigrationCount = 0;
         $finalMigrations = [];
+        $verbosity = $output->getVerbosity();
+        if ($format === 'json') {
+            $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+        }
         if (count($migrations)) {
             // TODO - rewrite using Symfony Table Helper as we already have this library
             // included and it will fix formatting issues (e.g drawing the lines)
@@ -234,9 +238,11 @@ class Manager
 
         // write an empty line
         $output->writeln('');
+
         if ($format !== null) {
             switch ($format) {
                 case 'json':
+                    $output->setVerbosity($verbosity);
                     $output->writeln(json_encode(
                         [
                             'pending_count' => $pendingMigrationCount,

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -198,7 +198,7 @@ class ManagerTest extends TestCase
         $this->assertSame(0, $return);
         rewind($this->manager->getOutput()->getStream());
         $outputStr = trim(stream_get_contents($this->manager->getOutput()->getStream()));
-        $this->assertStringEndsWith('{"pending_count":0,"missing_count":0,"total_count":2,"migrations":[{"migration_status":"up","migration_id":"20120111235330","migration_name":"TestMigration"},{"migration_status":"up","migration_id":"20120116183504","migration_name":"TestMigration2"}]}', $outputStr);
+        $this->assertEquals('{"pending_count":0,"missing_count":0,"total_count":2,"migrations":[{"migration_status":"up","migration_id":"20120111235330","migration_name":"TestMigration"},{"migration_status":"up","migration_id":"20120116183504","migration_name":"TestMigration2"}]}', $outputStr);
     }
 
     public function testPrintStatusMethodWithNamespace()


### PR DESCRIPTION
Sort of fixes #962

If using `--format json` for `phinx status`, it will print out just the JSON object and not the full status table as well.

Before:
```
Phinx by CakePHP - https://phinx.org. 0.11.1

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /Users/mpeveler/Work/Github/phinx/db/migrations
using seed paths
warning no environment specified, defaulting to: production
using format json
ordering by creation time

 Status  [Migration ID]  Started              Finished             Migration Name
----------------------------------------------------------------------------------
     up  20190828175258  2019-08-28 17:55:41  2019-08-28 17:55:41  TestMigration

{"pending_count":0,"missing_count":0,"total_count":1,"migrations":{"20190828175259":{"migration_status":"up","migration_id":"20190828175258","migration_name":"TestMigration"}}}
```

After:
```
Phinx by CakePHP - https://phinx.org. 0.11.1

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /Users/mpeveler/Work/Github/phinx/db/migrations
using seed paths
warning no environment specified, defaulting to: production
using format json
ordering by creation time

{"pending_count":0,"missing_count":0,"total_count":1,"migrations":{"20190828175259":{"migration_status":"up","migration_id":"20190828175258","migration_name":"TestMigration"}}}
```

Working on a separate PR/proposal for how to deal with the header text in a nicer fashion making it easier to use this (and other) command in a pipeline without having to use tail or grep.