### PR TITLE
Add note about MySQL version incompatibility fix

### DIFF
--- a/UPGRADE_0.8.md
+++ b/UPGRADE_0.8.md
@@ -13,3 +13,14 @@ rather than reverse creation order. To achieve this new ordering, you will need 
   This feature will be of most importance when development of migrations takes place in different branches
   within a codebase and are merged in to master for deployment. It will no longer matter when the migrations
   were created if it becomes necessary to rollback the migrations.
+
+* Using an older version of Phinx on a pre 5.7 MySQL installation could lead to a case of an invalid table definition
+for the `default_migration_table` (e.g. `phinxlog`) when the database was upgraded to 5.7. On upgrading, if you used
+phinx on a pre 5.7 MySQL installation, it is suggested to do the following:
+
+```
+ALTER TABLE phinxlog MODIFY start_time timestamp NULL DEFAULT NULL;
+ALTER TABLE phinxlog MODIFY end_time timestamp NULL DEFAULT NULL;
+UPDATE phinxlog SET start_time = NULL WHERE start_time = '0000-00-00 00:00:00';
+UPDATE phinxlog SET end_time = NULL WHERE end_time = '0000-00-00 00:00:00';
+```

--- a/UPGRADE_0.8.md
+++ b/UPGRADE_0.8.md
@@ -14,9 +14,9 @@ rather than reverse creation order. To achieve this new ordering, you will need 
   within a codebase and are merged in to master for deployment. It will no longer matter when the migrations
   were created if it becomes necessary to rollback the migrations.
 
-* Using an older version of Phinx on a pre 5.7 MySQL installation could lead to a case of an invalid table definition
-for the `default_migration_table` (e.g. `phinxlog`) when the database was upgraded to 5.7. On upgrading, if you used
-phinx on a pre 5.7 MySQL installation, it is suggested to do the following:
+* Using an older version of Phinx on a pre 5.6 MySQL installation could lead to a case of an invalid table definition
+for the `default_migration_table` (e.g. `phinxlog`) when the database was upgraded to 5.6. On upgrading, if you used
+phinx on a pre 5.6 MySQL installation, it is suggested to do the following:
 
 ```
 ALTER TABLE phinxlog MODIFY start_time timestamp NULL DEFAULT NULL;


### PR DESCRIPTION
Closes #1000

Adds a note to the 0.8 upgrade guide for people that used phinx on a pre 5.7 MySQL with phinx and that were then looking to upgrade to 5.6.