### PR TITLE
PHP 7.4: Trying to access array offset on value of type bool

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -206,8 +206,8 @@ class Manager
                     '%s %14.0f  %19s  %19s  <comment>%s</comment>',
                     $status,
                     $migration->getVersion(),
-                    $version['start_time'],
-                    $version['end_time'],
+                    ($version ? $version['start_time'] : ''),
+                    ($version ? $version['end_time'] : ''),
                     $migration->getName()
                 ));
 


### PR DESCRIPTION
When using PHP 7.4.0beta4


```
There were 13 errors:

1) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithMissingMigrations
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:378

2) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithMissingMigrationsWithNamespace
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:423

3) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithMissingMigrationsWithMixedNamespace
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:468

4) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithMissingMigrationsAndBreakpointSet
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:710

5) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithDownMigrations
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:739

6) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithDownMigrationsWithNamespace
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:768

7) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithDownMigrationsWithMixedNamespace
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:817

8) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithMissingAndDownMigrations
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:872

9) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithMissingAndDownMigrationsWithNamespace
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:914

10) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodWithMissingAndDownMigrationsWithMixedNamespace
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:973

11) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodVersionOrderHeader with data set "With the default version order" (Phinx\Config\Config Object (...), ' Status  <info>[Migration ID]... Name ')
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:1012

12) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodVersionOrderHeader with data set "With the creation version order" (Phinx\Config\Config Object (...), ' Status  <info>[Migration ID]... Name ')
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:1012

13) Test\Phinx\Migration\ManagerTest::testPrintStatusMethodVersionOrderHeader with data set "With the execution version order" (Phinx\Config\Config Object (...), ' Status  Migration ID    <inf... Name ')
Trying to access array offset on value of type bool

/dev/shm/BUILDROOT/phinx-0.11.1-1.fc29.remi.x86_64/usr/share/php/Phinx/Migration/Manager.php:209
/dev/shm/BUILD/phinx-a6cced878695d26396b26dfd62ce300aea07de05/tests/Phinx/Migration/ManagerTest.php:1012

```