### PR TITLE
fix phpdoc type for ManagerTest::testPrintStatusMethodVersionOrderHeader

### DIFF
--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -1029,8 +1029,8 @@ class ManagerTest extends TestCase
      *
      * @dataProvider statusVersionOrderProvider
      *
-     * @param array  $config
-     * @param string $expectedStatusHeader
+     * @param Config $config Config to use for the test
+     * @param string $expectedStatusHeader expected header string
      */
     public function testPrintStatusMethodVersionOrderHeader($config, $expectedStatusHeader)
     {


### PR DESCRIPTION
Relatively inconsequential test code documentation fix, but without the fix my editor complains that there's an error in `ManagerTest` where `$config` is passed to something that expects a `ConfigInterface` type.