### PR TITLE
Remove non-necessary cakephp dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "require": {
         "php": ">=5.6",
         "cakephp/collection": "^3.6",
-        "cakephp/core": "^3.6",
         "cakephp/database": "^3.6",
         "cakephp/datasource": "^3.6",
         "symfony/console": "^3.4|^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     }],
     "require": {
         "php": ">=5.6",
-        "cakephp/collection": "^3.6",
-        "cakephp/database": "^3.6",
-        "cakephp/datasource": "^3.6",
+        "cakephp/collection": "^3.7",
+        "cakephp/database": "^3.7",
+        "cakephp/datasource": "^3.7",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/yaml": "^3.4|^4.0|^5.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "php": ">=5.6",
         "cakephp/collection": "^3.7",
         "cakephp/database": "^3.7",
-        "cakephp/datasource": "^3.7",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/yaml": "^3.4|^4.0|^5.0"


### PR DESCRIPTION
cakephp/core and cakephp/datasource are sub-dependencies of cakephp/database and so not necessary to include directly, though does require a bump in version of the cakephp/database (see https://travis-ci.org/MasterOdin/phinx/jobs/626553916 for error that happens otherwise).

