### PR TITLE
Fix ordering of arguments to implode

### DIFF
--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -108,7 +108,7 @@ class Util
     {
         $arr = preg_split('/(?=[A-Z])/', $className);
         unset($arr[0]); // remove the first element ('')
-        $fileName = static::getCurrentTimestamp() . '_' . strtolower(implode($arr, '_')) . '.php';
+        $fileName = static::getCurrentTimestamp() . '_' . strtolower(implode('_', $arr)) . '.php';
 
         return $fileName;
     }


### PR DESCRIPTION
Fixes a batch of the errors in https://travis-ci.org/cakephp/phinx/jobs/578364719.

While implode allows either ordering currently for historical reasons, PHP 7.4 has now deprecated the old syntax.