### PR TITLE
Migrate to phpunit 8+ for testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/yaml": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=6.0,<8.0",
+        "phpunit/phpunit": "^8.5",
         "sebastian/comparator": ">=1.2.3",
         "cakephp/cakephp-codesniffer": "^3.0"
     },

--- a/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
+++ b/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
@@ -40,11 +40,12 @@ class ConfigDefaultEnvironmentTest extends AbstractConfigTest
 
     public function testGetDefaultEnvironmentOverridenByEnvButNotSet()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The environment configuration (read from $PHINX_ENVIRONMENT) for \'conf-test\' is missing');
         // set dummy
         $dummyEnv = 'conf-test';
         putenv('PHINX_ENVIRONMENT=' . $dummyEnv);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The environment configuration (read from $PHINX_ENVIRONMENT) for \'conf-test\' is missing');
 
         try {
             $config = new Config([]);
@@ -60,12 +61,14 @@ class ConfigDefaultEnvironmentTest extends AbstractConfigTest
 
     public function testGetDefaultEnvironmentOverridenFailedToFind()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Could not find a default environment');
         // set empty env var
         putenv('PHINX_ENVIRONMENT=');
 
         $config = new Config([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not find a default environment');
+
         $config->getDefaultEnvironment();
     }
 }

--- a/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
+++ b/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Config;
 
 use Phinx\Config\Config;
+use RuntimeException;
 
 /**
  * Class ConfigDefaultEnvironmentTest
@@ -37,12 +38,10 @@ class ConfigDefaultEnvironmentTest extends AbstractConfigTest
         $this->assertEquals('1234', $env['port']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The environment configuration (read from $PHINX_ENVIRONMENT) for 'conf-test' is missing
-     */
     public function testGetDefaultEnvironmentOverridenByEnvButNotSet()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The environment configuration (read from $PHINX_ENVIRONMENT) for \'conf-test\' is missing');
         // set dummy
         $dummyEnv = 'conf-test';
         putenv('PHINX_ENVIRONMENT=' . $dummyEnv);
@@ -59,12 +58,10 @@ class ConfigDefaultEnvironmentTest extends AbstractConfigTest
         }
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Could not find a default environment
-     */
     public function testGetDefaultEnvironmentOverridenFailedToFind()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not find a default environment');
         // set empty env var
         putenv('PHINX_ENVIRONMENT=');
 

--- a/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
+++ b/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
@@ -50,8 +50,7 @@ class ConfigDefaultEnvironmentTest extends AbstractConfigTest
         try {
             $config = new Config([]);
             $config->getDefaultEnvironment();
-        }
-        finally {
+        } finally {
             putenv('PHINX_ENVIRONMENT=');
         }
     }

--- a/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
+++ b/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
@@ -50,12 +50,9 @@ class ConfigDefaultEnvironmentTest extends AbstractConfigTest
         try {
             $config = new Config([]);
             $config->getDefaultEnvironment();
-        } catch (\Exception $e) {
-            // reset back to normal
+        }
+        finally {
             putenv('PHINX_ENVIRONMENT=');
-
-            // throw again in order to finish test
-            throw $e;
         }
     }
 

--- a/tests/Phinx/Config/ConfigFileTest.php
+++ b/tests/Phinx/Config/ConfigFileTest.php
@@ -15,13 +15,13 @@ class ConfigFileTest extends TestCase
 
     private $baseDir;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->previousDir = getcwd();
         $this->baseDir = realpath(__DIR__ . '/_rootDirectories');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         chdir($this->previousDir);
     }

--- a/tests/Phinx/Config/ConfigFileTest.php
+++ b/tests/Phinx/Config/ConfigFileTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Config;
 
+use InvalidArgumentException;
 use Phinx\Console\Command\AbstractCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -50,10 +51,10 @@ class ConfigFileTest extends TestCase
      *
      * @param $input
      * @param $dir
-     * @expectedException \InvalidArgumentException
      */
     public function testNotWorkingGetConfigFile($input, $dir)
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->runLocateFile($input, $dir);
     }
 

--- a/tests/Phinx/Config/ConfigJsonTest.php
+++ b/tests/Phinx/Config/ConfigJsonTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Config;
 
 use Phinx\Config\Config;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * Class ConfigJsonTest
@@ -24,10 +25,10 @@ class ConfigJsonTest extends TestCase
 
     /**
      * @covers \Phinx\Config\Config::fromJson
-     * @expectedException \RuntimeException
      */
     public function testFromJSONInvalidJson()
     {
+        $this->expectException(RuntimeException::class);
         $path = __DIR__ . '/_files';
         Config::fromJson($path . '/invalid.json');
     }

--- a/tests/Phinx/Config/ConfigJsonTest.php
+++ b/tests/Phinx/Config/ConfigJsonTest.php
@@ -28,8 +28,10 @@ class ConfigJsonTest extends TestCase
      */
     public function testFromJSONInvalidJson()
     {
-        $this->expectException(RuntimeException::class);
         $path = __DIR__ . '/_files';
+
+        $this->expectException(RuntimeException::class);
+
         Config::fromJson($path . '/invalid.json');
     }
 }

--- a/tests/Phinx/Config/ConfigMigrationPathsTest.php
+++ b/tests/Phinx/Config/ConfigMigrationPathsTest.php
@@ -40,7 +40,7 @@ class ConfigMigrationPathsTest extends AbstractConfigTest
         $config = new Config($values);
         $paths = $config->getMigrationPaths();
 
-        $this->assertInternalType('array', $paths);
+        $this->assertIsArray($paths);
         $this->assertCount(1, $paths);
     }
 }

--- a/tests/Phinx/Config/ConfigMigrationPathsTest.php
+++ b/tests/Phinx/Config/ConfigMigrationPathsTest.php
@@ -15,8 +15,10 @@ class ConfigMigrationPathsTest extends AbstractConfigTest
 {
     public function testGetMigrationPathsThrowsExceptionForNoPath()
     {
-        $this->expectException(UnexpectedValueException::class);
         $config = new Config([]);
+
+        $this->expectException(UnexpectedValueException::class);
+
         $config->getMigrationPaths();
     }
 

--- a/tests/Phinx/Config/ConfigMigrationPathsTest.php
+++ b/tests/Phinx/Config/ConfigMigrationPathsTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Config;
 
 use Phinx\Config\Config;
+use UnexpectedValueException;
 
 /**
  * Class ConfigMigrationPathsTest
@@ -12,11 +13,9 @@ use Phinx\Config\Config;
  */
 class ConfigMigrationPathsTest extends AbstractConfigTest
 {
-    /**
-     * @expectedException \UnexpectedValueException
-     */
     public function testGetMigrationPathsThrowsExceptionForNoPath()
     {
+        $this->expectException(UnexpectedValueException::class);
         $config = new Config([]);
         $config->getMigrationPaths();
     }

--- a/tests/Phinx/Config/ConfigPhpTest.php
+++ b/tests/Phinx/Config/ConfigPhpTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Config;
 
 use Phinx\Config\Config;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * Class ConfigPhpTest
@@ -26,10 +27,10 @@ class ConfigPhpTest extends TestCase
     /**
      * @covers \Phinx\Config\Config::fromPhp
      * @covers \Phinx\Config\Config::getDefaultEnvironment
-     * @expectedException \RuntimeException
      */
     public function testFromPHPMethodWithoutArray()
     {
+        $this->expectException(RuntimeException::class);
         $path = __DIR__ . '/_files';
         $config = Config::fromPhp($path . '/config_without_array.php');
         $this->assertEquals('dev', $config->getDefaultEnvironment());
@@ -38,10 +39,10 @@ class ConfigPhpTest extends TestCase
     /**
      * @covers \Phinx\Config\Config::fromPhp
      * @covers \Phinx\Config\Config::getDefaultEnvironment
-     * @expectedException \RuntimeException
      */
     public function testFromJSONMethodWithoutJSON()
     {
+        $this->expectException(RuntimeException::class);
         $path = __DIR__ . '/_files';
         $config = Config::fromPhp($path . '/empty.json');
         $this->assertEquals('dev', $config->getDefaultEnvironment());

--- a/tests/Phinx/Config/ConfigPhpTest.php
+++ b/tests/Phinx/Config/ConfigPhpTest.php
@@ -30,10 +30,11 @@ class ConfigPhpTest extends TestCase
      */
     public function testFromPHPMethodWithoutArray()
     {
-        $this->expectException(RuntimeException::class);
         $path = __DIR__ . '/_files';
+
+        $this->expectException(RuntimeException::class);
+
         $config = Config::fromPhp($path . '/config_without_array.php');
-        $this->assertEquals('dev', $config->getDefaultEnvironment());
     }
 
     /**
@@ -42,9 +43,10 @@ class ConfigPhpTest extends TestCase
      */
     public function testFromJSONMethodWithoutJSON()
     {
-        $this->expectException(RuntimeException::class);
         $path = __DIR__ . '/_files';
+
+        $this->expectException(RuntimeException::class);
+
         $config = Config::fromPhp($path . '/empty.json');
-        $this->assertEquals('dev', $config->getDefaultEnvironment());
     }
 }

--- a/tests/Phinx/Config/ConfigReplaceTokensTest.php
+++ b/tests/Phinx/Config/ConfigReplaceTokensTest.php
@@ -54,15 +54,15 @@ class ConfigReplaceTokensTest extends AbstractConfigTest
             'some-var-4' => 123456,
         ]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             static::$server['PHINX_TEST_VAR_1'] . '', // force convert to string
             $config->offsetGet('some-var-1')
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             static::$server['NON_PHINX_TEST_VAR_1'] . '', // force convert to string
             $config->offsetGet('some-var-2')
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             static::$server['PHINX_TEST_VAR_2'] . '', // force convert to string
             $config->offsetGet('some-var-3')
         );
@@ -85,15 +85,15 @@ class ConfigReplaceTokensTest extends AbstractConfigTest
 
         $folding = $config->offsetGet('folding');
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             static::$server['PHINX_TEST_VAR_1'] . '', // force convert to string
             $folding['some-var-1']
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             static::$server['NON_PHINX_TEST_VAR_1'] . '', // force convert to string
             $folding['some-var-2']
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             static::$server['PHINX_TEST_VAR_2'] . '', // force convert to string
             $folding['some-var-3']
         );

--- a/tests/Phinx/Config/ConfigReplaceTokensTest.php
+++ b/tests/Phinx/Config/ConfigReplaceTokensTest.php
@@ -24,7 +24,7 @@ class ConfigReplaceTokensTest extends AbstractConfigTest
     /**
      * Pass vars to $_SERVER
      */
-    public function setUp()
+    public function setUp(): void
     {
         foreach (static::$server as $name => $value) {
             $_SERVER[$name] = $value;
@@ -34,7 +34,7 @@ class ConfigReplaceTokensTest extends AbstractConfigTest
     /**
      * Clean-up
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (static::$server as $name => $value) {
              unset($_SERVER[$name]);

--- a/tests/Phinx/Config/ConfigSeedPathsTest.php
+++ b/tests/Phinx/Config/ConfigSeedPathsTest.php
@@ -40,7 +40,7 @@ class ConfigSeedPathsTest extends AbstractConfigTest
         $config = new Config($values);
         $paths = $config->getSeedPaths();
 
-        $this->assertInternalType('array', $paths);
+        $this->assertIsArray($paths);
         $this->assertCount(1, $paths);
     }
 }

--- a/tests/Phinx/Config/ConfigSeedPathsTest.php
+++ b/tests/Phinx/Config/ConfigSeedPathsTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Config;
 
 use Phinx\Config\Config;
+use UnexpectedValueException;
 
 /**
  * Class ConfigSeedPathsTest
@@ -12,11 +13,9 @@ use Phinx\Config\Config;
  */
 class ConfigSeedPathsTest extends AbstractConfigTest
 {
-    /**
-     * @expectedException \UnexpectedValueException
-     */
     public function testGetSeedPathsThrowsExceptionForNoPath()
     {
+        $this->expectException(UnexpectedValueException::class);
         $config = new Config([]);
         $config->getSeedPaths();
     }

--- a/tests/Phinx/Config/ConfigSeedPathsTest.php
+++ b/tests/Phinx/Config/ConfigSeedPathsTest.php
@@ -15,8 +15,10 @@ class ConfigSeedPathsTest extends AbstractConfigTest
 {
     public function testGetSeedPathsThrowsExceptionForNoPath()
     {
-        $this->expectException(UnexpectedValueException::class);
         $config = new Config([]);
+
+        $this->expectException(UnexpectedValueException::class);
+
         $config->getSeedPaths();
     }
 

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -22,7 +22,6 @@ class ConfigTest extends AbstractConfigTest
         $config = new Config([]);
         // this option is set to its default value when not being passed in the constructor, so we can ignore it
         unset($config['version_order']);
-        ;
         $this->assertAttributeEmpty('values', $config);
         $this->assertAttributeEmpty('configFilePath', $config);
         $this->assertNull($config->getConfigFilePath());

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -212,10 +212,12 @@ class ConfigTest extends AbstractConfigTest
      */
     public function testGetSeedPathThrowsException()
     {
+        $config = new \Phinx\Config\Config([]);
+
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Seeds path missing from config file');
 
-        $config = new \Phinx\Config\Config([]);
+        $config->getSeedPaths();
     }
 
     /**

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -2,7 +2,9 @@
 
 namespace Test\Phinx\Config;
 
+use InvalidArgumentException;
 use Phinx\Config\Config;
+use UnexpectedValueException;
 
 /**
  * Class ConfigTest
@@ -114,11 +116,11 @@ class ConfigTest extends AbstractConfigTest
 
     /**
      * @covers \Phinx\Config\Config::offsetGet
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Identifier "foo" is not defined.
      */
     public function testUndefinedArrayAccess()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Identifier "foo" is not defined.');
         $config = new Config([]);
         $config['foo'];
     }
@@ -205,11 +207,11 @@ class ConfigTest extends AbstractConfigTest
 
     /**
      * @covers \Phinx\Config\Config::getSeedPaths
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Seeds path missing from config file
      */
     public function testGetSeedPathThrowsException()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Seeds path missing from config file');
         $config = new \Phinx\Config\Config([]);
         $this->assertEquals('db/seeds', $config->getSeedPaths());
     }

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -21,7 +21,7 @@ class ConfigTest extends AbstractConfigTest
     {
         $config = new Config([]);
         // this option is set to its default value when not being passed in the constructor, so we can ignore it
-        unset($config['version_order']);
+        unset($config['version_order']);;
         $this->assertAttributeEmpty('values', $config);
         $this->assertAttributeEmpty('configFilePath', $config);
         $this->assertNull($config->getConfigFilePath());

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -21,7 +21,8 @@ class ConfigTest extends AbstractConfigTest
     {
         $config = new Config([]);
         // this option is set to its default value when not being passed in the constructor, so we can ignore it
-        unset($config['version_order']);;
+        unset($config['version_order']);
+        ;
         $this->assertAttributeEmpty('values', $config);
         $this->assertAttributeEmpty('configFilePath', $config);
         $this->assertNull($config->getConfigFilePath());

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -119,9 +119,11 @@ class ConfigTest extends AbstractConfigTest
      */
     public function testUndefinedArrayAccess()
     {
+        $config = new Config([]);
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Identifier "foo" is not defined.');
-        $config = new Config([]);
+
         $config['foo'];
     }
 
@@ -212,8 +214,8 @@ class ConfigTest extends AbstractConfigTest
     {
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Seeds path missing from config file');
+
         $config = new \Phinx\Config\Config([]);
-        $this->assertEquals('db/seeds', $config->getSeedPaths());
     }
 
     /**

--- a/tests/Phinx/Config/ConfigYamlTest.php
+++ b/tests/Phinx/Config/ConfigYamlTest.php
@@ -19,10 +19,12 @@ class ConfigYamlTest extends TestCase
      */
     public function testGetDefaultEnvironmentWithAnEmptyYamlFile()
     {
-        $this->expectException(RuntimeException::class);
         // test using a Yaml file with no key or entries
         $path = __DIR__ . '/_files';
         $config = Config::fromYaml($path . '/empty.yml');
+
+        $this->expectException(RuntimeException::class);
+
         $config->getDefaultEnvironment();
     }
 
@@ -32,12 +34,14 @@ class ConfigYamlTest extends TestCase
      */
     public function testGetDefaultEnvironmentWithAMissingEnvironmentEntry()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("The environment configuration for 'staging' is missing");
         // test using a Yaml file with a 'default_database' key, but without a
         // corresponding entry
         $path = __DIR__ . '/_files';
         $config = Config::fromYaml($path . '/missing_environment_entry.yml');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("The environment configuration for 'staging' is missing");
+
         $config->getDefaultEnvironment();
     }
 

--- a/tests/Phinx/Config/ConfigYamlTest.php
+++ b/tests/Phinx/Config/ConfigYamlTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Config;
 
 use Phinx\Config\Config;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * Class ConfigYamlTest
@@ -15,10 +16,10 @@ class ConfigYamlTest extends TestCase
     /**
      * @covers \Phinx\Config\Config::fromYaml
      * @covers \Phinx\Config\Config::getDefaultEnvironment
-     * @expectedException \RuntimeException
      */
     public function testGetDefaultEnvironmentWithAnEmptyYamlFile()
     {
+        $this->expectException(RuntimeException::class);
         // test using a Yaml file with no key or entries
         $path = __DIR__ . '/_files';
         $config = Config::fromYaml($path . '/empty.yml');
@@ -28,11 +29,11 @@ class ConfigYamlTest extends TestCase
     /**
      * @covers \Phinx\Config\Config::fromYaml
      * @covers \Phinx\Config\Config::getDefaultEnvironment
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The environment configuration for 'staging' is missing
      */
     public function testGetDefaultEnvironmentWithAMissingEnvironmentEntry()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("The environment configuration for 'staging' is missing");
         // test using a Yaml file with a 'default_database' key, but without a
         // corresponding entry
         $path = __DIR__ . '/_files';

--- a/tests/Phinx/Config/ConfigYamlTest.php
+++ b/tests/Phinx/Config/ConfigYamlTest.php
@@ -21,11 +21,11 @@ class ConfigYamlTest extends TestCase
     {
         // test using a Yaml file with no key or entries
         $path = __DIR__ . '/_files';
-        $config = Config::fromYaml($path . '/empty.yml');
 
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches("/File '.*\/empty.yml' must be valid YAML/");
 
-        $config->getDefaultEnvironment();
+        Config::fromYaml($path . '/empty.yml');
     }
 
     /**

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -39,7 +39,7 @@ class BreakpointTest extends TestCase
      */
     const DEFAULT_TEST_ENVIRONMENT = 'development';
 
-    protected function setUp()
+    public function setUp(): void
     {
         @mkdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations', 0777, true);
         $this->config = new Config(

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -158,12 +158,10 @@ class BreakpointTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Cannot toggle a breakpoint and remove all breakpoints at the same time.
-     */
     public function testRemoveAllAndTargetThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot toggle a breakpoint and remove all breakpoints at the same time.');
         $application = new PhinxApplication('testing');
         $application->add(new Breakpoint());
 
@@ -189,19 +187,17 @@ class BreakpointTest extends TestCase
             ],
             ['decorated' => false]
         );
-
-        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     /**
      * @param array $commandLine
      *
      * @dataProvider provideCombinedParametersToCauseException
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Cannot use more than one of --set, --unset, or --remove-all at the same time.
      */
     public function testRemoveAllSetUnsetCombinedThrowsException($commandLine)
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use more than one of --set, --unset, or --remove-all at the same time.');
         $application = new PhinxApplication('testing');
         $application->add(new Breakpoint());
 

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -160,8 +160,6 @@ class BreakpointTest extends TestCase
 
     public function testRemoveAllAndTargetThrowsException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot toggle a breakpoint and remove all breakpoints at the same time.');
         $application = new PhinxApplication('testing');
         $application->add(new Breakpoint());
 
@@ -179,7 +177,10 @@ class BreakpointTest extends TestCase
 
         $commandTester = new CommandTester($command);
 
-        $exitCode = $commandTester->execute(
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot toggle a breakpoint and remove all breakpoints at the same time.');
+
+        $commandTester->execute(
             [
                 'command' => $command->getName(),
                 '--remove-all' => true,
@@ -196,8 +197,6 @@ class BreakpointTest extends TestCase
      */
     public function testRemoveAllSetUnsetCombinedThrowsException($commandLine)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use more than one of --set, --unset, or --remove-all at the same time.');
         $application = new PhinxApplication('testing');
         $application->add(new Breakpoint());
 
@@ -216,8 +215,11 @@ class BreakpointTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $commandLine = array_merge(['command' => $command->getName()], $commandLine);
-        $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
-        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use more than one of --set, --unset, or --remove-all at the same time.');
+
+        $commandTester->execute($commandLine, ['decorated' => false]);
     }
 
     public function provideCombinedParametersToCauseException()

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -36,7 +36,7 @@ class CreateTest extends TestCase
      */
     protected $output;
 
-    protected function setUp()
+    public function setUp(): void
     {
         @mkdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations', 0777, true);
         $this->config = new Config(

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -73,8 +73,6 @@ class CreateTest extends TestCase
 
     public function testExecuteWithDuplicateMigrationNames()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The migration class name "MyDuplicateMigration" already exists');
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
@@ -92,13 +90,15 @@ class CreateTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
         sleep(1.01); // need at least a second due to file naming scheme
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The migration class name "MyDuplicateMigration" already exists');
+
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
     }
 
     public function testExecuteWithDuplicateMigrationNamesWithNamespace()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The migration class name "Foo\Bar\MyDuplicateMigration" already exists');
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
@@ -122,13 +122,15 @@ class CreateTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
         sleep(1.01); // need at least a second due to file naming scheme
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The migration class name "Foo\Bar\MyDuplicateMigration" already exists');
+
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
     }
 
     public function testSupplyingBothClassAndTemplateAtCommandLineThrowsException()
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Cannot use --template and --class at the same time');
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
@@ -144,13 +146,15 @@ class CreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Cannot use --template and --class at the same time');
+
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyFailingMigration', '--template' => 'MyTemplate', '--class' => 'MyTemplateClass']);
     }
 
     public function testSupplyingBothClassAndTemplateInConfigThrowsException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot define template:class and template:file at the same time');
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
@@ -171,6 +175,10 @@ class CreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot define template:class and template:file at the same time');
+
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyFailingMigration']);
     }
 
@@ -233,8 +241,11 @@ class CreateTest extends TestCase
 
         $commandTester = new CommandTester($command);
 
-        $this->setExpectedException('\InvalidArgumentException', $exceptionMessage);
         $commandLine = array_merge(['command' => $command->getName(), 'name' => 'MyFailingMigration'], $commandLine);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($exceptionMessage);
+
         $commandTester->execute($commandLine);
     }
 
@@ -373,22 +384,5 @@ class CreateTest extends TestCase
         // Does the migration match our expectation?
         $expectedMigration = "useClassName Phinx\\Migration\\AbstractMigration / className {$commandLine['name']} / version {$match['Version']} / baseClassName AbstractMigration";
         $this->assertStringEqualsFile($match['MigrationFilename'], $expectedMigration, 'Failed to create migration file from template generator correctly.');
-    }
-
-    public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = null)
-    {
-        if (method_exists($this, 'expectException')) {
-            //PHPUnit 5+
-            $this->expectException($exceptionName);
-            if ($exceptionMessage !== '') {
-                $this->expectExceptionMessage($exceptionMessage);
-            }
-            if ($exceptionCode !== null) {
-                $this->expectExceptionCode($exceptionCode);
-            }
-        } else {
-            //PHPUnit 4
-            parent::setExpectedException($exceptionName, $exceptionMessage, $exceptionCode);
-        }
     }
 }

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -2,6 +2,8 @@
 
 namespace Test\Phinx\Console\Command;
 
+use Exception;
+use InvalidArgumentException;
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\Create;
@@ -69,12 +71,10 @@ class CreateTest extends TestCase
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The migration class name "MyDuplicateMigration" already exists
-     */
     public function testExecuteWithDuplicateMigrationNames()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The migration class name "MyDuplicateMigration" already exists');
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
@@ -95,12 +95,10 @@ class CreateTest extends TestCase
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The migration class name "Foo\Bar\MyDuplicateMigration" already exists
-     */
     public function testExecuteWithDuplicateMigrationNamesWithNamespace()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The migration class name "Foo\Bar\MyDuplicateMigration" already exists');
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
@@ -127,12 +125,10 @@ class CreateTest extends TestCase
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Cannot use --template and --class at the same time
-     */
     public function testSupplyingBothClassAndTemplateAtCommandLineThrowsException()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Cannot use --template and --class at the same time');
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
@@ -151,12 +147,10 @@ class CreateTest extends TestCase
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyFailingMigration', '--template' => 'MyTemplate', '--class' => 'MyTemplateClass']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot define template:class and template:file at the same time
-     */
     public function testSupplyingBothClassAndTemplateInConfigThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot define template:class and template:file at the same time');
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -39,7 +39,7 @@ class InitTest extends TestCase
 
         $commandTester->execute($command, ['decorated' => false]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             "created $fullPath",
             $commandTester->getDisplay()
         );
@@ -109,7 +109,7 @@ class InitTest extends TestCase
     public function testThrowsExceptionWhenConfigFilePresent()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Config file ".*" already exists./');
+        $this->expectExceptionMessageMatches('/Config file ".*" already exists./');
         touch(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.yml');
         $application = new PhinxApplication('testing');
         $application->add(new Init());
@@ -128,7 +128,7 @@ class InitTest extends TestCase
     public function testThrowsExceptionWhenInvalidDir()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Invalid path ".*" for config file./');
+        $this->expectExceptionMessageMatches('/Invalid path ".*" for config file./');
         $application = new PhinxApplication('testing');
         $application->add(new Init());
 

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Console\Command;
 
+use InvalidArgumentException;
 use Phinx\Console\Command\Init;
 use Phinx\Console\PhinxApplication;
 use PHPUnit\Framework\TestCase;
@@ -105,12 +106,10 @@ class InitTest extends TestCase
         chdir($current_dir);
     }
 
-    /**
-     * @expectedException              \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Config file ".*" already exists./
-     */
     public function testThrowsExceptionWhenConfigFilePresent()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/Config file ".*" already exists./');
         touch(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.yml');
         $application = new PhinxApplication('testing');
         $application->add(new Init());
@@ -126,12 +125,10 @@ class InitTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException              \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Invalid path ".*" for config file./
-     */
     public function testThrowsExceptionWhenInvalidDir()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/Invalid path ".*" for config file./');
         $application = new PhinxApplication('testing');
         $application->add(new Init());
 
@@ -146,12 +143,10 @@ class InitTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException              \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Invalid format "invalid". Format must be either yml, json, or php./
-     */
     public function testThrowsExceptionWhenInvalidFormat()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid format "invalid". Format must be either yml, json, or php.');
         $application = new PhinxApplication('testing');
         $application->add(new Init());
 

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -108,8 +108,6 @@ class InitTest extends TestCase
 
     public function testThrowsExceptionWhenConfigFilePresent()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Config file ".*" already exists./');
         touch(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.yml');
         $application = new PhinxApplication('testing');
         $application->add(new Init());
@@ -117,6 +115,10 @@ class InitTest extends TestCase
         $command = $application->find('init');
 
         $commandTester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Config file ".*" already exists./');
+
         $commandTester->execute([
             'command' => $command->getName(),
             'path' => sys_get_temp_dir(),
@@ -127,14 +129,16 @@ class InitTest extends TestCase
 
     public function testThrowsExceptionWhenInvalidDir()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Invalid path ".*" for config file./');
         $application = new PhinxApplication('testing');
         $application->add(new Init());
 
         $command = $application->find('init');
 
         $commandTester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Invalid path ".*" for config file./');
+
         $commandTester->execute([
             'command' => $command->getName(),
             'path' => '/this/dir/does/not/exists',
@@ -145,14 +149,16 @@ class InitTest extends TestCase
 
     public function testThrowsExceptionWhenInvalidFormat()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid format "invalid". Format must be either yml, json, or php.');
         $application = new PhinxApplication('testing');
         $application->add(new Init());
 
         $command = $application->find('init');
 
         $commandTester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid format "invalid". Format must be either yml, json, or php.');
+
         $commandTester->execute([
             'command' => $command->getName(),
             'path' => sys_get_temp_dir() . DIRECTORY_SEPARATOR,

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class InitTest extends TestCase
 {
-    protected function setUp()
+    public function setUp(): void
     {
         foreach (['.yml', '.json', '.php'] as $format) {
             $file = sys_get_temp_dir() . '/phinx' . $format;

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -41,13 +41,13 @@ class ListAliasesTest extends TestCase
         $display = $commandTester->getDisplay(false);
 
         if ($hasAliases) {
-            $this->assertNotContains('No aliases defined in ', $display);
-            $this->assertContains('Alias            Class                                             ', $display);
-            $this->assertContains('================ ==================================================', $display);
-            $this->assertContains('MakePermission   Vendor\Package\Migration\Creation\MakePermission  ', $display);
-            $this->assertContains('RemovePermission Vendor\Package\Migration\Creation\RemovePermission', $display);
+            $this->assertStringNotContainsString('No aliases defined in ', $display);
+            $this->assertStringContainsString('Alias            Class                                             ', $display);
+            $this->assertStringContainsString('================ ==================================================', $display);
+            $this->assertStringContainsString('MakePermission   Vendor\Package\Migration\Creation\MakePermission  ', $display);
+            $this->assertStringContainsString('RemovePermission Vendor\Package\Migration\Creation\RemovePermission', $display);
         } else {
-            $this->assertContains('No aliases defined in ', $display);
+            $this->assertStringContainsString('No aliases defined in ', $display);
         }
     }
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -33,7 +33,7 @@ class MigrateTest extends TestCase
      */
     protected $output;
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -38,7 +38,7 @@ class RollbackTest extends TestCase
      */
     const DEFAULT_TEST_ENVIRONMENT = 'development';
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -265,9 +265,11 @@ class RollbackTest extends TestCase
      */
     public function testGetTargetFromDateThrowsException($invalidDate)
     {
+        $rollbackCommand = new Rollback();
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
-        $rollbackCommand = new Rollback();
+
         $rollbackCommand->getTargetFromDate($invalidDate);
     }
 

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Console\Command;
 
+use InvalidArgumentException;
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\AbstractCommand;
@@ -261,11 +262,11 @@ class RollbackTest extends TestCase
 
     /**
      * @dataProvider getTargetFromDateThrowsExceptionDataProvider
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].
      */
     public function testGetTargetFromDateThrowsException($invalidDate)
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
         $rollbackCommand = new Rollback();
         $rollbackCommand->getTargetFromDate($invalidDate);
     }

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -60,8 +60,6 @@ class SeedCreateTest extends TestCase
 
     public function testExecute()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The file "MyDuplicateSeeder.php" already exists');
         $application = new PhinxApplication('testing');
         $application->add(new SeedCreate());
 
@@ -79,14 +77,15 @@ class SeedCreateTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateSeeder'], ['decorated' => false]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The file "MyDuplicateSeeder.php" already exists');
+
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateSeeder'], ['decorated' => false]);
     }
 
     public function testExecuteWithInvalidClassName()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class name "badseedname" is invalid. Please use CamelCase format');
-
         $application = new PhinxApplication('testing');
         $application->add(new SeedCreate());
 
@@ -103,6 +102,10 @@ class SeedCreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seed class name "badseedname" is invalid. Please use CamelCase format');
+
         $commandTester->execute(['command' => $command->getName(), 'name' => 'badseedname'], ['decorated' => false]);
     }
 }

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -32,7 +32,7 @@ class SeedCreateTest extends TestCase
      */
     protected $output;
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Console\Command;
 
+use InvalidArgumentException;
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\SeedCreate;
@@ -57,12 +58,10 @@ class SeedCreateTest extends TestCase
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The file "MyDuplicateSeeder.php" already exists
-     */
     public function testExecute()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The file "MyDuplicateSeeder.php" already exists');
         $application = new PhinxApplication('testing');
         $application->add(new SeedCreate());
 
@@ -83,12 +82,11 @@ class SeedCreateTest extends TestCase
         $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateSeeder'], ['decorated' => false]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The seed class name "badseedname" is invalid. Please use CamelCase format
-     */
     public function testExecuteWithInvalidClassName()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seed class name "badseedname" is invalid. Please use CamelCase format');
+
         $application = new PhinxApplication('testing');
         $application->add(new SeedCreate());
 

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -33,7 +33,7 @@ class SeedRunTest extends TestCase
      */
     protected $output;
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -38,7 +38,7 @@ class StatusTest extends TestCase
      */
     const DEFAULT_TEST_ENVIRONMENT = 'development';
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -12,12 +12,12 @@ class AdapterFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = AdapterFactory::instance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->factory);
     }

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -43,9 +43,11 @@ class AdapterFactoryTest extends TestCase
 
     public function testRegisterAdapterFailure()
     {
+        $adapter = get_class($this);
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Adapter class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must implement Phinx\Db\Adapter\AdapterInterface');
-        $adapter = get_class($this);
+
         $this->factory->registerAdapter('test', $adapter);
     }
 
@@ -78,9 +80,11 @@ class AdapterFactoryTest extends TestCase
 
     public function testRegisterWrapperFailure()
     {
+        $wrapper = get_class($this);
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Wrapper class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must be implement Phinx\Db\Adapter\WrapperInterface');
-        $wrapper = get_class($this);
+
         $this->factory->registerWrapper('test', $wrapper);
     }
 

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\AdapterFactory;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class AdapterFactoryTest extends TestCase
 {
@@ -40,12 +41,10 @@ class AdapterFactoryTest extends TestCase
         $this->assertEquals($adapter, $method->invoke($this->factory, 'test'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Adapter class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must implement Phinx\Db\Adapter\AdapterInterface
-     */
     public function testRegisterAdapterFailure()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Adapter class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must implement Phinx\Db\Adapter\AdapterInterface');
         $adapter = get_class($this);
         $this->factory->registerAdapter('test', $adapter);
     }
@@ -57,12 +56,10 @@ class AdapterFactoryTest extends TestCase
         $this->assertInstanceOf('Phinx\Db\Adapter\MysqlAdapter', $adapter);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Adapter "bad" has not been registered
-     */
     public function testGetAdapterFailure()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Adapter "bad" has not been registered');
         $this->factory->getAdapter('bad', []);
     }
 
@@ -79,12 +76,10 @@ class AdapterFactoryTest extends TestCase
         $this->assertEquals($wrapper, $method->invoke($this->factory, 'test'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Wrapper class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must be implement Phinx\Db\Adapter\WrapperInterface
-     */
     public function testRegisterWrapperFailure()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Wrapper class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must be implement Phinx\Db\Adapter\WrapperInterface');
         $wrapper = get_class($this);
         $this->factory->registerWrapper('test', $wrapper);
     }
@@ -101,12 +96,10 @@ class AdapterFactoryTest extends TestCase
         $this->assertInstanceOf('Phinx\Db\Adapter\TablePrefixAdapter', $wrapper);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Wrapper "nope" has not been registered
-     */
     public function testGetWrapperFailure()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Wrapper "nope" has not been registered');
         $this->factory->getWrapper('nope', $this->getAdapterMock());
     }
 }

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -62,6 +62,7 @@ class AdapterFactoryTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Adapter "bad" has not been registered');
+
         $this->factory->getAdapter('bad', []);
     }
 
@@ -104,6 +105,7 @@ class AdapterFactoryTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Wrapper "nope" has not been registered');
+
         $this->factory->getWrapper('nope', $this->getAdapterMock());
     }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use PDOException;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Util\Literal;
@@ -940,11 +941,9 @@ class MysqlAdapterTest extends TestCase
         $this->assertEquals($limit, $sqlType['limit']);
     }
 
-    /**
-     * @expectedException \PDOException
-     */
     public function testTimestampInvalidLimit()
     {
+        $this->expectException(PDOException::class);
         $this->adapter->connect();
         if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
             $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -943,12 +943,14 @@ class MysqlAdapterTest extends TestCase
 
     public function testTimestampInvalidLimit()
     {
-        $this->expectException(PDOException::class);
         $this->adapter->connect();
         if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
             $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
         }
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
+
+        $this->expectException(PDOException::class);
+
         $table->addColumn('column1', 'timestamp', ['limit' => 7])->save();
     }
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1535,7 +1535,7 @@ class MysqlAdapterTest extends TestCase
 CREATE TABLE `table1` (`id` INT(11) NOT NULL AUTO_INCREMENT, `column1` VARCHAR(255) NOT NULL, `column2` INT(11) NOT NULL, `column3` VARCHAR(255) NOT NULL DEFAULT 'test', PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');
     }
 
     /**
@@ -1574,7 +1574,7 @@ INSERT INTO `table1` (`string_col`) VALUES (null);
 INSERT INTO `table1` (`int_col`) VALUES (23);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the insert to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the insert to the output');
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         self::assertTrue($countQuery->execute());
@@ -1615,7 +1615,7 @@ OUTPUT;
 INSERT INTO `table1` (`string_col`, `int_col`) VALUES ('test_data1', 23), (null, 42);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the bulkinsert to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the bulkinsert to the output');
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         self::assertTrue($countQuery->execute());
@@ -1648,7 +1648,7 @@ CREATE TABLE `table1` (`column1` VARCHAR(255) NOT NULL, `column2` INT(11) NOT NU
 INSERT INTO `table1` (`column1`, `column2`) VALUES ('id1', 1);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
     }
 
     public function testDumpTransaction()

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -19,7 +19,7 @@ class MysqlAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED) {
             $this->markTestSkipped('Mysql tests disabled. See TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED constant.');
@@ -42,7 +42,7 @@ class MysqlAdapterTest extends TestCase
         $this->adapter->disconnect();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->adapter);
     }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -36,12 +36,12 @@ class PdoAdapterTest extends TestCase
 {
     private $adapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', [['foo' => 'bar']]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->adapter);
     }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -143,12 +143,13 @@ class PdoAdapterTest extends TestCase
 
     public function testGetVersionLogInvalidVersionOrderKO()
     {
-        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid version_order configuration option');
         $adapter = $this->getMockForAbstractClass(
             '\Phinx\Db\Adapter\PdoAdapter',
             [['version_order' => 'invalid']]
         );
+
+        $this->expectException(RuntimeException::class);
 
         $adapter->getVersionLog();
     }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Db\Adapter;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class PdoAdapterTestPDOMock extends \PDO
 {
@@ -140,12 +141,10 @@ class PdoAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Invalid version_order configuration option
-     */
     public function testGetVersionLogInvalidVersionOrderKO()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid version_order configuration option');
         $adapter = $this->getMockForAbstractClass(
             '\Phinx\Db\Adapter\PdoAdapter',
             [['version_order' => 'invalid']]

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1179,6 +1179,7 @@ class PostgresAdapterTest extends TestCase
     {
         $this->expectException(UnsupportedColumnTypeException::class);
         $this->expectExceptionMessage('Column type "idontexist" is not supported by Postgresql.');
+
         $this->adapter->getSqlType('idontexist');
     }
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -36,7 +36,7 @@ class PostgresAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!TESTS_PHINX_DB_ADAPTER_POSTGRES_ENABLED) {
             $this->markTestSkipped('Postgres tests disabled.  See TESTS_PHINX_DB_ADAPTER_POSTGRES_ENABLED constant.');
@@ -68,7 +68,7 @@ class PostgresAdapterTest extends TestCase
         $this->adapter->disconnect();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->adapter) {
             $this->adapter->dropAllSchemas();

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1761,7 +1761,7 @@ class PostgresAdapterTest extends TestCase
         'NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
         '"table1_pkey" PRIMARY KEY ("id"));';
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains(
+        $this->assertStringContainsString(
             $expectedOutput,
             $actualOutput,
             'Passing the --dry-run option does not dump create table query'
@@ -1787,7 +1787,7 @@ class PostgresAdapterTest extends TestCase
         'NOT NULL, "column2" INTEGER NOT NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
         '"table1_pkey" PRIMARY KEY ("id"));';
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains(
+        $this->assertStringContainsString(
             $expectedOutput,
             $actualOutput,
             'Passing the --dry-run option does not dump create table query'
@@ -1830,7 +1830,7 @@ INSERT INTO "public"."table1" ("string_col") VALUES (null);
 INSERT INTO "public"."table1" ("int_col") VALUES (23);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains(
+        $this->assertStringContainsString(
             $expectedOutput,
             $actualOutput,
             'Passing the --dry-run option doesn\'t dump the insert to the output'
@@ -1875,7 +1875,7 @@ OUTPUT;
 INSERT INTO "public"."table1" ("string_col", "int_col") VALUES ('test_data1', 23), (null, 42);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains(
+        $this->assertStringContainsString(
             $expectedOutput,
             $actualOutput,
             'Passing the --dry-run option doesn\'t dump the bulkinsert to the output'
@@ -1914,7 +1914,7 @@ CREATE TABLE "schema1"."table1" ("column1" CHARACTER VARYING (255) NOT NULL, "co
 INSERT INTO "schema1"."table1" ("column1", "column2") VALUES ('id1', 1);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
     }
 
     public function testDumpTransaction()

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1175,12 +1175,10 @@ class PostgresAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasSchema('bar'));
     }
 
-    /**
-     * @expectedException \Phinx\Db\Adapter\UnsupportedColumnTypeException
-     * @expectedExceptionMessage Column type "idontexist" is not supported by Postgresql.
-     */
     public function testInvalidSqlType()
     {
+        $this->expectException(UnsupportedColumnTypeException::class);
+        $this->expectExceptionMessage('Column type "idontexist" is not supported by Postgresql.');
         $this->adapter->getSqlType('idontexist');
     }
 

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -128,9 +128,6 @@ class ProxyAdapterTest extends TestCase
 
     public function testGetInvertedCommandsThrowsExceptionForIrreversibleCommand()
     {
-        $this->expectException(IrreversibleMigrationException::class);
-        $this->expectExceptionMessage('Cannot reverse a "Phinx\Db\Action\RemoveColumn" command');
-
         $this->adapter
             ->getAdapter()
             ->expects($this->any())
@@ -140,6 +137,10 @@ class ProxyAdapterTest extends TestCase
         $table = new \Phinx\Db\Table('atable', [], $this->adapter);
         $table->removeColumn('thing')
               ->save();
+
+        $this->expectException(IrreversibleMigrationException::class);
+        $this->expectExceptionMessage('Cannot reverse a "Phinx\Db\Action\RemoveColumn" command');
+
         $this->adapter->getInvertedCommands();
     }
 }

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -12,7 +12,7 @@ class ProxyAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $stub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
             ->setConstructorArgs([[]])
@@ -26,7 +26,7 @@ class ProxyAdapterTest extends TestCase
         $this->adapter = new ProxyAdapter($stub);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->adapter);
     }

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\ProxyAdapter;
+use Phinx\Migration\IrreversibleMigrationException;
 use PHPUnit\Framework\TestCase;
 
 class ProxyAdapterTest extends TestCase
@@ -125,12 +126,11 @@ class ProxyAdapterTest extends TestCase
         $this->assertEquals(['ref_table_id'], $commands[0]->getForeignKey()->getColumns());
     }
 
-    /**
-     * @expectedException \Phinx\Migration\IrreversibleMigrationException
-     * @expectedExceptionMessage Cannot reverse a "Phinx\Db\Action\RemoveColumn" command
-     */
     public function testGetInvertedCommandsThrowsExceptionForIrreversibleCommand()
     {
+        $this->expectException(IrreversibleMigrationException::class);
+        $this->expectExceptionMessage('Cannot reverse a "Phinx\Db\Action\RemoveColumn" command');
+
         $this->adapter
             ->getAdapter()
             ->expects($this->any())

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -20,7 +20,7 @@ class SQLiteAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!TESTS_PHINX_DB_ADAPTER_SQLITE_ENABLED) {
             $this->markTestSkipped('SQLite tests disabled. See TESTS_PHINX_DB_ADAPTER_SQLITE_ENABLED constant.');
@@ -41,7 +41,7 @@ class SQLiteAdapterTest extends TestCase
         $this->adapter->disconnect();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->adapter);
     }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1307,6 +1307,7 @@ INPUT;
     public function testHasNamedPrimaryKey()
     {
         $this->expectException(\InvalidArgumentException::class);
+
         $this->adapter->hasPrimaryKey('t', [], 'named_constraint');
     }
 
@@ -1356,6 +1357,7 @@ INPUT;
     public function testHasNamedForeignKey()
     {
         $this->expectException(\InvalidArgumentException::class);
+
         $this->adapter->hasForeignKey('t', [], 'named_constraint');
     }
 
@@ -1367,6 +1369,7 @@ INPUT;
     {
         if ($exp instanceof \Exception) {
             $this->expectException(get_class($exp));
+
             $this->adapter->getSqlType($phinxType, $limit);
         } else {
             $exp = ['name' => $exp, 'limit' => $limit];

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -697,7 +697,7 @@ class SQLiteAdapterTest extends TestCase
     public function testFailingDropForeignKey()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/test/');
+        $this->expectExceptionMessageMatches('/test/');
 
         $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
         $refTable->save();
@@ -942,7 +942,7 @@ class SQLiteAdapterTest extends TestCase
 CREATE TABLE `table1` (`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `column1` VARCHAR NULL, `column2` INTEGER NULL, `column3` VARCHAR NOT NULL DEFAULT 'test');
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');
     }
 
     /**
@@ -982,7 +982,7 @@ INSERT INTO `table1` (`int_col`) VALUES (23);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
         $actualOutput = preg_replace("/\r\n|\r/", "\n", $actualOutput); // normalize line endings for Windows
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the insert to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the insert to the output');
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         self::assertTrue($countQuery->execute());
@@ -1023,7 +1023,7 @@ OUTPUT;
 INSERT INTO `table1` (`string_col`, `int_col`) VALUES ('test_data1', 23), (null, 42);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the bulkinsert to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the bulkinsert to the output');
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         self::assertTrue($countQuery->execute());
@@ -1058,7 +1058,7 @@ CREATE TABLE `table1` (`column1` VARCHAR NULL, `column2` INTEGER NULL, PRIMARY K
 INSERT INTO `table1` (`column1`, `column2`) VALUES ('id1', 1);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2,6 +2,8 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use BadMethodCallException;
+use InvalidArgumentException;
 use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Db\Table\Column;
 use Phinx\Util\Literal;
@@ -315,11 +317,9 @@ class SQLiteAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAddMultipleColumnPrimaryKeyFails()
     {
+        $this->expectException(InvalidArgumentException::class);
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table
             ->addColumn('column1', 'integer')
@@ -331,11 +331,9 @@ class SQLiteAdapterTest extends TestCase
             ->save();
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testChangeCommentFails()
     {
+        $this->expectException(BadMethodCallException::class);
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->save();
 
@@ -696,12 +694,11 @@ class SQLiteAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasTable($table->getName()));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /test/
-     */
     public function testFailingDropForeignKey()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/test/');
+
         $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
         $refTable->save();
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -319,12 +319,13 @@ class SQLiteAdapterTest extends TestCase
 
     public function testAddMultipleColumnPrimaryKeyFails()
     {
-        $this->expectException(InvalidArgumentException::class);
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table
             ->addColumn('column1', 'integer')
             ->addColumn('column2', 'integer')
             ->save();
+
+        $this->expectException(InvalidArgumentException::class);
 
         $table
             ->changePrimaryKey(['column1', 'column2'])
@@ -333,9 +334,10 @@ class SQLiteAdapterTest extends TestCase
 
     public function testChangeCommentFails()
     {
-        $this->expectException(BadMethodCallException::class);
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->save();
+
+        $this->expectException(BadMethodCallException::class);
 
         $table
             ->changeComment('comment1')
@@ -696,9 +698,6 @@ class SQLiteAdapterTest extends TestCase
 
     public function testFailingDropForeignKey()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/test/');
-
         $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
         $refTable->save();
 
@@ -707,6 +706,9 @@ class SQLiteAdapterTest extends TestCase
             ->addColumn('ref_table_id', 'integer')
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/test/');
 
         $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'test']);
     }
@@ -1357,7 +1359,8 @@ INPUT;
         $this->adapter->hasForeignKey('t', [], 'named_constraint');
     }
 
-    /** @dataProvider providePhinxTypes
+    /**
+     * @dataProvider providePhinxTypes
      * @covers \Phinx\Db\Adapter\SQLiteAdapter::getSqlType
      */
     public function testGetSqlType($phinxType, $limit, $exp)

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -690,6 +690,7 @@ WHERE t.name='ntable'");
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Column type "idontexist" is not supported by SqlServer.');
+
         $this->adapter->getSqlType('idontexist');
     }
 

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -904,7 +904,7 @@ CREATE TABLE [table1] ([column1] NVARCHAR (255)   NOT NULL , [column2] INT   NOT
 INSERT INTO [table1] ([column1], [column2]) VALUES ('id1', 1);
 OUTPUT;
         $actualOutput = str_replace("\r\n", "\n", $consoleOutput->fetch());
-        $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
     }
 
     public function testDumpTransaction()

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -18,7 +18,7 @@ class SqlServerAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!TESTS_PHINX_DB_ADAPTER_SQLSRV_ENABLED) {
             $this->markTestSkipped('SqlServer tests disabled. See TESTS_PHINX_DB_ADAPTER_SQLSRV_ENABLED constant.');
@@ -41,7 +41,7 @@ class SqlServerAdapterTest extends TestCase
         $this->adapter->disconnect();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (!empty($this->adapter)) {
             $this->adapter->disconnect();

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -2,9 +2,11 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use BadMethodCallException;
 use Phinx\Db\Adapter\SqlServerAdapter;
 use Phinx\Util\Literal;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -276,11 +278,9 @@ WHERE t.name='ntable'");
         $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testChangeCommentFails()
     {
+        $this->expectException(BadMethodCallException::class);
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->save();
 
@@ -685,12 +685,10 @@ WHERE t.name='ntable'");
         $this->adapter->dropDatabase('phinx_temp_database');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Column type "idontexist" is not supported by SqlServer.
-     */
     public function testInvalidSqlType()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Column type "idontexist" is not supported by SqlServer.');
         $this->adapter->getSqlType('idontexist');
     }
 

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -280,9 +280,10 @@ WHERE t.name='ntable'");
 
     public function testChangeCommentFails()
     {
-        $this->expectException(BadMethodCallException::class);
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->save();
+
+        $this->expectException(BadMethodCallException::class);
 
         $table
             ->changeComment('comment1')

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -32,7 +32,7 @@ class TablePrefixAdapterTest extends TestCase
      */
     private $mock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $options = [
             'table_prefix' => 'pre_',
@@ -57,7 +57,7 @@ class TablePrefixAdapterTest extends TestCase
         $this->adapter = new TablePrefixAdapter($this->mock);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->adapter);
         unset($this->mock);

--- a/tests/Phinx/Db/Table/ColumnTest.php
+++ b/tests/Phinx/Db/Table/ColumnTest.php
@@ -10,9 +10,11 @@ class ColumnTest extends TestCase
 {
     public function testSetOptionThrowsExceptionIfOptionIsNotString()
     {
+        $column = new Column();
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('"0" is not a valid column option.');
-        $column = new Column();
+
         $column->setOptions(['identity']);
     }
 }

--- a/tests/Phinx/Db/Table/ColumnTest.php
+++ b/tests/Phinx/Db/Table/ColumnTest.php
@@ -4,15 +4,14 @@ namespace Test\Phinx\Db\Table;
 
 use Phinx\Db\Table\Column;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class ColumnTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage "0" is not a valid column option.
-     */
     public function testSetOptionThrowsExceptionIfOptionIsNotString()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"0" is not a valid column option.');
         $column = new Column();
         $column->setOptions(['identity']);
     }

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -13,7 +13,7 @@ class ForeignKeyTest extends TestCase
      */
     private $fk = null;
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->fk = new ForeignKey();
     }

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -64,12 +64,14 @@ class ForeignKeyTest extends TestCase
     public function testUnknownActionsNotAllowedThroughSetter()
     {
         $this->expectException(InvalidArgumentException::class);
+
         $this->fk->setOnDelete('i m dump');
     }
 
     public function testUnknownActionsNotAllowedThroughOptions()
     {
         $this->expectException(InvalidArgumentException::class);
+
         $this->fk->setOptions(['update' => 'no yu a dumb']);
     }
 
@@ -91,6 +93,7 @@ class ForeignKeyTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('"0" is not a valid foreign key option');
+
         $this->fk->setOptions(['update']);
     }
 }

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -2,8 +2,10 @@
 
 namespace Test\Phinx\Db\Table;
 
+use InvalidArgumentException;
 use Phinx\Db\Table\ForeignKey;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class ForeignKeyTest extends TestCase
 {
@@ -59,19 +61,15 @@ class ForeignKeyTest extends TestCase
         $this->assertEquals($valueOfConstant, $this->fk->getOnUpdate());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUnknownActionsNotAllowedThroughSetter()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->fk->setOnDelete('i m dump');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUnknownActionsNotAllowedThroughOptions()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->fk->setOptions(['update' => 'no yu a dumb']);
     }
 
@@ -89,12 +87,10 @@ class ForeignKeyTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage "0" is not a valid foreign key option.
-     */
     public function testSetOptionThrowsExceptionIfOptionIsNotString()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"0" is not a valid foreign key option');
         $this->fk->setOptions(['update']);
     }
 }

--- a/tests/Phinx/Db/Table/IndexTest.php
+++ b/tests/Phinx/Db/Table/IndexTest.php
@@ -10,9 +10,11 @@ class IndexTest extends TestCase
 {
     public function testSetOptionThrowsExceptionIfOptionIsNotString()
     {
+        $column = new Index();
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('"0" is not a valid index option.');
-        $column = new Index();
+
         $column->setOptions(['type']);
     }
 }

--- a/tests/Phinx/Db/Table/IndexTest.php
+++ b/tests/Phinx/Db/Table/IndexTest.php
@@ -4,15 +4,14 @@ namespace Test\Phinx\Db\Table;
 
 use Phinx\Db\Table\Index;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class IndexTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage "0" is not a valid index option.
-     */
     public function testSetOptionThrowsExceptionIfOptionIsNotString()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"0" is not a valid index option.');
         $column = new Index();
         $column->setOptions(['type']);
     }

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -289,6 +289,7 @@ class AbstractMigrationTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Migration has pending actions after execution!');
+
         $migrationStub->postFlightCheck();
     }
 

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -194,13 +194,11 @@ class AbstractMigrationTest extends TestCase
 
     public function testInsertDeprecated()
     {
-        if (PHP_VERSION_ID < 70000) {
-            $this->expectException(\PHPUnit_Framework_Error_Deprecated::class);
-        } else {
-            $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
-        }
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+
+        $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
+
         $migrationStub->insert('testdb', ['row' => 'value']);
     }
 
@@ -319,13 +317,11 @@ class AbstractMigrationTest extends TestCase
 
     public function testDropTableDeprecated()
     {
-        if (PHP_VERSION_ID < 70000) {
-            $this->expectException(\PHPUnit_Framework_Error_Deprecated::class);
-        } else {
-            $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
-        }
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+
+        $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
+
         $migrationStub->dropTable('test_table');
     }
 }

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -79,7 +79,7 @@ class AbstractMigrationTest extends TestCase
     public function testGetName()
     {
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
-        $this->assertContains('AbstractMigration', $migrationStub->getName());
+        $this->assertStringContainsString('AbstractMigration', $migrationStub->getName());
     }
 
     public function testVersionMethods()

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -218,6 +218,7 @@ class EnvironmentTest extends TestCase
     public function testNoAdapter()
     {
         $this->expectException(RuntimeException::class);
+
         $this->environment->getAdapter();
     }
 

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -207,9 +207,11 @@ class EnvironmentTest extends TestCase
 
     public function testInvalidAdapter()
     {
+        $this->environment->setOptions(['adapter' => 'fakeadapter']);
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Adapter "fakeadapter" has not been registered');
-        $this->environment->setOptions(['adapter' => 'fakeadapter']);
+
         $this->environment->getAdapter();
     }
 
@@ -240,9 +242,11 @@ class EnvironmentTest extends TestCase
 
     public function testGetAdapterWithBadExistingPdoInstance()
     {
+        $this->environment->setOptions(['connection' => new \stdClass()]);
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The specified connection is not a PDO instance');
-        $this->environment->setOptions(['connection' => new \stdClass()]);
+
         $this->environment->getAdapter();
     }
 

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -6,6 +6,7 @@ use Phinx\Db\Adapter\AdapterFactory;
 use Phinx\Migration\Manager\Environment;
 use Phinx\Migration\MigrationInterface;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class PDOMock extends \PDO
 {
@@ -204,21 +205,17 @@ class EnvironmentTest extends TestCase
         $this->assertArrayHasKey('dsn', $env->getOptions());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Adapter "fakeadapter" has not been registered
-     */
     public function testInvalidAdapter()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Adapter "fakeadapter" has not been registered');
         $this->environment->setOptions(['adapter' => 'fakeadapter']);
         $this->environment->getAdapter();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testNoAdapter()
     {
+        $this->expectException(RuntimeException::class);
         $this->environment->getAdapter();
     }
 
@@ -241,12 +238,10 @@ class EnvironmentTest extends TestCase
         $this->assertEquals(\PDO::ERRMODE_EXCEPTION, $options['connection']->getAttribute(\PDO::ATTR_ERRMODE));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The specified connection is not a PDO instance
-     */
     public function testGetAdapterWithBadExistingPdoInstance()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The specified connection is not a PDO instance');
         $this->environment->setOptions(['connection' => new \stdClass()]);
         $this->environment->getAdapter();
     }

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -33,7 +33,7 @@ class EnvironmentTest extends TestCase
      */
     private $environment;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->environment = new Environment('test', []);
     }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5409,9 +5409,6 @@ class ManagerTest extends TestCase
         $this->expectExceptionMessage('The seed class "NonExistentSeeder" does not exist');
 
         $this->manager->seed('mockenv', 'NonExistentSeeder');
-        rewind($this->manager->getOutput()->getStream());
-        $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertStringContainsString('UserSeeder', $output);
     }
 
     public function testExecuteANonExistentSeedWorksAsExpectedWithNamespace()
@@ -5427,9 +5424,6 @@ class ManagerTest extends TestCase
         $this->expectExceptionMessage('The seed class "Foo\Bar\NonExistentSeeder" does not exist');
 
         $this->manager->seed('mockenv', 'Foo\Bar\NonExistentSeeder');
-        rewind($this->manager->getOutput()->getStream());
-        $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertStringContainsString('Foo\Bar\UserSeeder', $output);
     }
 
     public function testExecuteANonExistentSeedWorksAsExpectedWithMixedNamespace()
@@ -5445,11 +5439,6 @@ class ManagerTest extends TestCase
         $this->expectExceptionMessage('The seed class "Baz\NonExistentSeeder" does not exist');
 
         $this->manager->seed('mockenv', 'Baz\NonExistentSeeder');
-        rewind($this->manager->getOutput()->getStream());
-        $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertStringContainsString('UserSeeder', $output);
-        $this->assertStringContainsString('Baz\UserSeeder', $output);
-        $this->assertStringContainsString('Foo\Bar\UserSeeder', $output);
     }
 
     public function testOrderSeeds()

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -1053,7 +1053,7 @@ class ManagerTest extends TestCase
         $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => true], $return);
 
         $outputStr = $this->manager->getOutput()->fetch();
-        $this->assertContains($expectedStatusHeader, $outputStr);
+        $this->assertStringContainsString($expectedStatusHeader, $outputStr);
     }
 
     public function statusVersionOrderProvider()
@@ -1248,7 +1248,7 @@ class ManagerTest extends TestCase
         if (is_null($expectedMigration)) {
             $this->assertEmpty($output, $message);
         } else {
-            $this->assertContains($expectedMigration, $output, $message);
+            $this->assertStringContainsString($expectedMigration, $output, $message);
         }
     }
 
@@ -1280,7 +1280,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1314,7 +1314,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1348,7 +1348,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1381,7 +1381,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1415,7 +1415,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1449,7 +1449,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1492,7 +1492,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1535,7 +1535,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1577,7 +1577,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1620,7 +1620,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1662,7 +1662,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1686,10 +1686,10 @@ class ManagerTest extends TestCase
         $this->manager->rollback('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('== 20120111235330 TestMigration: reverting', $output);
-        $this->assertContains('== 20120111235330 TestMigration: reverted', $output);
-        $this->assertNotContains('No migrations to rollback', $output);
-        $this->assertNotContains('Undefined offset: -1', $output);
+        $this->assertStringContainsString('== 20120111235330 TestMigration: reverting', $output);
+        $this->assertStringContainsString('== 20120111235330 TestMigration: reverted', $output);
+        $this->assertStringNotContainsString('No migrations to rollback', $output);
+        $this->assertStringNotContainsString('Undefined offset: -1', $output);
     }
 
     public function testRollbackToVersionWithTwoMigrationsDoesNotRollbackBothMigrations()
@@ -1723,7 +1723,7 @@ class ManagerTest extends TestCase
         $this->manager->rollback('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertNotContains('== 20120111235330 TestMigration: reverting', $output);
+        $this->assertStringNotContainsString('== 20120111235330 TestMigration: reverting', $output);
     }
 
     public function testRollbackToVersionWithTwoMigrationsDoesNotRollbackBothMigrationsWithNamespace()
@@ -1758,7 +1758,7 @@ class ManagerTest extends TestCase
         $this->manager->rollback('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertNotContains('== 20160111235330 Foo\Bar\TestMigration: reverting', $output);
+        $this->assertStringNotContainsString('== 20160111235330 Foo\Bar\TestMigration: reverting', $output);
     }
 
     public function testRollbackToVersionWithTwoMigrationsDoesNotRollbackBothMigrationsWithMixedNamespace()
@@ -1793,8 +1793,8 @@ class ManagerTest extends TestCase
         $this->manager->rollback('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('== 20150116183504 Baz\TestMigration2: reverting', $output);
-        $this->assertNotContains('== 20160111235330 TestMigration: reverting', $output);
+        $this->assertStringContainsString('== 20150116183504 Baz\TestMigration2: reverting', $output);
+        $this->assertStringNotContainsString('== 20160111235330 TestMigration: reverting', $output);
     }
 
     /**
@@ -1832,7 +1832,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1871,7 +1871,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -1910,7 +1910,7 @@ class ManagerTest extends TestCase
             }
 
             foreach ($expectedOutput as $expectedLine) {
-                $this->assertContains($expectedLine, $output);
+                $this->assertStringContainsString($expectedLine, $output);
             }
         }
     }
@@ -5311,9 +5311,9 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('GSeeder', $output);
-        $this->assertContains('PostSeeder', $output);
-        $this->assertContains('UserSeeder', $output);
+        $this->assertStringContainsString('GSeeder', $output);
+        $this->assertStringContainsString('PostSeeder', $output);
+        $this->assertStringContainsString('UserSeeder', $output);
     }
 
     public function testExecuteSeedWorksAsExpectedWithNamespace()
@@ -5327,9 +5327,9 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('Foo\Bar\GSeeder', $output);
-        $this->assertContains('Foo\Bar\PostSeeder', $output);
-        $this->assertContains('Foo\Bar\UserSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\GSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\PostSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\UserSeeder', $output);
     }
 
     public function testExecuteSeedWorksAsExpectedWithMixedNamespace()
@@ -5343,15 +5343,15 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('GSeeder', $output);
-        $this->assertContains('PostSeeder', $output);
-        $this->assertContains('UserSeeder', $output);
-        $this->assertContains('Baz\GSeeder', $output);
-        $this->assertContains('Baz\PostSeeder', $output);
-        $this->assertContains('Baz\UserSeeder', $output);
-        $this->assertContains('Foo\Bar\GSeeder', $output);
-        $this->assertContains('Foo\Bar\PostSeeder', $output);
-        $this->assertContains('Foo\Bar\UserSeeder', $output);
+        $this->assertStringContainsString('GSeeder', $output);
+        $this->assertStringContainsString('PostSeeder', $output);
+        $this->assertStringContainsString('UserSeeder', $output);
+        $this->assertStringContainsString('Baz\GSeeder', $output);
+        $this->assertStringContainsString('Baz\PostSeeder', $output);
+        $this->assertStringContainsString('Baz\UserSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\GSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\PostSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\UserSeeder', $output);
     }
 
     public function testExecuteASingleSeedWorksAsExpected()
@@ -5364,7 +5364,7 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv', 'UserSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('UserSeeder', $output);
+        $this->assertStringContainsString('UserSeeder', $output);
     }
 
     public function testExecuteASingleSeedWorksAsExpectedWithNamespace()
@@ -5378,7 +5378,7 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv', 'Foo\Bar\UserSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('Foo\Bar\UserSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\UserSeeder', $output);
     }
 
     public function testExecuteASingleSeedWorksAsExpectedWithMixedNamespace()
@@ -5392,7 +5392,7 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv', 'Baz\UserSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('Baz\UserSeeder', $output);
+        $this->assertStringContainsString('Baz\UserSeeder', $output);
     }
 
     public function testExecuteANonExistentSeedWorksAsExpected()
@@ -5408,7 +5408,7 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv', 'NonExistentSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('UserSeeder', $output);
+        $this->assertStringContainsString('UserSeeder', $output);
     }
 
     public function testExecuteANonExistentSeedWorksAsExpectedWithNamespace()
@@ -5425,7 +5425,7 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv', 'Foo\Bar\NonExistentSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('Foo\Bar\UserSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\UserSeeder', $output);
     }
 
     public function testExecuteANonExistentSeedWorksAsExpectedWithMixedNamespace()
@@ -5442,9 +5442,9 @@ class ManagerTest extends TestCase
         $this->manager->seed('mockenv', 'Baz\NonExistentSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertContains('UserSeeder', $output);
-        $this->assertContains('Baz\UserSeeder', $output);
-        $this->assertContains('Foo\Bar\UserSeeder', $output);
+        $this->assertStringContainsString('UserSeeder', $output);
+        $this->assertStringContainsString('Baz\UserSeeder', $output);
+        $this->assertStringContainsString('Foo\Bar\UserSeeder', $output);
     }
 
     public function testOrderSeeds()
@@ -5926,7 +5926,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
-        $this->assertContains('is not a valid version', $output);
+        $this->assertStringContainsString('is not a valid version', $output);
     }
 
     public function testPostgresFullMigration()

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -2,10 +2,12 @@
 
 namespace Test\Phinx\Migration;
 
+use InvalidArgumentException;
 use Phinx\Config\Config;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -1083,12 +1085,10 @@ class ManagerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Invalid version_order configuration option
-     */
     public function testPrintStatusInvalidVersionOrderKO()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid version_order configuration option');
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
             ->setConstructorArgs(['mockenv', []])
@@ -5395,12 +5395,11 @@ class ManagerTest extends TestCase
         $this->assertContains('Baz\UserSeeder', $output);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The seed class "NonExistentSeeder" does not exist
-     */
     public function testExecuteANonExistentSeedWorksAsExpected()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seed class "NonExistentSeeder" does not exist');
+
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
             ->setConstructorArgs(['mockenv', []])
@@ -5412,12 +5411,11 @@ class ManagerTest extends TestCase
         $this->assertContains('UserSeeder', $output);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The seed class "Foo\Bar\NonExistentSeeder" does not exist
-     */
     public function testExecuteANonExistentSeedWorksAsExpectedWithNamespace()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seed class "Foo\Bar\NonExistentSeeder" does not exist');
+
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
             ->setConstructorArgs(['mockenv', []])
@@ -5430,12 +5428,11 @@ class ManagerTest extends TestCase
         $this->assertContains('Foo\Bar\UserSeeder', $output);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The seed class "Baz\NonExistentSeeder" does not exist
-     */
     public function testExecuteANonExistentSeedWorksAsExpectedWithMixedNamespace()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seed class "Baz\NonExistentSeeder" does not exist');
+
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
             ->setConstructorArgs(['mockenv', []])
@@ -5488,12 +5485,11 @@ class ManagerTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The environment "invalidenv" does not exist
-     */
     public function testGettingAnInvalidEnvironment()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The environment "invalidenv" does not exist');
+
         $this->manager->getEnvironment('invalidenv');
     }
 

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -31,7 +31,7 @@ class ManagerTest extends TestCase
      */
     private $manager;
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->config = new Config($this->getConfigArray());
         $this->input = new ArrayInput([]);
@@ -80,7 +80,7 @@ class ManagerTest extends TestCase
         return $config;
     }
 
-    protected function tearDown()
+    public function tearDown(): void
     {
         $this->manager = null;
     }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -1087,8 +1087,6 @@ class ManagerTest extends TestCase
 
     public function testPrintStatusInvalidVersionOrderKO()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid version_order configuration option');
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
             ->setConstructorArgs(['mockenv', []])
@@ -1101,37 +1099,37 @@ class ManagerTest extends TestCase
         $this->manager = new Manager($config, $this->input, $this->output);
 
         $this->manager->setEnvironments(['mockenv' => $envStub]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid version_order configuration option');
+
         $this->manager->printStatus('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationVersions()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Duplicate migration - "' . $this->getCorrectedPath(__DIR__ . '/_files/duplicateversions/20120111235330_duplicate_migration_2.php') . '" has the same version as "20120111235330"'
-        );
         $config = new Config(['paths' => ['migrations' => $this->getCorrectedPath(__DIR__ . '/_files/duplicateversions')]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Duplicate migration - "' . $this->getCorrectedPath(__DIR__ . '/_files/duplicateversions/20120111235330_duplicate_migration_2.php') . '" has the same version as "20120111235330"');
+
         $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationVersionsWithNamespace()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Duplicate migration - "' . $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/duplicateversions/20160111235330_duplicate_migration_2.php') . '" has the same version as "20160111235330"'
-        );
         $config = new Config(['paths' => ['migrations' => ['Foo\Bar' => $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/duplicateversions')]]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Duplicate migration - "' . $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/duplicateversions/20160111235330_duplicate_migration_2.php') . '" has the same version as "20160111235330"');
+
         $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationVersionsWithMixedNamespace()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Duplicate migration - "' . $this->getCorrectedPath(__DIR__ . '/_files_baz/duplicateversions_mix_ns/20120111235330_duplicate_migration_mixed_namespace_2.php') . '" has the same version as "20120111235330"'
-        );
         $config = new Config(['paths' => [
             'migrations' => [
                 $this->getCorrectedPath(__DIR__ . '/_files/duplicateversions_mix_ns'),
@@ -1139,72 +1137,76 @@ class ManagerTest extends TestCase
             ]
         ]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Duplicate migration - "' . $this->getCorrectedPath(__DIR__ . '/_files_baz/duplicateversions_mix_ns/20120111235330_duplicate_migration_mixed_namespace_2.php') . '" has the same version as "20120111235330"');
+
         $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationNames()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Migration "20120111235331_duplicate_migration_name.php" has the same name as "20120111235330_duplicate_migration_name.php"'
-        );
         $config = new Config(['paths' => ['migrations' => $this->getCorrectedPath(__DIR__ . '/_files/duplicatenames')]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Migration "20120111235331_duplicate_migration_name.php" has the same name as "20120111235330_duplicate_migration_name.php"');
+
         $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithDuplicateMigrationNamesWithNamespace()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Migration "20160111235331_duplicate_migration_name.php" has the same name as "20160111235330_duplicate_migration_name.php"'
-        );
         $config = new Config(['paths' => ['migrations' => ['Foo\Bar' => $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/duplicatenames')]]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Migration "20160111235331_duplicate_migration_name.php" has the same name as "20160111235330_duplicate_migration_name.php"');
+
         $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithInvalidMigrationClassName()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Could not find class "InvalidClass" in file "' . $this->getCorrectedPath(__DIR__ . '/_files/invalidclassname/20120111235330_invalid_class.php') . '"'
-        );
         $config = new Config(['paths' => ['migrations' => $this->getCorrectedPath(__DIR__ . '/_files/invalidclassname')]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find class "InvalidClass" in file "' . $this->getCorrectedPath(__DIR__ . '/_files/invalidclassname/20120111235330_invalid_class.php') . '"');
+
         $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithInvalidMigrationClassNameWithNamespace()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Could not find class "Foo\Bar\InvalidClass" in file "' . $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/invalidclassname/20160111235330_invalid_class.php') . '"'
-        );
         $config = new Config(['paths' => ['migrations' => ['Foo\Bar' => $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/invalidclassname')]]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find class "Foo\Bar\InvalidClass" in file "' . $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/invalidclassname/20160111235330_invalid_class.php') . '"');
+
         $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithClassThatDoesntExtendAbstractMigration()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'The class "InvalidSuperClass" in file "' . $this->getCorrectedPath(__DIR__ . '/_files/invalidsuperclass/20120111235330_invalid_super_class.php') . '" must extend \Phinx\Migration\AbstractMigration'
-        );
         $config = new Config(['paths' => ['migrations' => $this->getCorrectedPath(__DIR__ . '/_files/invalidsuperclass')]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The class "InvalidSuperClass" in file "' . $this->getCorrectedPath(__DIR__ . '/_files/invalidsuperclass/20120111235330_invalid_super_class.php') . '" must extend \Phinx\Migration\AbstractMigration');
+
         $manager->getMigrations('mockenv');
     }
 
     public function testGetMigrationsWithClassThatDoesntExtendAbstractMigrationWithNamespace()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'The class "Foo\Bar\InvalidSuperClass" in file "' . $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/invalidsuperclass/20160111235330_invalid_super_class.php') . '" must extend \Phinx\Migration\AbstractMigration'
-        );
         $config = new Config(['paths' => ['migrations' => ['Foo\Bar' => $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/invalidsuperclass')]]]);
         $manager = new Manager($config, $this->input, $this->output);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The class "Foo\Bar\InvalidSuperClass" in file "' . $this->getCorrectedPath(__DIR__ . '/_files_foo_bar/invalidsuperclass/20160111235330_invalid_super_class.php') . '" must extend \Phinx\Migration\AbstractMigration');
+
         $manager->getMigrations('mockenv');
     }
 
@@ -5397,14 +5399,15 @@ class ManagerTest extends TestCase
 
     public function testExecuteANonExistentSeedWorksAsExpected()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class "NonExistentSeeder" does not exist');
-
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
         $this->manager->setEnvironments(['mockenv' => $envStub]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seed class "NonExistentSeeder" does not exist');
+
         $this->manager->seed('mockenv', 'NonExistentSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -5413,15 +5416,16 @@ class ManagerTest extends TestCase
 
     public function testExecuteANonExistentSeedWorksAsExpectedWithNamespace()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class "Foo\Bar\NonExistentSeeder" does not exist');
-
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
         $this->manager->setConfig($this->getConfigWithNamespace());
         $this->manager->setEnvironments(['mockenv' => $envStub]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seed class "Foo\Bar\NonExistentSeeder" does not exist');
+
         $this->manager->seed('mockenv', 'Foo\Bar\NonExistentSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -5430,15 +5434,16 @@ class ManagerTest extends TestCase
 
     public function testExecuteANonExistentSeedWorksAsExpectedWithMixedNamespace()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class "Baz\NonExistentSeeder" does not exist');
-
         // stub environment
         $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
         $this->manager->setConfig($this->getConfigWithMixedNamespace());
         $this->manager->setEnvironments(['mockenv' => $envStub]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seed class "Baz\NonExistentSeeder" does not exist');
+
         $this->manager->seed('mockenv', 'Baz\NonExistentSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -6039,23 +6044,6 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasColumn('table1', 'table3_id'));
         $this->assertFalse($adapter->hasForeignKey('table1', ['table3_id'], 'table1_table3_id'));
         $this->assertFalse($adapter->hasIndexByName('table1', 'table1_table3_id'));
-    }
-
-    public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = null)
-    {
-        if (method_exists($this, 'expectException')) {
-            //PHPUnit 5+
-            $this->expectException($exceptionName);
-            if ($exceptionMessage !== '') {
-                $this->expectExceptionMessage($exceptionMessage);
-            }
-            if ($exceptionCode !== null) {
-                $this->expectExceptionCode($exceptionCode);
-            }
-        } else {
-            //PHPUnit 4
-            parent::setExpectedException($exceptionName, $exceptionMessage, $exceptionCode);
-        }
     }
 
     public function testInvalidVersionBreakpoint()


### PR DESCRIPTION
With the dropping of everything below PHP 7.2, there is now no reason not to migrate to using only PHPUnit 8 for testing beyond the deprecation of usage of certain methods. It also has the added benefit (for me) of allowing alternative code coverage utilities, like pcov to be used out of the box.

As part of this PR, I've resolved all deprecation notices for PHPUnit with the exception of two in ConfigTest which are testing private class properties. The options as I see them here would be to:
1. Add a getter for `values` in Config object.
2. Do not test that `values` property of Config object is empty.
