### PR TITLE
Use both $_SERVER and $_ENV for getting replacement config tokens

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -365,9 +365,11 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     protected function replaceTokens(array $arr)
     {
         // Get environment variables
-        // $_ENV is empty because variables_order does not include it normally
+        // Depending on configuration of server / OS and variables_order directive,
+        // environment variables either end up in $_SERVER (most likely) or $_ENV,
+        // so we search through both
         $tokens = [];
-        foreach ($_SERVER as $varname => $varvalue) {
+        foreach (array_merge($_ENV, $_SERVER) as $varname => $varvalue) {
             if (strpos($varname, 'PHINX_') === 0) {
                 $tokens['%%' . $varname . '%%'] = $varvalue;
             }

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -283,4 +283,34 @@ class ConfigTest extends AbstractConfigTest
             ],
         ];
     }
+
+    public function testConfigReplacesEnvironmentTokens()
+    {
+        $_SERVER['PHINX_TEST_CONFIG_ADAPTER'] = 'sqlite';
+        $_SERVER['PHINX_TEST_CONFIG_SUFFIX'] = 'sqlite3';
+        $_ENV['PHINX_TEST_CONFIG_NAME'] = 'phinx_testing';
+        $_ENV['PHINX_TEST_CONFIG_SUFFIX'] = 'foo';
+
+        try {
+            $config = new \Phinx\Config\Config([
+                'environments' => [
+                    'production' => [
+                        'adapter' => '%%PHINX_TEST_CONFIG_ADAPTER%%',
+                        'name' => '%%PHINX_TEST_CONFIG_NAME%%',
+                        'suffix' => '%%PHINX_TEST_CONFIG_SUFFIX%%'
+                    ],
+                ],
+            ]);
+
+            $this->assertSame(
+                ['adapter' => 'sqlite', 'name' => 'phinx_testing', 'suffix' => 'sqlite3'],
+                $config->getEnvironment('production')
+            );
+        } finally {
+            unset($_SERVER['PHINX_TEST_CONFIG_ADAPTER']);
+            unset($_SERVER['PHINX_TEST_CONFIG_SUFFIX']);
+            unset($_ENV['PHINX_TEST_CONFIG_NAME']);
+            unset($_ENV['PHINX_TEST_CONFIG_SUFFIX']);
+        }
+    }
 }

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -297,7 +297,7 @@ class ConfigTest extends AbstractConfigTest
                     'production' => [
                         'adapter' => '%%PHINX_TEST_CONFIG_ADAPTER%%',
                         'name' => '%%PHINX_TEST_CONFIG_NAME%%',
-                        'suffix' => '%%PHINX_TEST_CONFIG_SUFFIX%%'
+                        'suffix' => '%%PHINX_TEST_CONFIG_SUFFIX%%',
                     ],
                 ],
             ]);


### PR DESCRIPTION
Depending on configuration of the php.ini setting `variables_order`, `$_ENV` is generally empty, but it is possible in some environments that this is not always true (an example would also be that all environment variables set by phpunit are available under `$_ENV`, and not `$_SERVER`), and so it is better to probably just iterate through both arrays to find any matching `PHINX_` replacement token, especially to retain backwards compatibility (if someone was setting stuff through htaccess or whatever).

Included test case to test that loading from both `$_SERVER` and `$_ENV` is supported, and that values from `$_SERVER` are preferred in conflicts.

May fix #1692, but I am not sure without additional information from the author. 