### PR TITLE
Raise error on ignored primary key

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -238,6 +238,9 @@ class MysqlAdapter extends PdoAdapter
                    ->setIdentity(true);
 
             array_unshift($columns, $column);
+            if (isset($options['primary_key'])) {
+                throw new InvalidArgumentException('You cannot enable an auto incrementing ID field and a primary key');
+            }
             $options['primary_key'] = $options['id'];
         }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -207,6 +207,9 @@ class PostgresAdapter extends PdoAdapter
                    ->setIdentity(true);
 
             array_unshift($columns, $column);
+            if (isset($options['primary_key'])) {
+                throw new InvalidArgumentException('You cannot enable an auto incrementing ID field and a primary key');
+            }
             $options['primary_key'] = $options['id'];
         }
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -227,6 +227,9 @@ class SqlServerAdapter extends PdoAdapter
                    ->setIdentity(true);
 
             array_unshift($columns, $column);
+            if (isset($options['primary_key'])) {
+                throw new InvalidArgumentException('You cannot enable an auto incrementing ID field and a primary key');
+            }
             $options['primary_key'] = $options['id'];
         }
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -229,6 +229,18 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasColumn('atable', 'id'));
     }
 
+    public function testCreateTableWithConflictingPrimaryKeys()
+    {
+        $options = [
+            'primary_key' => 'user_id',
+        ];
+        $table = new \Phinx\Db\Table('atable', $options, $this->adapter);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot enable an auto incrementing ID field and a primary key');
+        $table->addColumn('user_id', 'integer')->save();
+    }
+
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = [

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1426,12 +1426,12 @@ class PostgresAdapterTest extends TestCase
         $userId = 'user';
         $sessionId = 'session';
 
-        $local = new \Phinx\Db\Table('users', ['primary_key' => $userId, 'id' => $userId], $this->adapter);
+        $local = new \Phinx\Db\Table('users', ['id' => $userId], $this->adapter);
         $local->create();
 
         $foreign = new \Phinx\Db\Table(
             'sessions',
-            ['primary_key' => $sessionId, 'id' => $sessionId],
+            ['id' => $sessionId],
             $this->adapter
         );
         $foreign->addColumn('user', 'integer')
@@ -1450,14 +1450,14 @@ class PostgresAdapterTest extends TestCase
 
         $local = new \Phinx\Db\Table(
             'schema_users.users',
-            ['primary_key' => $userId, 'id' => $userId],
+            ['id' => $userId],
             $this->adapter
         );
         $local->create();
 
         $foreign = new \Phinx\Db\Table(
             'schema_users.sessions',
-            ['primary_key' => $sessionId, 'id' => $sessionId],
+            ['id' => $sessionId],
             $this->adapter
         );
         $foreign->addColumn('user', 'integer')
@@ -1479,14 +1479,14 @@ class PostgresAdapterTest extends TestCase
 
         $local = new \Phinx\Db\Table(
             'schema_users.users',
-            ['primary_key' => $userId, 'id' => $userId],
+            ['id' => $userId],
             $this->adapter
         );
         $local->create();
 
         $foreign = new \Phinx\Db\Table(
             'schema_sessions.sessions',
-            ['primary_key' => $sessionId, 'id' => $sessionId],
+            ['id' => $sessionId],
             $this->adapter
         );
         $foreign->addColumn('user', 'integer')

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -213,6 +213,18 @@ class PostgresAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasColumn('atable', 'id'));
     }
 
+    public function testCreateTableWithConflictingPrimaryKeys()
+    {
+        $options = [
+            'primary_key' => 'user_id',
+        ];
+        $table = new \Phinx\Db\Table('atable', $options, $this->adapter);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot enable an auto incrementing ID field and a primary key');
+        $table->addColumn('user_id', 'integer')->save();
+    }
+
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = [

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -181,6 +181,18 @@ WHERE t.name='ntable'");
         $this->assertFalse($this->adapter->hasColumn('atable', 'id'));
     }
 
+    public function testCreateTableWithConflictingPrimaryKeys()
+    {
+        $options = [
+            'primary_key' => 'user_id',
+        ];
+        $table = new \Phinx\Db\Table('atable', $options, $this->adapter);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot enable an auto incrementing ID field and a primary key');
+        $table->addColumn('user_id', 'integer')->save();
+    }
+
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = [

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -776,10 +776,10 @@ WHERE t.name='ntable'");
         $userId = 'user';
         $sessionId = 'session';
 
-        $local = new \Phinx\Db\Table('users', ['primary_key' => $userId, 'id' => $userId], $this->adapter);
+        $local = new \Phinx\Db\Table('users', ['id' => $userId], $this->adapter);
         $local->create();
 
-        $foreign = new \Phinx\Db\Table('sessions', ['primary_key' => $sessionId, 'id' => $sessionId], $this->adapter);
+        $foreign = new \Phinx\Db\Table('sessions', ['id' => $sessionId], $this->adapter);
         $foreign->addColumn('user', 'integer')
                 ->addForeignKey('user', 'users', $userId)
                 ->create();


### PR DESCRIPTION
At the moment if you define a `primary_key` but forget to set `'id' => false` then your intended `primary_key` is silently ignored and the standard auto increment `id` field is created instead.

This PR instead makes this configuration an error so that the user is aware they are doing something wrong and can decide whether to remove their `primary_key` to confirm the actual behaviour, or to add `'id' => false` to get their intended behaviour.

There was also a few instances of this mistake in the postgres tests, so this PR fixes those too