### PR TITLE
Remove duplication of get[Migration|Seed]Files functions

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -793,23 +793,7 @@ class Manager
      */
     protected function getMigrationFiles()
     {
-        $config = $this->getConfig();
-        $paths = $config->getMigrationPaths();
-        $files = [];
-
-        foreach ($paths as $path) {
-            $files = array_merge(
-                $files,
-                Util::glob($path . DIRECTORY_SEPARATOR . '*.php')
-            );
-        }
-        // glob() can return the same file multiple times
-        // This will cause the migration to fail with a
-        // false assumption of duplicate migrations
-        // http://php.net/manual/en/function.glob.php#110340
-        $files = array_unique($files);
-
-        return $files;
+        return Util::getFiles($this->getConfig()->getMigrationPaths());
     }
 
     /**
@@ -940,23 +924,7 @@ class Manager
      */
     protected function getSeedFiles()
     {
-        $config = $this->getConfig();
-        $paths = $config->getSeedPaths();
-        $files = [];
-
-        foreach ($paths as $path) {
-            $files = array_merge(
-                $files,
-                Util::glob($path . DIRECTORY_SEPARATOR . '*.php')
-            );
-        }
-        // glob() can return the same file multiple times
-        // This will cause the migration to fail with a
-        // false assumption of duplicate migrations
-        // http://php.net/manual/en/function.glob.php#110340
-        $files = array_unique($files);
-
-        return $files;
+        return Util::getFiles($this->getConfig()->getSeedPaths());
     }
 
     /**

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -246,4 +246,23 @@ class Util
 
         return $filePath;
     }
+
+    /**
+     * Given an array of paths, return all unique files that are in them
+     *
+     * @return string[]
+     */
+    public static function getFiles($paths)
+    {
+        $files = static::globAll(array_map(function ($path) {
+            return $path . DIRECTORY_SEPARATOR . "*.php";
+        }, $paths));
+        // glob() can return the same file multiple times
+        // This will cause the migration to fail with a
+        // false assumption of duplicate migrations
+        // http://php.net/manual/en/function.glob.php#110340
+        $files = array_unique($files);
+
+        return $files;
+    }
 }

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -248,8 +248,9 @@ class Util
     }
 
     /**
-     * Given an array of paths, return all unique files that are in them
+     * Given an array of paths, return all unique PHP files that are in them
      *
+     * @param string[] $paths array of paths to get php files
      * @return string[]
      */
     public static function getFiles($paths)

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -113,4 +113,19 @@ class UtilTest extends TestCase
         $this->assertEquals('not_a_migration.php', basename($files[2]));
         $this->assertEquals('empty.txt', basename($files[3]));
     }
+
+    public function testGetFiles()
+    {
+        $files = Util::getFiles([
+            __DIR__ . '/_files/migrations',
+            __DIR__ . '/_files/migrations/subdirectory',
+            __DIR__ . '/_files/migrations/subdirectory'
+        ]);
+
+        $this->assertCount(4, $files);
+        $this->assertEquals('20120111235330_test_migration.php', basename($files[0]));
+        $this->assertEquals('20120116183504_test_migration_2.php', basename($files[1]));
+        $this->assertEquals('not_a_migration.php', basename($files[2]));
+        $this->assertEquals('foobar.php', basename($files[3]));
+    }
 }


### PR DESCRIPTION
`Manager::getMigrationFiles` and `Manager::getSeedFiles` did more or less the same with just a deviation of the paths used. Given that the functions are marked as just `protected` instead of `private`, I elected to not remove them in-case they're being modified by downstream consumers of phinx.