### PR TITLE
Bump Dockerfile PHP version to 7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1
+FROM php:7.2
 
 # system dependecies
 RUN apt-get update && apt-get install -y \
@@ -6,7 +6,9 @@ RUN apt-get update && apt-get install -y \
    libicu-dev \
    libpq-dev \
    unzip \
-   zlib1g-dev
+   zlib1g-dev \
+   libonig-dev \
+   libzip-dev
 
 # PHP dependencies
 RUN docker-php-ext-install \


### PR DESCRIPTION
This PR updates the dockerfile to base based in PHP 7.2 rather than 7.1, fixing the issue with project dependencies. Closes #1708.