### PR TITLE
Expose ports for databases in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,12 @@ services:
         environment:
             - MYSQL_DATABASE=phinx_testing
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+        ports:
+            - 3306:3306
+
     postgres:
         image: postgres:9.2
         environment:
             - POSTGRES_DB=phinx_testing
-
+        ports:
+            - 5432:5432


### PR DESCRIPTION
Exposes the ports for the databases that are spun up by the docker-compose file. This makes using the docker-compose file possible without also having to be forced into using it solely within the phinx application. I personally would prefer to use my host terminal and its tools (e.g. zsh, usql) for working, not a plain Debian based system.