### PR TITLE
feat: add validation in PostgresAdapter for timestamp column limit

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1134,11 +1134,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 );
             } elseif (in_array($sqlType['name'], ['time', 'timestamp'])) {
                 if (is_numeric($column->getPrecision())) {
-                    if ($sqlType['name'] == 'timestamp' && $column->getPrecision() > 6) {
-                        $buffer[] = sprintf('(6)');
-                    } else {
-                        $buffer[] = sprintf('(%s)', $column->getPrecision());
-                    }
+                    $buffer[] = sprintf('(%s)', min($column->getPrecision(), 6));
                 }
 
                 if ($column->isTimezone()) {

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1134,7 +1134,11 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 );
             } elseif (in_array($sqlType['name'], ['time', 'timestamp'])) {
                 if (is_numeric($column->getPrecision())) {
-                    $buffer[] = sprintf('(%s)', $column->getPrecision());
+                    if ($sqlType['name'] == 'timestamp' && $column->getPrecision() > 6) {
+                        $buffer[] = sprintf('(6)');
+                    } else {
+                        $buffer[] = sprintf('(%s)', $column->getPrecision());
+                    }
                 }
 
                 if ($column->isTimezone()) {

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1974,4 +1974,27 @@ OUTPUT;
 
         $this->assertEquals(1, $stm->rowCount());
     }
+
+    public function testDumpCreateTableWithColumnTimestampAndLimitGreaterThanSix()
+    {
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+
+        $table->addColumn('column1', 'timestamp', ['limit' => 99])
+            ->save();
+
+        $expectedOutput = 'CREATE TABLE "public"."table1" ("id" SERIAL NOT NULL, "column1" TIMESTAMP (6) ' .
+            'NOT NULL, CONSTRAINT "table1_pkey" PRIMARY KEY ("id"));';
+        $actualOutput = $consoleOutput->fetch();
+        $this->assertContains(
+            $expectedOutput,
+            $actualOutput,
+            'Passing the --dry-run option does not dump create table query'
+        );
+    }
 }


### PR DESCRIPTION
Maybe this is not needed it since PostgreSQL reduces precision to the maximum allowed if you try a greater number, but since this was a topic in https://github.com/cakephp/phinx/pull/1289 I decided to open this PR