### PR TITLE
Create and deploy phinx.phar on travis build for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,20 @@ cache:
 
 notifications:
   email: false
+
+before_deploy:
+  # have to move symfony/yaml from devDependency to dependency so box packs it
+  - composer require symfony/yaml
+  - composer global require humbug/box:^3.8
+  - ~/.composer/vendor/bin/box compile
+
+deploy:
+  provider: releases
+  api_key:
+    secure: <api_key>
+  file: phinx.phar
+  on:
+    repo: cakephp/phinx
+    tags: true
+    php: 7.2
+    condition: $DEFAULT = 1 && $PREFER_LOWEST != 1

--- a/box.json
+++ b/box.json
@@ -1,9 +1,8 @@
 {
     "alias": "phinx.phar",
-    "chmod": "0755",
     "compactors": [
-        "Herrera\\Box\\Compactor\\Json",
-        "Herrera\\Box\\Compactor\\Php"
+        "KevinGH\\Box\\Compactor\\Json",
+        "KevinGH\\Box\\Compactor\\Php"
     ],
     "directories": ["src","app"],
     "files": [
@@ -26,9 +25,6 @@
             "in": "vendor"
         }
     ],
-    "git-version": "git_tag",
-    "main": "bin/phinx",
-    "output": "phinx-@git-version@.phar",
-    "stub": true,
+    "output": "phinx.phar",
     "exclude-composer-files": false
 }


### PR DESCRIPTION
Closes #1559 

As discussed in https://github.com/cakephp/phinx/issues/1559#issuecomment-610123985, this PR sets up Travis to generate a phar using [`humbug/box`](https://github.com/humbug/box)`. This will then be uploaded to a release as it's made through the [Travis Deploy](https://docs.travis-ci.com/user/deployment/releases/).

The `stub` and `main` key/value pairs were removed from the `box.json` file as they were the default values box was using anyway during the compile process and it recommends to. The `Herrera` packages were deprecated in favor of the `KevinGH` ones.

For this to work, someone with release access will have to use the [Travis-CI CLI](https://github.com/travis-ci/travis.rb) and do the following:
1. Remove the deploy section added in this PR
1. Run the following command: ```travis setup releases --org```, where it will ask for username, password, file to upload (phinx.phar), deploy only from `cakephp/phinx` (yes), deploy from current branch (no), and encrypt the api key (yes)
1. Copy the `deploy.api_key.secure` value from the changed .travis.yml file
1. Revert the changes to .travis.yml
1. Paste the copied key over where it says `<api_key>`

A test run of things can be found at:
1. GitHub release: https://github.com/MasterOdin/phinx/releases/tag/v0.12.0-test
2. Travis Build: https://travis-ci.org/github/MasterOdin/phinx/builds/672799256