### PR TITLE
Allow explicitly setting primary key to same value as id

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -238,7 +238,7 @@ class MysqlAdapter extends PdoAdapter
                    ->setIdentity(true);
 
             array_unshift($columns, $column);
-            if (isset($options['primary_key'])) {
+            if (isset($options['primary_key']) && (array)$options['id'] !== (array)$options['primary_key']) {
                 throw new InvalidArgumentException('You cannot enable an auto incrementing ID field and a primary key');
             }
             $options['primary_key'] = $options['id'];

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -207,7 +207,7 @@ class PostgresAdapter extends PdoAdapter
                    ->setIdentity(true);
 
             array_unshift($columns, $column);
-            if (isset($options['primary_key'])) {
+            if (isset($options['primary_key']) && (array)$options['id'] !== (array)$options['primary_key']) {
                 throw new InvalidArgumentException('You cannot enable an auto incrementing ID field and a primary key');
             }
             $options['primary_key'] = $options['id'];

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -227,7 +227,7 @@ class SqlServerAdapter extends PdoAdapter
                    ->setIdentity(true);
 
             array_unshift($columns, $column);
-            if (isset($options['primary_key'])) {
+            if (isset($options['primary_key']) && (array)$options['id'] !== (array)$options['primary_key']) {
                 throw new InvalidArgumentException('You cannot enable an auto incrementing ID field and a primary key');
             }
             $options['primary_key'] = $options['id'];

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -241,6 +241,41 @@ class MysqlAdapterTest extends TestCase
         $table->addColumn('user_id', 'integer')->save();
     }
 
+    public function testCreateTableWithPrimaryKeySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => 'id',
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
+    public function testCreateTableWithPrimaryKeyArraySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => ['id'],
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
+    public function testCreateTableWithMultiplePrimaryKeyArraySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => ['id', 'user_id'],
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot enable an auto incrementing ID field and a primary key');
+        $table->addColumn('user_id', 'integer')->save();
+    }
+
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = [

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -225,6 +225,41 @@ class PostgresAdapterTest extends TestCase
         $table->addColumn('user_id', 'integer')->save();
     }
 
+    public function testCreateTableWithPrimaryKeySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => 'id',
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
+    public function testCreateTableWithPrimaryKeyArraySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => ['id'],
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
+    public function testCreateTableWithMultiplePrimaryKeyArraySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => ['id', 'user_id'],
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot enable an auto incrementing ID field and a primary key');
+        $table->addColumn('user_id', 'integer')->save();
+    }
+
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = [

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -193,6 +193,41 @@ WHERE t.name='ntable'");
         $table->addColumn('user_id', 'integer')->save();
     }
 
+    public function testCreateTableWithPrimaryKeySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => 'id',
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
+    public function testCreateTableWithPrimaryKeyArraySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => ['id'],
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
+    public function testCreateTableWithMultiplePrimaryKeyArraySetToImplicitId()
+    {
+        $options = [
+            'primary_key' => ['id', 'user_id'],
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot enable an auto incrementing ID field and a primary key');
+        $table->addColumn('user_id', 'integer')->save();
+    }
+
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = [


### PR DESCRIPTION
Fixes #1724

#1716 introduced an exception that is thrown if both `id` and `primary_key` are set. However, this includes the case where `primary_key` and `id` have the same value. This PR makes it so in the case that `id` and `primary_key` refer to the same value, no error is thrown.

So these are now valid again:
```
$this->table('table', ['id' => true, 'primary_key' => 'id'])->create();
$this->table('table', ['id' => true, 'primary_key' => ['id']])->create();
$this->table('table', ['id' => 'test', 'primary_key' => 'test'])->create();
```