### PR TITLE
postgresql does not allow limit parameter for type text

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1140,7 +1140,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 if ($column->isTimezone()) {
                     $buffer[] = strtoupper('with time zone');
                 }
-            } elseif (!in_array($sqlType['name'], ['integer', 'smallint', 'bigint', 'boolean'])) {
+            } elseif (!in_array($sqlType['name'], ['integer', 'smallint', 'bigint', 'boolean', 'text'])) {
                 if ($column->getLimit() || isset($sqlType['limit'])) {
                     $buffer[] = sprintf('(%s)', $column->getLimit() ?: $sqlType['limit']);
                 }


### PR DESCRIPTION
fixes PDOException: SQLSTATE[42601]: Syntax error: 7 ERROR:  type modifier is not allowed for type "text"