### PR TITLE
Use not null by default for sqlite column definitions

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -809,7 +809,7 @@ Option  Description
 limit   set maximum length for strings, also hints column types in adapters (see note below)
 length  alias for ``limit``
 default set default value or action
-null    allow ``NULL`` values (should not be used with primary keys!)
+null    allow ``NULL`` values, defaults to false (should not be used with primary keys!) (see note below)
 after   specify the column that a new column should be placed after *(only applies to MySQL)*
 comment set a text comment on the column
 ======= ===========
@@ -951,6 +951,25 @@ INT_BIG      BIGINT
                ->addColumn('quantity', 'integer', ['limit' => MysqlAdapter::INT_TINY])
                ->create();
 
+Null Option and SQLite
+~~~~~~~~~~~~~~~~~~~~~~
+
+When using the SQLite adapter, if appending a column to an existing table, you must
+specify a default or make the column nullable. This does not apply when initially creating
+the table.
+
+.. code-block:: php
+
+        $table = $this->table('cart_items', 'id' => false);
+        // Can not specify default here and use NOT NULL
+        $table->addColumn('column1', 'integer')
+            ->create();
+
+        // Must either specify null => false, or specify a default here
+        $table
+            ->addColumn('column2', 'integer', ['null' => false])
+            ->addColumn('column3', 'integer', ['default' => 1])
+            ->update();
 
 Get a column list
 ~~~~~~~~~~~~~~~~~

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1158,7 +1158,7 @@ class MysqlAdapter extends PdoAdapter
         $def .= $column->getEncoding() ? ' CHARACTER SET ' . $column->getEncoding() : '';
         $def .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
         $def .= (!$column->isSigned() && isset($this->signedColumnTypes[$column->getType()])) ? ' unsigned' : '';
-        $def .= ($column->isNull() == false) ? ' NOT NULL' : ' NULL';
+        $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
         $def .= $column->isIdentity() ? ' AUTO_INCREMENT' : '';
         $def .= $this->getDefaultValueDefinition($column->getDefault(), $column->getType());
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1458,7 +1458,7 @@ PCRE_PATTERN;
 
         $default = $column->getDefault();
 
-        $def .= (!$column->isIdentity() && ($column->isNull() || $default === null)) ? ' NULL' : ' NOT NULL';
+        $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
         $def .= $this->getDefaultValueDefinition($default, $column->getType());
         $def .= $column->isIdentity() ? ' PRIMARY KEY AUTOINCREMENT' : '';
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -360,7 +360,7 @@ class SQLiteAdapterTest extends TestCase
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->save();
         $this->assertFalse($table->hasColumn('email'));
-        $table->addColumn('email', 'string')
+        $table->addColumn('email', 'string', ['null' => true])
             ->save();
         $this->assertTrue($table->hasColumn('email'));
 
@@ -405,7 +405,7 @@ class SQLiteAdapterTest extends TestCase
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->save();
-        $table->addColumn('foo', 'double')
+        $table->addColumn('foo', 'double', ['null' => true])
             ->save();
         $rows = $this->adapter->fetchAll(sprintf('pragma table_info(%s)', 'table1'));
         $this->assertEquals('DOUBLE', $rows[1]['type']);
@@ -791,7 +791,7 @@ class SQLiteAdapterTest extends TestCase
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->addColumn('column1', 'string')
-            ->addColumn('column2', 'integer')
+            ->addColumn('column2', 'integer', ['null' => true])
             ->insert([
                 [
                     'column1' => 'value1',
@@ -831,7 +831,7 @@ class SQLiteAdapterTest extends TestCase
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->addColumn('column1', 'string')
-            ->addColumn('column2', 'integer')
+            ->addColumn('column2', 'integer', ['null' => true])
             ->insert([
                 [
                     'column1' => 'value1',
@@ -941,7 +941,7 @@ class SQLiteAdapterTest extends TestCase
             ->save();
 
         $expectedOutput = <<<'OUTPUT'
-CREATE TABLE `table1` (`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `column1` VARCHAR NULL, `column2` INTEGER NULL, `column3` VARCHAR NOT NULL DEFAULT 'test');
+CREATE TABLE `table1` (`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `column1` VARCHAR NOT NULL, `column2` INTEGER NOT NULL, `column3` VARCHAR NOT NULL DEFAULT 'test');
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
         $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');
@@ -1056,7 +1056,7 @@ OUTPUT;
         ])->save();
 
         $expectedOutput = <<<'OUTPUT'
-CREATE TABLE `table1` (`column1` VARCHAR NULL, `column2` INTEGER NULL, PRIMARY KEY (`column1`));
+CREATE TABLE `table1` (`column1` VARCHAR NOT NULL, `column2` INTEGER NOT NULL, PRIMARY KEY (`column1`));
 INSERT INTO `table1` (`column1`, `column2`) VALUES ('id1', 1);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
@@ -1115,8 +1115,8 @@ OUTPUT;
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->save();
 
-        $table->addColumn('string_col', 'string');
-        $table->addColumn('string_col_2', 'string');
+        $table->addColumn('string_col', 'string', ['default' => '']);
+        $table->addColumn('string_col_2', 'string', ['null' => true]);
         $table->save();
         $this->assertTrue($this->adapter->hasColumn('table1', 'string_col'));
         $this->assertTrue($this->adapter->hasColumn('table1', 'string_col_2'));


### PR DESCRIPTION
Fixes #1446

This brings the SQLite adapter inline with all other adapters, making it so that all creates columns as `NOT NULL` by default. SQLite does have an annoying "bug" where a column can be `NOT NULL` without specifying a default on table creation, but cannot if appending it to an existing table. I've added a note to the docs about this

Either this PR or #1687 should be merged and the other should be closed.

The change to the MySQLAdapter is just cosmetic to make it match the other adapters.