### PR TITLE
Fix default phpunit file to work with docker-compose

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,7 +24,7 @@
         <env name="TESTS_PHINX_DB_ADAPTER_SQLSRV_PORT" value="1433"/>
         <!-- MySQL -->
         <env name="TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED" value="true" />
-        <env name="TESTS_PHINX_DB_ADAPTER_MYSQL_HOST" value="localhost" />
+        <env name="TESTS_PHINX_DB_ADAPTER_MYSQL_HOST" value="127.0.0.1" />
         <env name="TESTS_PHINX_DB_ADAPTER_MYSQL_USERNAME" value="root" />
         <env name="TESTS_PHINX_DB_ADAPTER_MYSQL_PASSWORD" value="" />
         <env name="TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE" value="phinx_testing" />


### PR DESCRIPTION
When specifying `localhost` as the host for MySQL, it will attempt to implicitly use a socket to connect, which fails when using docker-compose to host the DBs for testing purposes. Using 127.0.0.1 instead causes it to always use TCP which is fairly likely to always exist on default installations of mysql as well as works properly with the docker-compose setup.