### PR TITLE
Add block on executing Phinx inside another symfony console app

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -306,6 +306,51 @@ and to rollback use `<http://localhost:8000/rollback>`__.
         or other another dynamic option, set ``$_SERVER['PHINX_DBNAME']`` before
         running commands. Available options are documented in the Configuration page.
 
+Wrapping Phinx in another Symfony Console Application
+-----------------------------------------------------
+
+Phinx can be wrapped and run as part of a separate Symfony console application. This
+may be desirable to present a unified interface to the user for all aspects of your
+application, or because you wish to run multiple Phinx commands. While you could
+run the commands through ``exec`` or use the above ``Phinx\Wrapper\TextWrapper``,
+though this makes it hard to deal with the return code and output in a similar fashion
+as your application.
+
+Luckily, Symfony makes doing this sort of "meta" command straight-forward:
+
+.. code-block:: php
+
+    use Symfony\Component\Console\Input\ArrayInput;
+    use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Output\OutputInterface;
+    use Phinx\Console\PhinxApplication;
+
+    // ...
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $phinx = new PhinxApplication();        
+        $command = $phinx->find('migrate');
+
+        $arguments = [
+            'command'         => 'migrate',
+            '--environment'   => 'production',
+            '--configuration' => '/path/to/config/phinx.yml'
+        ];
+        
+        $input = new ArrayInput($arguments);
+        $returnCode = $command->run(new ArrayInput($arguments), $output);
+        // ...
+    }
+    
+Here, you are instantianting the ``PhinxApplication``, telling it to find the ``migrate``
+command, defining the arguments to pass to it (which match the commandline arguments and flags),
+and then finally running the command, passing it the same ``OutputInterface`` that your
+application uses.
+
+See this `Symfony page <https://symfony.com/doc/current/console/calling_commands.html>`_ for more information.
+
 Using Phinx with PHPUnit
 --------------------------
 


### PR DESCRIPTION
Adds documentation per @dereuromark's request in #1628. Uses a combination of https://github.com/cakephp/phinx/issues/1365#issuecomment-396245197 and https://symfony.com/doc/current/console/calling_commands.html to explain how to do it so that it's better highlighted.