### PR TITLE
Introduce new command to list migration template creation aliases.

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -237,7 +237,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      */
     public function getAliases()
     {
-        return !empty($this->values['aliases']) ? $this->values['aliases'] : null;
+        return !empty($this->values['aliases']) ? $this->values['aliases'] : [];
     }
 
     /**

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -235,6 +235,14 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * {@inheritdoc}
      */
+    public function getAliases()
+    {
+        return !empty($this->values['aliases']) ? $this->values['aliases'] : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getConfigFilePath()
     {
         return $this->configFilePath;

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -84,7 +84,7 @@ interface ConfigInterface extends \ArrayAccess
     /**
      * Get all the aliased values.
      *
-     * @return array|null
+     * @return array
      */
     public function getAliases();
 

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -82,6 +82,13 @@ interface ConfigInterface extends \ArrayAccess
     public function getAlias($alias);
 
     /**
+     * Get all the aliased values.
+     *
+     * @return array|null
+     */
+    public function getAliases();
+
+    /**
      * Gets the config file path.
      *
      * @return string

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -84,7 +84,7 @@ interface ConfigInterface extends \ArrayAccess
     /**
      * Get all the aliased values.
      *
-     * @return array
+     * @return string[]
      */
     public function getAliases();
 

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author     Richard Quadling
+ * @package    Phinx
+ * @subpackage Phinx\Console
+ */
+
+namespace Phinx\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListAliases extends AbstractCommand
+{
+    protected static $defaultName = 'list:aliases';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setDescription('List template class aliases')
+            ->setHelp('The <info>list:aliases</info> command lists the migration template generation class aliases');
+    }
+
+    /**
+     * Toggle the breakpoint.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int integer 0 on success, or an error code.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->bootstrap($input, $output);
+
+        $aliases = $this->config->getAliases();
+
+        if ($aliases) {
+            $maxAliasLength = max(array_map('strlen', array_keys($aliases)));
+            $maxClassLength = max(array_map('strlen', $aliases));
+            $output->writeln(
+                array_merge(
+                    [
+                        '',
+                        sprintf('%s %s', str_pad('Alias', $maxAliasLength), str_pad('Class', $maxClassLength)),
+                        sprintf('%s %s', str_repeat('=', $maxAliasLength), str_repeat('=', $maxClassLength)),
+                    ],
+                    array_map(
+                        function ($alias, $class) use ($maxAliasLength, $maxClassLength) {
+                            return sprintf('%s %s', str_pad($alias, $maxAliasLength), str_pad($class, $maxClassLength));
+                        },
+                        array_keys($aliases),
+                        $aliases
+                    )
+                )
+            );
+        } else {
+            $output->writeln(
+                sprintf(
+                    '<error>No aliases defined in %s</error>',
+                    str_replace(getcwd(), '', realpath($this->config->getConfigFilePath()))
+                )
+            );
+        }
+
+        return 0;
+    }
+}

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -49,12 +49,9 @@ class ListAliases extends AbstractCommand
     }
 
     /**
-     * Toggle the breakpoint.
+     * List migration template creation aliases.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     *
-     * @return int integer 0 on success, or an error code.
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -31,6 +31,7 @@ namespace Phinx\Console;
 use Phinx\Console\Command\Breakpoint;
 use Phinx\Console\Command\Create;
 use Phinx\Console\Command\Init;
+use Phinx\Console\Command\ListAliases;
 use Phinx\Console\Command\Migrate;
 use Phinx\Console\Command\Rollback;
 use Phinx\Console\Command\SeedCreate;
@@ -74,6 +75,7 @@ class PhinxApplication extends Application
             new Test(),
             new SeedCreate(),
             new SeedRun(),
+            new ListAliases(),
         ]);
     }
 

--- a/tests/Phinx/Config/_files/seeds_with_aliases.yml
+++ b/tests/Phinx/Config/_files/seeds_with_aliases.yml
@@ -1,0 +1,34 @@
+paths:
+    migrations: '%%PHINX_CONFIG_DIR%%/db/migrations'
+    seeds: '%%PHINX_CONFIG_DIR%%/db/seeds'
+
+environments:
+    default_migration_table: phinxlog
+    default_database: staging
+    production:
+        adapter: mysql
+        host: localhost
+        name: production_db
+        user: root
+        pass: ''
+        port: 3306
+
+    development:
+        adapter: mysql
+        host: localhost
+        name: development_db
+        user: root
+        pass: ''
+        port: 3306
+
+    testing:
+        adapter: mysql
+        host: localhost
+        name: testing_db
+        user: root
+        pass: ''
+        port: 3306
+
+aliases:
+    MakePermission: Vendor\Package\Migration\Creation\MakePermission
+    RemovePermission: Vendor\Package\Migration\Creation\RemovePermission

--- a/tests/Phinx/Config/_files/valid_config_with_aliases.json
+++ b/tests/Phinx/Config/_files/valid_config_with_aliases.json
@@ -1,0 +1,21 @@
+{
+	"paths": {
+		"migrations": "application/migrations"
+	},
+	"environments": {
+		"default_migration_table": "phinxlog",
+		"default_database": "dev",
+		"dev": {
+			"adapter": "mysql",
+			"host": "localhost",
+			"name": "testing",
+			"user": "root",
+			"pass": "",
+			"port": 3306
+		}
+	},
+    "aliases": {
+        "MakePermission": "Vendor\\Package\\Migration\\Creation\\MakePermission",
+        "RemovePermission": "Vendor\\Package\\Migration\\Creation\\RemovePermission"
+    }
+}

--- a/tests/Phinx/Config/_files/valid_config_with_aliases.php
+++ b/tests/Phinx/Config/_files/valid_config_with_aliases.php
@@ -1,0 +1,30 @@
+<?php
+return [
+    'paths' => [
+        'migrations' => [
+            'application/migrations',
+            'application2/migrations'
+        ],
+        'seeds' => [
+            'application/seeds',
+            'application2/seeds'
+        ]
+    ],
+    'environments' => [
+        'default_migration_table' => 'phinxlog',
+        'default_database' => 'dev',
+        'dev' => [
+            'adapter' => 'mysql',
+            'wrapper' => 'testwrapper',
+            'host' => 'localhost',
+            'name' => 'testing',
+            'user' => 'root',
+            'pass' => '',
+            'port' => 3306
+        ]
+    ],
+    'aliases' => [
+        'MakePermission' => Vendor\Package\Migration\Creation\MakePermission::class,
+        'RemovePermission' => Vendor\Package\Migration\Creation\RemovePermission::class,
+    ],
+];

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -26,7 +26,7 @@ class ListAliasesTest extends TestCase
      *
      * @dataProvider provideConfigurations
      */
-    public function testListingAliases(string $file, bool $hasAliases)
+    public function testListingAliases($file, $hasAliases)
     {
         $command = (new PhinxApplication('testing'))->find('list:aliases');
         $commandTester = new CommandTester($command);

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -33,7 +33,7 @@ class ListAliasesTest extends TestCase
         $commandTester->execute(
             [
                 'command' => $command->getName(),
-                '--configuration' => realpath(__DIR__.'/../../Config/_files/'.$file),
+                '--configuration' => realpath(sprintf('%s/../../Config/_files/%s', __DIR__, $file)),
             ],
             ['decorated' => false]
         );

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Test\Phinx\Console\Command;
+
+use Phinx\Console\PhinxApplication;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ListAliasesTest extends TestCase
+{
+    public function provideConfigurations()
+    {
+        return [
+            'JSON config without aliases' => ['valid_config.json', false],
+            'JSON config with aliases' => ['valid_config_with_aliases.json', true],
+            'PHP config without aliases' => ['valid_config.php', false],
+            'PHP config with aliases' => ['valid_config_with_aliases.php', true],
+            'YAML config without aliases' => ['seeds.yml', false],
+            'YAML config with aliases' => ['seeds_with_aliases.yml', true],
+        ];
+    }
+
+    /**
+     * @param string $file
+     * @param bool $hasAliases
+     *
+     * @dataProvider provideConfigurations
+     */
+    public function testListingAliases(string $file, bool $hasAliases)
+    {
+        $command = (new PhinxApplication('testing'))->find('list:aliases');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            [
+                'command' => $command->getName(),
+                '--configuration' => realpath(__DIR__.'/../../Config/_files/'.$file),
+            ],
+            ['decorated' => false]
+        );
+
+        $display = $commandTester->getDisplay(false);
+
+        if ($hasAliases) {
+            $this->assertNotContains('No aliases defined in ', $display);
+            $this->assertContains('Alias            Class                                             ', $display);
+            $this->assertContains('================ ==================================================', $display);
+            $this->assertContains('MakePermission   Vendor\Package\Migration\Creation\MakePermission  ', $display);
+            $this->assertContains('RemovePermission Vendor\Package\Migration\Creation\RemovePermission', $display);
+        } else {
+            $this->assertContains('No aliases defined in ', $display);
+        }
+    }
+}


### PR DESCRIPTION
For those using migration template generators, the use of aliases provides a nice way to keep the names short, rather than providing full class names.

But the list of aliases and what they are aliasing is only available within the config file. Which is fine. 

This command simply lists the aliases and the aliased class.