### PR TITLE
Make same output for migrations value of status JSON for 32 and 64 bit PHP

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -242,7 +242,7 @@ class Manager
                             'pending_count' => $pendingMigrationCount,
                             'missing_count' => $missingCount,
                             'total_count' => $migrationCount + $missingCount,
-                            'migrations' => $migrations_final
+                            'migrations' => $finalMigrations
                         ]
                     ));
                     break;

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -113,6 +113,7 @@ class Manager
         $migrationCount = 0;
         $missingCount = 0;
         $pendingMigrationCount = 0;
+        $migrations_final = [];
         if (count($migrations)) {
             // TODO - rewrite using Symfony Table Helper as we already have this library
             // included and it will fix formatting issues (e.g drawing the lines)
@@ -215,7 +216,7 @@ class Manager
                     $output->writeln('         <error>BREAKPOINT SET</error>');
                 }
 
-                $migrations[] = ['migration_status' => trim(strip_tags($status)), 'migration_id' => sprintf('%14.0f', $migration->getVersion()), 'migration_name' => $migration->getName()];
+                $migrations_final[] = ['migration_status' => trim(strip_tags($status)), 'migration_id' => sprintf('%14.0f', $migration->getVersion()), 'migration_name' => $migration->getName()];
                 unset($versions[$migration->getVersion()]);
             }
 
@@ -241,7 +242,7 @@ class Manager
                             'pending_count' => $pendingMigrationCount,
                             'missing_count' => $missingCount,
                             'total_count' => $migrationCount + $missingCount,
-                            'migrations' => $migrations
+                            'migrations' => $migrations_final
                         ]
                     ));
                     break;

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -113,7 +113,7 @@ class Manager
         $migrationCount = 0;
         $missingCount = 0;
         $pendingMigrationCount = 0;
-        $migrations_final = [];
+        $finalMigrations = [];
         if (count($migrations)) {
             // TODO - rewrite using Symfony Table Helper as we already have this library
             // included and it will fix formatting issues (e.g drawing the lines)
@@ -216,7 +216,7 @@ class Manager
                     $output->writeln('         <error>BREAKPOINT SET</error>');
                 }
 
-                $migrations_final[] = ['migration_status' => trim(strip_tags($status)), 'migration_id' => sprintf('%14.0f', $migration->getVersion()), 'migration_name' => $migration->getName()];
+                $finalMigrations[] = ['migration_status' => trim(strip_tags($status)), 'migration_id' => sprintf('%14.0f', $migration->getVersion()), 'migration_name' => $migration->getName()];
                 unset($versions[$migration->getVersion()]);
             }
 

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -164,6 +164,43 @@ class ManagerTest extends TestCase
         $this->assertRegExp('/up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2/', $outputStr);
     }
 
+    public function testPrintStatusMethodJsonFormat()
+    {
+        // stub environment
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(['mockenv', []])
+            ->getMock();
+        $envStub->expects($this->once())
+                ->method('getVersionLog')
+                ->will($this->returnValue(
+                    [
+                        '20120111235330' =>
+                            [
+                                'version' => '20120111235330',
+                                'start_time' => '2012-01-11 23:53:36',
+                                'end_time' => '2012-01-11 23:53:37',
+                                'migration_name' => '',
+                                'breakpoint' => '0',
+                            ],
+                        '20120116183504' =>
+                            [
+                                'version' => '20120116183504',
+                                'start_time' => '2012-01-16 18:35:40',
+                                'end_time' => '2012-01-16 18:35:41',
+                                'migration_name' => '',
+                                'breakpoint' => '0',
+                            ]
+                    ]
+                ));
+        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->getOutput()->setDecorated(false);
+        $return = $this->manager->printStatus('mockenv', 'json');
+        $this->assertSame(0, $return);
+        rewind($this->manager->getOutput()->getStream());
+        $outputStr = trim(stream_get_contents($this->manager->getOutput()->getStream()));
+        $this->assertStringEndsWith('{"pending_count":0,"missing_count":0,"total_count":2,"migrations":[{"migration_status":"up","migration_id":"20120111235330","migration_name":"TestMigration"},{"migration_status":"up","migration_id":"20120116183504","migration_name":"TestMigration2"}]}', $outputStr);
+    }
+
     public function testPrintStatusMethodWithNamespace()
     {
         // stub environment


### PR DESCRIPTION
Closes #1612, unblocks #1600.

The output for the `status` command is now the same on both 32-bit and 64-bit PHP, as a list of migrations instead of a map with random keys.