### PR TITLE
Fix minimum required version of PHP in install docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,7 +10,7 @@ website for more information.
 
 .. note::
 
-    Phinx requires at least PHP 5.4 (or later).
+    Phinx requires at least PHP 5.6 (or later).
 
 To install Phinx, simply require it using Composer:
 


### PR DESCRIPTION
The composer.json file specifies a minimum dependency of PHP 5.6:
https://github.com/cakephp/phinx/blob/688f40619fd00e79cbafcfae0069786ece26ecea/composer.json#L27-L28