### PR TITLE
Standardize exit codes to class constants

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -53,6 +53,26 @@ abstract class AbstractCommand extends Command
     protected $manager;
 
     /**
+     * @var int
+     */
+    const EXIT_SUCCESS = 0;
+
+    /**
+     * @var int
+     */
+    const EXIT_ERROR = 1;
+
+    /**
+     * @var int
+     */
+    const EXIT_STATUS_MISSING = 2;
+
+    /**
+     * @var int
+     */
+    const EXIT_STATUS_DOWN = 3;
+
+    /**
      * {@inheritDoc}
      *
      * @return void

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -53,24 +53,29 @@ abstract class AbstractCommand extends Command
     protected $manager;
 
     /**
+     * Exit code for when command executes successfully
      * @var int
      */
-    const EXIT_SUCCESS = 0;
+    const CODE_SUCCESS = 0;
 
     /**
+     * Exit code for when command hits a non-recoverable error during execution
      * @var int
      */
-    const EXIT_ERROR = 1;
+    const CODE_ERROR = 1;
 
     /**
+     * Exit code for when status command is run and there are missing migrations
      * @var int
      */
-    const EXIT_STATUS_MISSING = 2;
+    const CODE_STATUS_MISSING = 2;
 
     /**
+     * Exit code for when status command is run and there are no missing migations,
+     * but does have down migrations
      * @var int
      */
-    const EXIT_STATUS_DOWN = 3;
+    const CODE_STATUS_DOWN = 3;
 
     /**
      * {@inheritDoc}

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -78,7 +78,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return 1;
+            return self::EXIT_ERROR;
         }
 
         if ($version && $removeAll) {
@@ -103,6 +103,6 @@ EOT
             $this->getManager()->toggleBreakpoint($environment, $version);
         }
 
-        return 0;
+        return self::EXIT_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -78,7 +78,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         }
 
         if ($version && $removeAll) {
@@ -103,6 +103,6 @@ EOT
             $this->getManager()->toggleBreakpoint($environment, $version);
         }
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -304,6 +304,6 @@ class Create extends AbstractCommand
 
         $output->writeln('<info>created</info> ' . str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $filePath));
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -304,6 +304,6 @@ class Create extends AbstractCommand
 
         $output->writeln('<info>created</info> ' . str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $filePath));
 
-        return 0;
+        return self::EXIT_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -56,7 +56,7 @@ class Init extends Command
 
         $output->writeln("<info>created</info> {$path}");
 
-        return 0;
+        return AbstractCommand::EXIT_SUCCESS;
     }
 
     /**

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -56,7 +56,7 @@ class Init extends Command
 
         $output->writeln("<info>created</info> {$path}");
 
-        return AbstractCommand::EXIT_SUCCESS;
+        return AbstractCommand::CODE_SUCCESS;
     }
 
     /**

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -72,6 +72,6 @@ class ListAliases extends AbstractCommand
             );
         }
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -72,6 +72,6 @@ class ListAliases extends AbstractCommand
             );
         }
 
-        return 0;
+        return self::EXIT_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -77,7 +77,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         }
 
         $envOptions = $this->getConfig()->getEnvironment($environment);
@@ -94,7 +94,7 @@ EOT
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         }
 
         if (isset($envOptions['table_prefix'])) {
@@ -120,16 +120,16 @@ EOT
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->__toString() . '</error>');
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         } catch (Throwable $e) {
             $output->writeln('<error>' . $e->__toString() . '</error>');
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         }
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -77,7 +77,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return 1;
+            return self::EXIT_ERROR;
         }
 
         $envOptions = $this->getConfig()->getEnvironment($environment);
@@ -94,7 +94,7 @@ EOT
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
-            return 1;
+            return self::EXIT_ERROR;
         }
 
         if (isset($envOptions['table_prefix'])) {
@@ -120,16 +120,16 @@ EOT
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->__toString() . '</error>');
 
-            return 1;
+            return self::EXIT_ERROR;
         } catch (Throwable $e) {
             $output->writeln('<error>' . $e->__toString() . '</error>');
 
-            return 1;
+            return self::EXIT_ERROR;
         }
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
 
-        return 0;
+        return self::EXIT_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -88,7 +88,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return 1;
+            return self::EXIT_ERROR;
         }
 
         $envOptions = $config->getEnvironment($environment);
@@ -127,7 +127,7 @@ EOT
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
 
-        return 0;
+        return self::EXIT_SUCCESS;
     }
 
     /**

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -88,7 +88,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         }
 
         $envOptions = $config->getEnvironment($environment);
@@ -127,7 +127,7 @@ EOT
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 
     /**

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -189,6 +189,6 @@ class SeedCreate extends AbstractCommand
         $output->writeln('<info>using seed base class</info> ' . $classes['$useClassName']);
         $output->writeln('<info>created</info> .' . str_replace(getcwd(), '', $filePath));
 
-        return 0;
+        return self::EXIT_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -189,6 +189,6 @@ class SeedCreate extends AbstractCommand
         $output->writeln('<info>using seed base class</info> ' . $classes['$useClassName']);
         $output->writeln('<info>created</info> .' . str_replace(getcwd(), '', $filePath));
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -69,7 +69,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return 1;
+            return self::EXIT_ERROR;
         }
 
         $envOptions = $this->getConfig()->getEnvironment($environment);
@@ -86,7 +86,7 @@ EOT
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
-            return 1;
+            return self::EXIT_ERROR;
         }
 
         if (isset($envOptions['table_prefix'])) {
@@ -113,6 +113,6 @@ EOT
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
 
-        return 0;
+        return self::EXIT_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -69,7 +69,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         }
 
         $envOptions = $this->getConfig()->getEnvironment($environment);
@@ -86,7 +86,7 @@ EOT
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         }
 
         if (isset($envOptions['table_prefix'])) {
@@ -113,6 +113,6 @@ EOT
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -68,7 +68,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return 1;
+            return self::EXIT_ERROR;
         }
 
         if ($format !== null) {
@@ -78,6 +78,14 @@ EOT
         $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder() . " time");
 
         // print the status
-        return $this->getManager()->printStatus($environment, $format);
+        $result = $this->getManager()->printStatus($environment, $format);
+
+        if ($result['hasMissingMigration']) {
+            return self::EXIT_STATUS_MISSING;
+        } elseif ($result['hasDownMigration']) {
+            return self::EXIT_STATUS_DOWN;
+        }
+
+        return self::EXIT_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -68,7 +68,7 @@ EOT
         if (!$this->getConfig()->hasEnvironment($environment)) {
             $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
-            return self::EXIT_ERROR;
+            return self::CODE_ERROR;
         }
 
         if ($format !== null) {
@@ -81,11 +81,11 @@ EOT
         $result = $this->getManager()->printStatus($environment, $format);
 
         if ($result['hasMissingMigration']) {
-            return self::EXIT_STATUS_MISSING;
+            return self::CODE_STATUS_MISSING;
         } elseif ($result['hasDownMigration']) {
-            return self::EXIT_STATUS_DOWN;
+            return self::CODE_STATUS_DOWN;
         }
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -94,6 +94,6 @@ EOT
 
         $output->writeln('<info>success!</info>');
 
-        return self::EXIT_SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -94,6 +94,6 @@ EOT
 
         $output->writeln('<info>success!</info>');
 
-        return 0;
+        return self::EXIT_SUCCESS;
     }
 }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -76,7 +76,7 @@ class Manager
      *
      * @throws \RuntimeException
      *
-     * @return int 0 if all migrations are up, or an error code
+     * @return array array indicating if there are any missing or down migrations
      */
     public function printStatus($environment, $format = null)
     {

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -234,7 +234,7 @@ class Manager
 
         return [
             'hasMissingMigration' => $hasMissingMigration,
-            'hasDownMigration' => $hasDownMigration
+            'hasDownMigration' => $hasDownMigration,
         ];
     }
 

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -57,16 +57,6 @@ class Manager
     protected $seeds;
 
     /**
-     * @var int
-     */
-    const EXIT_STATUS_DOWN = 3;
-
-    /**
-     * @var int
-     */
-    const EXIT_STATUS_MISSING = 2;
-
-    /**
      * @param \Phinx\Config\ConfigInterface $config Configuration Object
      * @param \Symfony\Component\Console\Input\InputInterface $input Console Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Console Output
@@ -242,13 +232,10 @@ class Manager
             }
         }
 
-        if ($hasMissingMigration) {
-            return self::EXIT_STATUS_MISSING;
-        } elseif ($hasDownMigration) {
-            return self::EXIT_STATUS_DOWN;
-        } else {
-            return 0;
-        }
+        return [
+            'hasMissingMigration' => $hasMissingMigration,
+            'hasDownMigration' => $hasDownMigration
+        ];
     }
 
     /**

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -5,6 +5,7 @@ namespace Test\Phinx\Console\Command;
 use InvalidArgumentException;
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Breakpoint;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
@@ -189,7 +190,7 @@ class BreakpointTest extends TestCase
             ['decorated' => false]
         );
 
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 
     /**
@@ -220,7 +221,7 @@ class BreakpointTest extends TestCase
 
         $commandLine = array_merge(['command' => $command->getName()], $commandLine);
         $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 
     public function provideCombinedParametersToCauseException()
@@ -272,7 +273,7 @@ class BreakpointTest extends TestCase
 
         $commandLine = array_merge(['command' => $command->getName(), '--environment' => 'development'], []);
         $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithInvalidEnvironmentOption()
@@ -300,6 +301,6 @@ class BreakpointTest extends TestCase
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
-        $this->assertSame(1, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_ERROR, $exitCode);
     }
 }

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -190,7 +190,7 @@ class BreakpointTest extends TestCase
             ['decorated' => false]
         );
 
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     /**
@@ -221,7 +221,7 @@ class BreakpointTest extends TestCase
 
         $commandLine = array_merge(['command' => $command->getName()], $commandLine);
         $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function provideCombinedParametersToCauseException()
@@ -273,7 +273,7 @@ class BreakpointTest extends TestCase
 
         $commandLine = array_merge(['command' => $command->getName(), '--environment' => 'development'], []);
         $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithInvalidEnvironmentOption()
@@ -301,6 +301,6 @@ class BreakpointTest extends TestCase
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
-        $this->assertSame(AbstractCommand::EXIT_ERROR, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -80,7 +80,7 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -106,7 +106,7 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithInvalidEnvironmentOption()
@@ -133,7 +133,7 @@ class MigrateTest extends TestCase
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
-        $this->assertSame(AbstractCommand::EXIT_ERROR, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function testDatabaseNameSpecified()
@@ -159,7 +159,7 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testFakeMigrate()
@@ -185,6 +185,6 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--fake' => true], ['decorated' => false]);
 
         $this->assertRegExp('/warning performing fake migrations/', $commandTester->getDisplay());
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Console\Command;
 
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Migrate;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
@@ -79,7 +80,7 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -105,7 +106,7 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithInvalidEnvironmentOption()
@@ -132,7 +133,7 @@ class MigrateTest extends TestCase
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
-        $this->assertSame(1, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_ERROR, $exitCode);
     }
 
     public function testDatabaseNameSpecified()
@@ -158,7 +159,7 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 
     public function testFakeMigrate()
@@ -184,6 +185,6 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--fake' => true], ['decorated' => false]);
 
         $this->assertRegExp('/warning performing fake migrations/', $commandTester->getDisplay());
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 }

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Console\Command;
 
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Rollback;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
@@ -116,7 +117,7 @@ class RollbackTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithInvalidEnvironmentOption()
@@ -143,7 +144,7 @@ class RollbackTest extends TestCase
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
-        $this->assertSame(1, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_ERROR, $exitCode);
     }
 
     public function testDatabaseNameSpecified()

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -117,7 +117,7 @@ class RollbackTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithInvalidEnvironmentOption()
@@ -144,7 +144,7 @@ class RollbackTest extends TestCase
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
-        $this->assertSame(AbstractCommand::EXIT_ERROR, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function testDatabaseNameSpecified()

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -106,7 +106,7 @@ class SeedRunTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
         $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
-        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithInvalidEnvironmentOption()
@@ -133,7 +133,7 @@ class SeedRunTest extends TestCase
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
-        $this->assertSame(AbstractCommand::EXIT_ERROR, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function testDatabaseNameSpecified()

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Console\Command;
 
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\SeedRun;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
@@ -105,7 +106,7 @@ class SeedRunTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
         $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithInvalidEnvironmentOption()
@@ -132,7 +133,7 @@ class SeedRunTest extends TestCase
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
-        $this->assertSame(1, $exitCode);
+        $this->assertSame(AbstractCommand::EXIT_ERROR, $exitCode);
     }
 
     public function testDatabaseNameSpecified()

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Migration;
 
 use Phinx\Config\Config;
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -413,7 +414,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -458,7 +459,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -503,7 +504,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -559,7 +560,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -611,7 +612,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -695,7 +696,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -745,7 +746,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -774,7 +775,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_DOWN, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_DOWN, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -803,7 +804,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_DOWN, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_DOWN, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -852,7 +853,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_DOWN, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_DOWN, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -907,7 +908,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -949,7 +950,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -1008,7 +1009,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -1047,7 +1048,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(Manager::EXIT_STATUS_DOWN, $return);
+        $this->assertEquals(AbstractCommand::EXIT_STATUS_DOWN, $return);
 
         $outputStr = $this->manager->getOutput()->fetch();
         $this->assertContains($expectedStatusHeader, $outputStr);

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -157,7 +157,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(0, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -196,7 +196,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv', 'json');
-        $this->assertSame(0, $return);
+        $this->assertSame(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
         rewind($this->manager->getOutput()->getStream());
         $outputStr = trim(stream_get_contents($this->manager->getOutput()->getStream()));
         $this->assertEquals('{"pending_count":0,"missing_count":0,"total_count":2,"migrations":[{"migration_status":"up","migration_id":"20120111235330","migration_name":"TestMigration"},{"migration_status":"up","migration_id":"20120116183504","migration_name":"TestMigration2"}]}', $outputStr);
@@ -235,7 +235,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(0, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -308,7 +308,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(0, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -352,7 +352,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(0, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -375,7 +375,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(0, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -414,7 +414,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -459,7 +459,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -504,7 +504,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -560,7 +560,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => false], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -612,7 +612,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => false], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -696,7 +696,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => false], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -746,7 +746,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -775,7 +775,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_DOWN, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -804,7 +804,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_DOWN, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -853,7 +853,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_DOWN, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -908,7 +908,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -950,7 +950,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -1009,7 +1009,7 @@ class ManagerTest extends TestCase
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_MISSING, $return);
+        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -1048,7 +1048,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(AbstractCommand::EXIT_STATUS_DOWN, $return);
+        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => true], $return);
 
         $outputStr = $this->manager->getOutput()->fetch();
         $this->assertContains($expectedStatusHeader, $outputStr);


### PR DESCRIPTION
Closes #1623

Currently, the exit codes were magic returned numbers within each command. This creates a class constant in AbstractCommand to use instead over all commands. I also moved the two status exit codes from the Manager to AbstractCommand as well to make the manager a bit more agnostic to how the console is working to make it potentially easier for someone to extend if they wanted to.