### PR TITLE
Upgrade travis to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 addons:
-  postgresql: "9.2"
+  postgresql: "9.6"
 
 services:
   - postgresql


### PR DESCRIPTION
Moves from using trusty to xenial for Travis. The build line could be completely removed (as xenial is the default), but I personally prefer to be explicit and to not be surprised if/when the default changes to bionic in my own projects.

Completes one of the items in #1590 (I think).

Necessary for #1605 to fix the sqlite test failures asPHP 7.4 stopped bundling sqlite in their src, and the version of sqlite that comes with trusty is very old and lacking certain features.

Postgres version had to be updated as 9.2 is not available on xenial. Chose the last release of the 9.x branch to move to.