### PR TITLE
fix failing tests for mysql 8

### DIFF
--- a/.github/workflows/mysql8.yml
+++ b/.github/workflows/mysql8.yml
@@ -1,0 +1,47 @@
+name: MySQL 8
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  testsuite:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.4']
+    name: PHP ${{ matrix.php-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up PHP ${{ matrix.php-version }}
+      uses: shivammathur/setup-php@master
+      with:
+        php-version: ${{ matrix.php-version }}
+        overage: xdebug
+
+    - name: Setup MySQL
+      run: |
+        docker run --rm --name=mysqld --env MYSQL_DATABASE=phinx_testing --env MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 -d mysql:8 --default-authentication-plugin=mysql_native_password
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    - name: Run PHPUnit
+      env:
+        TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED: "true"
+        TESTS_PHINX_DB_ADAPTER_MYSQL_HOST: "127.0.0.1"
+        TESTS_PHINX_DB_ADAPTER_MYSQL_USERNAME: "root"
+        TESTS_PHINX_DB_ADAPTER_MYSQL_PASSWORD: ""
+        TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE: "phinx_testing"
+        TESTS_PHINX_DB_ADAPTER_MYSQL_PORT: "3306"
+      run: vendor/bin/phpunit --verbose --no-configuration --bootstrap tests/phpunit-bootstrap.php tests/

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -188,7 +188,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
 
         $rows = $this->adapter->fetchAll(sprintf(
-            "SELECT TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE table_schema='%s' AND table_name='ntable'",
+            "SELECT TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='ntable'",
             TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE
         ));
         $comment = $rows[0];

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1482,7 +1482,10 @@ class MysqlAdapterTest extends TestCase
               ->save();
 
         $rows = $this->adapter->fetchAll(sprintf(
-            "SELECT COLUMN_NAME, COLUMN_COMMENT FROM information_schema.columns WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='table1'",
+            "SELECT COLUMN_NAME, COLUMN_COMMENT
+            FROM information_schema.columns
+            WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='table1'
+            ORDER BY ORDINAL_POSITION",
             TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE
         ));
         $columnWithComment = $rows[1];

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -49,7 +49,7 @@ class MysqlAdapterTest extends TestCase
     }
 
     private function usingMysql8(): bool {
-        return version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '8') > -1;
+        return version_compare($this->adapter->getAttribute(\PDO::ATTR_SERVER_VERSION), '8.0.0', '>=');
     }
 
     public function testConnection()
@@ -548,8 +548,8 @@ class MysqlAdapterTest extends TestCase
             sprintf(
                 "SELECT TABLE_COMMENT
                     FROM INFORMATION_SCHEMA.TABLES
-                    WHERE table_schema='%s'
-                        AND table_name='%s'",
+                    WHERE TABLE_SCHEMA='%s'
+                        AND TABLE_NAME='%s'",
                 TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE,
                 'table1'
             )
@@ -570,8 +570,8 @@ class MysqlAdapterTest extends TestCase
             sprintf(
                 "SELECT TABLE_COMMENT
                     FROM INFORMATION_SCHEMA.TABLES
-                    WHERE table_schema='%s'
-                        AND table_name='%s'",
+                    WHERE TABLE_SCHEMA='%s'
+                        AND TABLE_NAME='%s'",
                 TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE,
                 'table1'
             )
@@ -592,8 +592,8 @@ class MysqlAdapterTest extends TestCase
             sprintf(
                 "SELECT TABLE_COMMENT
                     FROM INFORMATION_SCHEMA.TABLES
-                    WHERE table_schema='%s'
-                        AND table_name='%s'",
+                    WHERE TABLE_SCHEMA='%s'
+                        AND TABLE_NAME='%s'",
                 TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE,
                 'table1'
             )
@@ -1478,7 +1478,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
 
         $rows = $this->adapter->fetchAll(sprintf(
-            "SELECT COLUMN_NAME, COLUMN_COMMENT FROM information_schema.columns WHERE table_schema='%s' AND table_name='table1'",
+            "SELECT COLUMN_NAME, COLUMN_COMMENT FROM information_schema.columns WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='table1'",
             TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE
         ));
         $columnWithComment = $rows[1];


### PR DESCRIPTION
Closes #1751

MySQL 8.0.17 deprecated usage of the display width for integer data types, stating that it did not really do anything as it would allow integers to go beyond the specified width, and was only really used when you wanted to pad a number. The tests have been modified now to check on version of mysql to determine what the expected type for integer columns will be, but a more proper (and breaking) fix would be to probably not bother with display widths at all for MysqlAdapter.