### PR TITLE
Support user-configured DI container instantiation of seeds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "php": ">=7.2",
         "cakephp/collection": "^4.0",
         "cakephp/database": "^4.0",
+        "psr/container": "^1.0",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/config": "^3.4|^4.0|^5.0"
     },

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -354,6 +354,18 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getContainer()
+    {
+        if (!isset($this->values['container'])) {
+            return null;
+        }
+
+        return $this->values['container'];
+    }
+
+    /**
      * Get the version order.
      *
      * @return string

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -8,6 +8,7 @@
 namespace Phinx\Config;
 
 use ArrayAccess;
+use Psr\Container\ContainerInterface;
 
 /**
  * Phinx configuration interface.
@@ -106,6 +107,13 @@ interface ConfigInterface extends ArrayAccess
      * @return string|false
      */
     public function getTemplateClass();
+
+    /**
+     * Get the user-provided container for instantiating seeds
+     *
+     * @return ContainerInterface|null
+     */
+    public function getContainer();
 
     /**
      * Get the data domain array.

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -318,6 +318,10 @@ abstract class AbstractCommand extends Command
     {
         if ($this->getManager() === null) {
             $manager = new Manager($this->getConfig(), $input, $output);
+            $container = $this->config->getContainer();
+            if ($container !== null) {
+                $manager->setContainer($container);
+            }
             $this->setManager($manager);
         } else {
             $manager = $this->getManager();

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -620,7 +620,7 @@ class Manager
     /**
      * Sets the user defined PSR-11 container
      *
-     * @param ContainerInterface $container
+     * @param ContainerInterface $container Container
      */
     public function setContainer(ContainerInterface $container)
     {

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -913,8 +913,14 @@ class Manager
                     } else {
                         $seed = new $class();
                     }
-                    $seed->setInput($this->getInput());
-                    $seed->setOutput($this->getOutput());
+                    $input = $this->getInput();
+                    if ($input !== null) {
+                        $seed->setInput($input);
+                    }
+                    $output = $this->getOutput();
+                    if ($output !== null) {
+                        $seed->setOutput($output);
+                    }
 
                     if (!($seed instanceof AbstractSeed)) {
                         throw new InvalidArgumentException(sprintf(

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -40,17 +40,10 @@ abstract class AbstractSeed implements SeedInterface
     protected $output;
 
     /**
-     * @param \Symfony\Component\Console\Input\InputInterface|null $input Input
-     * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output
+     * Override to specify dependencies for dependency injection from the configured PSR-11 container
      */
-    final public function __construct(InputInterface $input = null, OutputInterface $output = null)
+    public function __construct()
     {
-        if ($input !== null) {
-            $this->setInput($input);
-        }
-        if ($output !== null) {
-            $this->setOutput($output);
-        }
     }
 
     /**


### PR DESCRIPTION
For our use-case of Phinx, we require some complex services for generating the correct seed data. This creates difficulties in having to manually instantiate all the services within the init methods of the Seed. If users could provide a PSR-11 container that implements the psr/container package interface then it would allow for much more flexability in this regard, including auto-wiring.