### PR TITLE
Unify the variable type of Migration version to float

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -50,7 +50,7 @@ abstract class AbstractMigration implements MigrationInterface
      */
     protected $environment;
     /**
-     * @var float
+     * @var int
      */
     protected $version;
 

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -87,7 +87,7 @@ abstract class AbstractMigration implements MigrationInterface
      * Class Constructor.
      *
      * @param string $environment Environment Detected
-     * @param int $version Migration Version
+     * @param float $version Migration Version
      * @param \Symfony\Component\Console\Input\InputInterface|null $input
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output
      */

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -116,7 +116,7 @@ interface MigrationInterface
     /**
      * Sets the migration version number.
      *
-     * @param int $version Version
+     * @param float $version Version
      * @return \Phinx\Migration\MigrationInterface
      */
     public function setVersion($version);
@@ -124,7 +124,7 @@ interface MigrationInterface
     /**
      * Gets the migration version number.
      *
-     * @return int
+     * @return float
      */
     public function getVersion();
 

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -116,7 +116,7 @@ interface MigrationInterface
     /**
      * Sets the migration version number.
      *
-     * @param float $version Version
+     * @param int $version Version
      * @return \Phinx\Migration\MigrationInterface
      */
     public function setVersion($version);
@@ -124,7 +124,7 @@ interface MigrationInterface
     /**
      * Gets the migration version number.
      *
-     * @return float
+     * @return int
      */
     public function getVersion();
 

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -86,14 +86,14 @@ class Util
      * Get the version from the beginning of a file name.
      *
      * @param string $fileName File Name
-     * @return string
+     * @return int
      */
     public static function getVersionFromFileName($fileName)
     {
         $matches = [];
         preg_match('/^[0-9]+/', basename($fileName), $matches);
 
-        return $matches[0];
+        return (int) $matches[0];
     }
 
     /**

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -86,14 +86,14 @@ class Util
      * Get the version from the beginning of a file name.
      *
      * @param string $fileName File Name
-     * @return int
+     * @return float
      */
     public static function getVersionFromFileName($fileName)
     {
         $matches = [];
         preg_match('/^[0-9]+/', basename($fileName), $matches);
 
-        return (int) $matches[0];
+        return (float) $matches[0];
     }
 
     /**


### PR DESCRIPTION
In the code base, the version variable could be assumed to be a string, integer, or float. Unifies things to be `int` throughout. Somewhat necessary to (hopefully) fix the issues with appveyor failing and Travis passing in #1600.