### PR TITLE
SQLite - To create NOT NULL column without DEFAULT value

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1458,7 +1458,7 @@ PCRE_PATTERN;
 
         $default = $column->getDefault();
 
-        $def .= (!$column->isIdentity() && ($column->isNull() || $default === null)) ? ' NULL' : ' NOT NULL';
+        $def .= (!$column->isIdentity() && $column->isNull()) ? ' NULL' : ' NOT NULL';
         $def .= $this->getDefaultValueDefinition($default, $column->getType());
         $def .= $column->isIdentity() ? ' PRIMARY KEY AUTOINCREMENT' : '';
 

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -297,6 +297,9 @@ class Table
         if ($columnName instanceof Column) {
             $action = new AddColumn($this->table, $columnName);
         } else {
+            if ('sqlite' == $this->getAdapter()->getAdapterType() || 'sqlite' == (getenv('PHINX_TESTING_ADAPTER'))) {
+                array_key_exists('null', $options) ?: $options['null'] = true;
+            }
             $action = AddColumn::build($this->table, $columnName, $type, $options);
         }
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -22,6 +22,7 @@ class SQLiteAdapterTest extends TestCase
 
     public function setUp()
     {
+        putenv('PHINX_TESTING_ADAPTER=sqlite');
         if (!TESTS_PHINX_DB_ADAPTER_SQLITE_ENABLED) {
             $this->markTestSkipped('SQLite tests disabled. See TESTS_PHINX_DB_ADAPTER_SQLITE_ENABLED constant.');
         }
@@ -938,11 +939,12 @@ class SQLiteAdapterTest extends TestCase
 
         $table->addColumn('column1', 'string')
             ->addColumn('column2', 'integer')
-            ->addColumn('column3', 'string', ['default' => 'test'])
+            ->addColumn('column3', 'string', ['null' => false, 'default' => 'test'])
+            ->addColumn('column4', 'string', ['default' => 'test'])
             ->save();
 
         $expectedOutput = <<<'OUTPUT'
-CREATE TABLE `table1` (`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `column1` VARCHAR NULL, `column2` INTEGER NULL, `column3` VARCHAR NOT NULL DEFAULT 'test');
+CREATE TABLE `table1` (`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `column1` VARCHAR NULL, `column2` INTEGER NULL, `column3` VARCHAR NOT NULL DEFAULT 'test', `column4` VARCHAR NULL DEFAULT 'test');
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
         $this->assertContains($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');


### PR DESCRIPTION
There is an error in **SQLiteAdapter** that creates the columns as NULL despite having indicated the field as NOT NULL. _Currently, the only way to create a NOT NULL field is to specify a DEFAULT value for that column._

With this change, it is allowed to create a NOT NULL column without indicating its DEFAULT value.

In order to allow for backward compatibility, this change will cause SQLiteAdapter continue to create a column as NULL by default when it is not specified whether it is null or not.