### PR TITLE
Print version order when running migrate

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -105,7 +105,7 @@ EOT
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();
-        $output->writeln('<info>ordering by </info>' . $versionOrder . " time");
+        $output->writeln('<info>ordering by</info>'  . $versionOrder . ' time');
 
         if ($fake) {
             $output->writeln('<comment>warning</comment> performing fake migrations');

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -105,7 +105,7 @@ EOT
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();
-        $output->writeln('<info>ordering by</info>'  . $versionOrder . ' time');
+        $output->writeln('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($fake) {
             $output->writeln('<comment>warning</comment> performing fake migrations');

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -104,6 +104,9 @@ EOT
             $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
         }
 
+        $versionOrder = $this->getConfig()->getVersionOrder();
+        $output->writeln('<info>ordering by </info>' . $versionOrder . " time");
+
         if ($fake) {
             $output->writeln('<comment>warning</comment> performing fake migrations');
         }

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -105,7 +105,7 @@ EOT
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();
-        $output->writeln('<info>ordering by </info>' . $versionOrder . " time");
+        $output->writeln('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($fake) {
             $output->writeln('<comment>warning</comment> performing fake rollbacks');


### PR DESCRIPTION
When running `rollback`, it prints out `ordering by [creation|execution] time` while migrate did not. This adds that print line to migrate to keep them consistent.

Added tests for when no order is provided (and defaults to creation) and when an order is provided.