### PR TITLE
Add save() call after removeIndex in docs

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -1305,10 +1305,12 @@ call this method for each index.
             public function up()
             {
                 $table = $this->table('users');
-                $table->removeIndex(['email']);
+                $table->removeIndex(['email'])
+                    ->save();
 
                 // alternatively, you can delete an index by its name, ie:
-                $table->removeIndexByName('idx_users_email');
+                $table->removeIndexByName('idx_users_email')
+                    ->save();
             }
 
             /**


### PR DESCRIPTION
Closes #1391

Adds `save()` call after calling `removeIndex` and `removeIndexByName` as it's necessary to do that now.

It should be noted that on https://book.cakephp.org/4/en/phinx/migrations.html#working-with-indexes, they already had the `save()` call, which makes me wonder where it's pulling its sources from for its docs as I could not find any branch in the repo that had this.