### PR TITLE
Mark ext-json as optional and check it exists for usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/yaml": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
+        "ext-json": "*",
         "phpunit/phpunit": ">=5.7,<8.0",
         "sebastian/comparator": ">=1.2.3",
         "cakephp/cakephp-codesniffer": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,9 @@
             "Test\\Phinx\\": "tests/Phinx/"
         }
     },
+    "suggest": {
+        "ext-json": "Install if using JSON configuration format"
+    },
     "scripts": {
         "check": [
             "@test",

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -87,6 +87,10 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      */
     public static function fromJson($configFilePath)
     {
+        if (!function_exists('json_decode')) {
+            throw new RuntimeException("Need to install JSON PHP extension to use JSON config");
+        }
+
         $configArray = json_decode(file_get_contents($configFilePath), true);
         if (!is_array($configArray)) {
             throw new RuntimeException(sprintf(


### PR DESCRIPTION
A bottom point from #1702 and my comment from https://github.com/cakephp/phinx/pull/1491#issuecomment-580784114.

Adds `ext-json` as a suggested package to be installed for phinx to function if using a JSON configuration file. I also add a check that the function exists before using it so that the error message can be a bit nicer (instead of throwing a fatal error with a stacktrace).

If this is merged #1491 should definitely be closed, given that its proposal was making ext-json mandatory (as it was when that PR was opened, but is no longer).