### PR TITLE
Fix schema table not being properly quoted in some queries

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -370,7 +370,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                 throw new RuntimeException('Invalid version_order configuration option');
         }
 
-        $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY %s', $this->getSchemaTableName(), $orderBy));
+        $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY %s', $this->quoteTableName($this->getSchemaTableName()), $orderBy));
         foreach ($rows as $version) {
             $result[$version['version']] = $version;
         }
@@ -424,7 +424,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         $this->query(
             sprintf(
                 'UPDATE %1$s SET %2$s = CASE %2$s WHEN %3$s THEN %4$s ELSE %3$s END, %7$s = %7$s WHERE %5$s = \'%6$s\';',
-                $this->getSchemaTableName(),
+                $this->quoteTableName($this->getSchemaTableName()),
                 $this->quoteColumnName('breakpoint'),
                 $this->castToBool(true),
                 $this->castToBool(false),
@@ -445,7 +445,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         return $this->execute(
             sprintf(
                 'UPDATE %1$s SET %2$s = %3$s, %4$s = %4$s WHERE %2$s <> %3$s;',
-                $this->getSchemaTableName(),
+                $this->quoteTableName($this->getSchemaTableName()),
                 $this->quoteColumnName('breakpoint'),
                 $this->castToBool(false),
                 $this->quoteColumnName('start_time')
@@ -482,7 +482,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         $this->query(
             sprintf(
                 'UPDATE %1$s SET %2$s = %3$s, %4$s = %4$s WHERE %5$s = \'%6$s\';',
-                $this->getSchemaTableName(),
+                $this->quoteTableName($this->getSchemaTableName()),
                 $this->quoteColumnName('breakpoint'),
                 $this->castToBool($state),
                 $this->quoteColumnName('start_time'),

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -89,13 +89,17 @@ class PdoAdapterTest extends TestCase
             true,
             true,
             true,
-            ['fetchAll', 'getSchemaTableName']
+            ['fetchAll', 'getSchemaTableName', 'quoteTableName']
         );
 
         $schemaTableName = 'log';
         $adapter->expects($this->once())
             ->method('getSchemaTableName')
             ->will($this->returnValue($schemaTableName));
+        $adapter->expects($this->once())
+            ->method('quoteTableName')
+            ->with($schemaTableName)
+            ->will($this->returnValue("'$schemaTableName'"));
 
         $mockRows = [
             [
@@ -110,7 +114,7 @@ class PdoAdapterTest extends TestCase
 
         $adapter->expects($this->once())
             ->method('fetchAll')
-            ->with("SELECT * FROM $schemaTableName ORDER BY $expectedOrderBy")
+            ->with("SELECT * FROM '$schemaTableName' ORDER BY $expectedOrderBy")
             ->will($this->returnValue($mockRows));
 
         // we expect the mock rows but indexed by version creation time


### PR DESCRIPTION
Fixes #1685 (probably, I believe user there was using a `-` in table name, but have not yet confirmed).

If the `default_migration_table` in the configuration was set to something that required quoting, it would cause an error to be thrown, due to several places lacking quoting on the table name for the direct query. An example would be `phinx-log` would cause:
```
$ bin/phinx status
Phinx by CakePHP - https://phinx.org.

using config file ./phinx.yml
using config parser yaml
using migration paths
 - /Users/mpeveler/Work/Github/phinx/db/migrations
using seed paths
warning no environment specified, defaulting to: sqlite
ordering by creation time

 Status  [Migration ID]  Started              Finished             Migration Name
----------------------------------------------------------------------------------

In PdoAdapter.php line 212:

  SQLSTATE[HY000]: General error: 1 near "-": syntax error


status [-c|--configuration CONFIGURATION] [-p|--parser PARSER] [-e|--environment ENVIRONMENT] [-f|--format FORMAT]
```

where after the fix would print the expected values of up/down.

This updates the PDO adapter to quote the schema table in all places missing it. Not sure what type of tests would be good here beyond the slight change included in the one test.