### PR TITLE
Update travis to test against 7.4 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 env:
   global:
@@ -33,7 +33,7 @@ matrix:
       env: PHPSTAN=1 DEFAULT=0
 
 before_install:
-  - if [[ ${TRAVIS_PHP_VERSION} != "7.4snapshot" ]]; then phpenv config-rm xdebug.ini; fi
+  - phpenv config-rm xdebug.ini
 
 before_script:
     - if [[ $PREFER_LOWEST != 1 ]]; then travis_retry composer update --no-interaction --prefer-stable; fi


### PR DESCRIPTION
PHP 7.4 got released on Nov 28, and so it's no longer necessary to test against the snapshot on Travis.

The next version (8.0) is currently not possible to use with PHPUnit so cannot add `nightly` or `8.0snapshot` for future testing.