### PR TITLE
Improving handling of add column instructions in sqlite

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -1028,26 +1028,6 @@ columns with different lengths, mismatched integer types (long vs. bigint, etc).
                 - jpg
                 - png
 
-Null Option and SQLite
-~~~~~~~~~~~~~~~~~~~~~~
-
-When using the SQLite adapter, if appending a column to an existing table, you must
-specify a default or make the column nullable. This does not apply when initially creating
-the table.
-
-.. code-block:: php
-
-        $table = $this->table('cart_items', 'id' => false);
-        // Can not specify default here and use NOT NULL
-        $table->addColumn('column1', 'integer')
-            ->create();
-
-        // Must either specify null => false, or specify a default here
-        $table
-            ->addColumn('column2', 'integer', ['null' => false])
-            ->addColumn('column3', 'integer', ['default' => 1])
-            ->update();
-
 Get a column list
 ~~~~~~~~~~~~~~~~~
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -814,7 +814,7 @@ PCRE_PATTERN;
         $selectColumns = array_map([$this, 'quoteColumnName'], $selectColumns);
         $writeColumns = array_map([$this, 'quoteColumnName'], $writeColumns);
 
-        if (!$found && $columnName !== false) {
+        if ($columnName && !$found) {
             throw new InvalidArgumentException(sprintf(
                 'The specified column doesn\'t exist: ' . $columnName
             ));

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1117,9 +1117,28 @@ OUTPUT;
 
         $table->addColumn('string_col', 'string', ['default' => '']);
         $table->addColumn('string_col_2', 'string', ['null' => true]);
+        $table->addColumn('string_col_3', 'string');
+        $table->addTimestamps();
         $table->save();
-        $this->assertTrue($this->adapter->hasColumn('table1', 'string_col'));
-        $this->assertTrue($this->adapter->hasColumn('table1', 'string_col_2'));
+
+        $columns = $this->adapter->getColumns('table1');
+        $expected = [
+            ['name' => 'id', 'type' => 'integer', 'default' => null, 'null' => false],
+            ['name' => 'string_col', 'type' => 'string', 'default' => '', 'null' => false],
+            ['name' => 'string_col_2', 'type' => 'string', 'default' => '', 'null' => true],
+            ['name' => 'string_col_3', 'type' => 'string', 'default' => '', 'null' => false],
+            ['name' => 'created_at', 'type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false],
+            ['name' => 'updated_at', 'type' => 'timestamp', 'default' => null, 'null' => true],
+        ];
+
+        $this->assertEquals(count($expected), count($columns));
+        $columnCount = count($columns);
+        for ($i = 0; $i < $columnCount; $i++) {
+            $this->assertSame($expected[$i]['name'], $columns[$i]->getName(), "Wrong name for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['type'], $columns[$i]->getType(), "Wrong type for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['default'], $columns[$i]->getDefault(), "Wrong default for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['null'], $columns[$i]->getNull(), "Wrong null for {$expected[$i]['name']}");
+        }
     }
 
     public function testLiteralSupport()

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1125,18 +1125,19 @@ OUTPUT;
         $expected = [
             ['name' => 'id', 'type' => 'integer', 'default' => null, 'null' => false],
             ['name' => 'string_col', 'type' => 'string', 'default' => '', 'null' => false],
-            ['name' => 'string_col_2', 'type' => 'string', 'default' => '', 'null' => true],
-            ['name' => 'string_col_3', 'type' => 'string', 'default' => '', 'null' => false],
+            ['name' => 'string_col_2', 'type' => 'string', 'default' => null, 'null' => true],
+            ['name' => 'string_col_3', 'type' => 'string', 'default' => null, 'null' => false],
             ['name' => 'created_at', 'type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false],
             ['name' => 'updated_at', 'type' => 'timestamp', 'default' => null, 'null' => true],
         ];
 
         $this->assertEquals(count($expected), count($columns));
+
         $columnCount = count($columns);
         for ($i = 0; $i < $columnCount; $i++) {
             $this->assertSame($expected[$i]['name'], $columns[$i]->getName(), "Wrong name for {$expected[$i]['name']}");
             $this->assertSame($expected[$i]['type'], $columns[$i]->getType(), "Wrong type for {$expected[$i]['name']}");
-            $this->assertSame($expected[$i]['default'], $columns[$i]->getDefault(), "Wrong default for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['default'], ($columns[$i]->getDefault() instanceof Literal) ? (string)$columns[$i]->getDefault() : $columns[$i]->getDefault(), "Wrong default for {$expected[$i]['name']}");
             $this->assertSame($expected[$i]['null'], $columns[$i]->getNull(), "Wrong null for {$expected[$i]['name']}");
         }
     }


### PR DESCRIPTION
SQLite has many limitations with the ALTER TABLE commands around dropping columns, altering them, etc. which have been covered in previous PRs. However, while SQLite does
support using ALTER TABLE to add columns, it comes with quite a bit of caveats which include not being able to define a NOT NULL without a default, cannot define a default that is a function (e.g. CURRENT_TIMESTAMP), etc. As such, to overcome these things which people probably would not expect coming from other DBs, this commit makes it so that add column commands, like the alter column and drop column commands, we create a temp table with our desired changes, then copy in all old data into.

Closes #1611 and removes the cop-out that was my original solution for #1718 (with something that works as expected).