### PR TITLE
add symfony/yaml back as dependency for 0.11.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,14 +29,14 @@
         "cakephp/collection": "^3.7",
         "cakephp/database": "^3.7",
         "symfony/console": "^3.4|^4.0|^5.0",
-        "symfony/config": "^3.4|^4.0|^5.0"
+        "symfony/config": "^3.4|^4.0|^5.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
         "ext-json": "*",
         "phpunit/phpunit": ">=5.7,<8.0",
         "sebastian/comparator": ">=1.2.3",
-        "cakephp/cakephp-codesniffer": "^3.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0"
+        "cakephp/cakephp-codesniffer": "^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As discussed with @dereuromark, this re-adds `symfony/yaml` as a dependency to the 0.11.x branch, as this was a breaking change and should have been held off on for 0.12.x release.

Follow-up here after merging would be:

* cut new 0.11.x release
* Update release notes for 0.12.x to mention this breaking change (symfony/yaml no longer installed by default, if using yaml conf file, you must install this dependency yourself).