### PR TITLE
Support setting SRID for geometry columns for MySQL 8+

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1163,7 +1163,8 @@ class MysqlAdapter extends PdoAdapter
         $def .= (!$column->isSigned() && isset($this->signedColumnTypes[$column->getType()])) ? ' unsigned' : '';
         $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
 
-        if (version_compare($this->getAttribute(\PDO::ATTR_SERVER_VERSION), '8') > -1
+        if (
+            version_compare($this->getAttribute(\PDO::ATTR_SERVER_VERSION), '8') > -1
             && in_array($column->getType(), [static::PHINX_TYPE_GEOMETRY, static::PHINX_TYPE_POINT, static::PHINX_TYPE_LINESTRING, static::PHINX_TYPE_POLYGON])
             && !is_null($column->getSrid())
         ) {

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1162,6 +1162,14 @@ class MysqlAdapter extends PdoAdapter
         $def .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
         $def .= (!$column->isSigned() && isset($this->signedColumnTypes[$column->getType()])) ? ' unsigned' : '';
         $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
+
+        if (version_compare($this->getAttribute(\PDO::ATTR_SERVER_VERSION), '8') > -1
+            && in_array($column->getType(), [static::PHINX_TYPE_GEOMETRY, static::PHINX_TYPE_POINT, static::PHINX_TYPE_LINESTRING, static::PHINX_TYPE_POLYGON])
+            && !is_null($column->getSrid())
+        ) {
+            $def .= " SRID {$column->getSrid()}";
+        }
+
         $def .= $column->isIdentity() ? ' AUTO_INCREMENT' : '';
         $def .= $this->getDefaultValueDefinition($column->getDefault(), $column->getType());
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1742,4 +1742,62 @@ INPUT;
         $this->assertCount(1, $columns);
         $this->assertEquals(Literal::from('double'), array_pop($columns)->getType());
     }
+
+    public function geometryTypeProvider()
+    {
+        return [
+            [MysqlAdapter::PHINX_TYPE_GEOMETRY, 'POINT(0 0)'],
+            [MysqlAdapter::PHINX_TYPE_POINT, 'POINT(0 0)'],
+            [MysqlAdapter::PHINX_TYPE_LINESTRING, 'LINESTRING(30 10,10 30,40 40)'],
+            [MysqlAdapter::PHINX_TYPE_POLYGON, 'POLYGON((30 10,40 40,20 40,10 20,30 10))']
+        ];
+    }
+
+    /**
+     * @dataProvider geometryTypeProvider
+     *
+     * @param string $type
+     * @param string $geom
+     */
+    public function testGeometrySridSupport($type, $geom)
+    {
+        $this->adapter->connect();
+        if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '8') === -1) {
+            $this->markTestSkipped('Cannot test datetime limit on versions less than 8.0.0');
+        }
+
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table
+            ->addColumn('geom', $type, ['srid' => 4326])
+            ->save();
+
+        $this->adapter->execute("INSERT INTO table1 (`geom`) VALUES (ST_GeomFromText('{$geom}', 4326))");
+        $rows = $this->adapter->fetchAll('SELECT ST_AsWKT(geom) as wkt, ST_SRID(geom) as srid FROM table1');
+        $this->assertSame(1, count($rows));
+        $this->assertSame($geom, $rows[0]['wkt']);
+        $this->assertSame('4326', $rows[0]['srid']);
+    }
+
+    /**
+     * @dataProvider geometryTypeProvider
+     *
+     * @param string $type
+     * @param string $geom
+     */
+    public function testGeometrySridThrowsInsertDifferentSrid($type, $geom)
+    {
+        $this->adapter->connect();
+        if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '8') === -1) {
+            $this->markTestSkipped('Cannot test datetime limit on versions less than 8.0.0');
+        }
+
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table
+            ->addColumn('geom', $type, ['srid' => 4326])
+            ->save();
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage("SQLSTATE[HY000]: General error: 3643 The SRID of the geometry does not match the SRID of the column 'geom'. The SRID of the geometry is 4322, but the SRID of the column is 4326. Consider changing the SRID of the geometry or the SRID property of the column.");
+        $this->adapter->execute("INSERT INTO table1 (`geom`) VALUES (ST_GeomFromText('{$geom}', 4322))");
+    }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1749,7 +1749,7 @@ INPUT;
             [MysqlAdapter::PHINX_TYPE_GEOMETRY, 'POINT(0 0)'],
             [MysqlAdapter::PHINX_TYPE_POINT, 'POINT(0 0)'],
             [MysqlAdapter::PHINX_TYPE_LINESTRING, 'LINESTRING(30 10,10 30,40 40)'],
-            [MysqlAdapter::PHINX_TYPE_POLYGON, 'POLYGON((30 10,40 40,20 40,10 20,30 10))']
+            [MysqlAdapter::PHINX_TYPE_POLYGON, 'POLYGON((30 10,40 40,20 40,10 20,30 10))'],
         ];
     }
 


### PR DESCRIPTION
Closes #1677

MySQL 8 added support for setting the SRID attribute of a column. This makes it so that you could only insert geometries of that SRID into that column.

I've set-up a travis build with MySQL 8 to show the tests passing (though it shows a lot of failing other MySQL tests on 8): https://travis-ci.org/github/MasterOdin/phinx/builds/672758069