### PR TITLE
Fix using deprecated phpunit methods

### DIFF
--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -104,7 +104,7 @@ class ConfigTest extends AbstractConfigTest
     public function testGetDataDomainMethod()
     {
         $config = new Config($this->getConfigArray());
-        $this->assertInternalType('array', $config->getDataDomain());
+        $this->assertIsArray($config->getDataDomain());
     }
 
     /**
@@ -113,7 +113,7 @@ class ConfigTest extends AbstractConfigTest
     public function testReturnsEmptyArrayWithEmptyDataDomain()
     {
         $config = new Config([]);
-        $this->assertInternalType('array', $config->getDataDomain());
+        $this->assertIsArray($config->getDataDomain());
         $this->assertCount(0, $config->getDataDomain());
     }
 

--- a/tests/Phinx/Db/Adapter/DataDomainTest.php
+++ b/tests/Phinx/Db/Adapter/DataDomainTest.php
@@ -2,19 +2,12 @@
 
 namespace Test\Phinx\Db\Adapter;
 
-use Phinx\Db\Adapter\AbstractAdapter;
-use Phinx\Db\Adapter\AdapterFactory;
+use InvalidArgumentException;
 use Phinx\Db\Adapter\MysqlAdapter;
-use Phinx\Db\Adapter\PostgresAdapter;
 use PHPUnit\Framework\TestCase;
 
 class DataDomainTest extends TestCase
 {
-
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage You must specify a type for data domain type "phone_number".
-     */
     public function testThrowsIfNoTypeSpecified()
     {
         $data_domain = [
@@ -23,13 +16,12 @@ class DataDomainTest extends TestCase
             ],
         ];
 
-        $adapter = new MysqlAdapter(['data_domain' => $data_domain]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You must specify a type for data domain type "phone_number".');
+
+        new MysqlAdapter(['data_domain' => $data_domain]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage An invalid column type "str" was specified for data domain type "phone_number".
-     */
     public function testThrowsIfInvalidBaseType()
     {
         $data_domain = [
@@ -39,12 +31,11 @@ class DataDomainTest extends TestCase
             ],
         ];
 
-        $adapter = new MysqlAdapter(['data_domain' => $data_domain]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('An invalid column type "str" was specified for data domain type "phone_number".');
+        new MysqlAdapter(['data_domain' => $data_domain]);
     }
 
-    /**
-     *
-     */
     public function testConvertsToInternalType()
     {
         $data_domain = [
@@ -60,9 +51,6 @@ class DataDomainTest extends TestCase
         $this->assertEquals($data_domain['phone_number']['type'], $dd['phone_number']['type']);
     }
 
-    /**
-     *
-     */
     public function testReplacesLengthForLimit()
     {
         $data_domain = [
@@ -75,13 +63,10 @@ class DataDomainTest extends TestCase
         $mysql_adapter = new MysqlAdapter(['data_domain' => $data_domain]);
         $dd = $mysql_adapter->getDataDomain();
 
-        $this->assertInternalType('array', $dd['phone_number']['options']);
+        $this->assertIsArray($dd['phone_number']['options']);
         $this->assertEquals(19, $dd['phone_number']['options']['limit']);
     }
 
-    /**
-     *
-     */
     public function testConvertsToMysqlLimit()
     {
         $data_domain = [
@@ -97,9 +82,6 @@ class DataDomainTest extends TestCase
         $this->assertEquals(MysqlAdapter::INT_BIG, $dd['prime']['options']['limit']);
     }
 
-    /**
-     *
-     */
     public function testCreatesTypeFromPhinxConstant()
     {
         $data_domain = [
@@ -116,10 +98,6 @@ class DataDomainTest extends TestCase
         $this->assertEquals(MysqlAdapter::INT_BIG, $dd['prime']['options']['limit']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage An invalid limit value "BIG_SUR" was specified for data domain type "prime".
-     */
     public function testThrowsErrorForInvalidMysqlLimit()
     {
         $data_domain = [
@@ -129,12 +107,11 @@ class DataDomainTest extends TestCase
             ],
         ];
 
-        $mysql_adapter = new MysqlAdapter(['data_domain' => $data_domain]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('An invalid limit value "BIG_SUR" was specified for data domain type "prime".');
+        new MysqlAdapter(['data_domain' => $data_domain]);
     }
 
-    /**
-     *
-     */
     public function testCreatesColumnWithDataDomain()
     {
         $data_domain = [
@@ -151,9 +128,6 @@ class DataDomainTest extends TestCase
         $this->assertEquals(19, $column->getLimit());
     }
 
-    /**
-     *
-     */
     public function testLocalOptionsOverridesDataDomainOptions()
     {
         $data_domain = [

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1872,7 +1872,7 @@ INPUT;
     {
         $this->adapter->connect();
         if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '8') === -1) {
-            $this->markTestSkipped('Cannot test datetime limit on versions less than 8.0.0');
+            $this->markTestSkipped('Cannot test geometry srid on versions less than 8.0.0');
         }
 
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
@@ -1897,7 +1897,7 @@ INPUT;
     {
         $this->adapter->connect();
         if (version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '8') === -1) {
-            $this->markTestSkipped('Cannot test datetime limit on versions less than 8.0.0');
+            $this->markTestSkipped('Cannot test geometry srid on versions less than 8.0.0');
         }
 
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);


### PR DESCRIPTION
#1320 had a number of deprecated phpunit test methods in it. This PR modifies them to use the not deprecated versions.

I also fixed a typo I introduced in #1730 from copying and pasting and not updating the string.