### PR TITLE
Simplify check for config in command bootstrap

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -103,9 +103,7 @@ abstract class AbstractCommand extends Command
      */
     public function bootstrap(InputInterface $input, OutputInterface $output)
     {
-        /** @var \Phinx\Config\ConfigInterface|null $config */
-        $config = $this->getConfig();
-        if (!$config) {
+        if (!$this->getConfig()) {
             $this->loadConfig($input, $output);
         }
 


### PR DESCRIPTION
The `$config` variable is not used beyond this check in the function, with everything after this point using `$this->getConfig()`. 