### PR TITLE
Split parsing DSN out to utility helper

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -9,6 +9,7 @@ namespace Phinx\Config;
 
 use Closure;
 use InvalidArgumentException;
+use Phinx\Util\Util;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 use UnexpectedValueException;
@@ -471,20 +472,12 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      */
     protected function parseAgnosticDsn(array $options)
     {
-        if (isset($options['dsn']) && is_string($options['dsn'])) {
-            $regex = '#^(?P<adapter>[^\\:]+)\\://(?:(?P<user>[^\\:@]+)(?:\\:(?P<pass>[^@]*))?@)?' .
-                '(?P<host>[^\\:@/]+)(?:\\:(?P<port>[1-9]\\d*))?/(?P<name>[^\?]+)(?:\?(?P<query>.*))?$#';
-            if (preg_match($regex, trim($options['dsn']), $parsedOptions)) {
-                $additionalOpts = [];
-                if (isset($parsedOptions['query'])) {
-                    parse_str($parsedOptions['query'], $additionalOpts);
-                }
-                $validOptions = ['adapter', 'user', 'pass', 'host', 'port', 'name'];
-                $parsedOptions = array_filter(array_intersect_key($parsedOptions, array_flip($validOptions)));
-                $options = array_merge($additionalOpts, $parsedOptions, $options);
-                unset($options['dsn']);
-            }
+        $parsed = Util::parseDsn($options['dsn'] ?? '');
+        if ($parsed) {
+            unset($options['dsn']);
         }
+
+        $options = array_merge($parsed, $options);
 
         return $options;
     }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -155,7 +155,7 @@ class SQLiteAdapter extends PdoAdapter
             $options = $this->getOptions();
 
             // use a memory database if the option was specified
-            if (!empty($options['memory'])) {
+            if (!empty($options['memory']) || $options['name'] === static::MEMORY) {
                 $dsn = 'sqlite:' . static::MEMORY;
             } else {
                 $dsn = 'sqlite:' . $options['name'] . $this->suffix;

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -273,4 +273,55 @@ class Util
 
         return $files;
     }
+
+    /**
+     * Parses DSN string into db config array.
+     *
+     * @param string $dsn DSN string
+     * @return array
+     */
+    public static function parseDsn(string $dsn): array
+    {
+        $pattern = <<<'REGEXP'
+{
+    ^
+    (?:
+        (?P<adapter>[\w\\\\]+)://
+    )
+    (?:
+        (?P<user>.*?)
+        (?:
+            :(?P<pass>.*?)
+        )?
+        @
+    )?
+    (?:
+        (?P<host>[^?#/:@]+)
+        (?:
+            :(?P<port>\d+)
+        )?
+    )?
+    (?:
+        /(?P<name>[^?#]*)
+    )?
+    (?:
+        \?(?P<query>[^#]*)
+    )?
+    $
+}x
+REGEXP;
+
+        if (!preg_match($pattern, $dsn, $parsed)) {
+            return [];
+        }
+
+        // filter out everything except the matched groups
+        $config = array_intersect_key($parsed, array_flip(['adapter', 'user', 'pass', 'host', 'port', 'name']));
+        $config = array_filter($config);
+
+        parse_str($parsed['query'] ?? '', $query);
+        $config = array_merge($query, $config);
+
+        return $config;
+    }
 }

--- a/tests/Phinx/Config/ConfigDsnTest.php
+++ b/tests/Phinx/Config/ConfigDsnTest.php
@@ -117,17 +117,15 @@ class ConfigDsnTest extends AbstractConfigTest
             ['postgres://user:pass@host/name?'],
             ['mssql://user:@host:1234/name'],
             ['sqlite3://user@host:1234/name'],
+            ['sqlite3:///:memory:'],
             ['pdomock://host:1234/name'],
             ['pdomock://user:pass@host/name'],
             ['pdomock://host/name'],
-            // The RegEx that parses the DSN is purely to extract information
-            // from the string in the right order, it is not responsible for
-            // ensuring that the information is correct. Technically the
-            // following, whilst useless, is valid (validation will happen
-            // during connection):
-            ['£$%^&}{@>://$%*(*&^}{:?£}{@^>}"{$:1234/>@"}%{^>£}:/^'],
             ['pdomock://user:pass@host/:1234/name'],
             ['pdomock://user:pa:ss@host:1234/name'],
+            ['pdomock://user:pass@host:1234/ '],
+            ['pdomock://:pass@host:1234/name'],
+            ['pdomock://user:pass@host:01234/name'],
         ];
     }
 
@@ -135,13 +133,10 @@ class ConfigDsnTest extends AbstractConfigTest
     {
         return [
             ['pdomock://user:pass@host:/name'],
-            ['pdomock://user:pass@host:1234/ '],
             ['pdomock://user:pass@:1234/name'],
-            ['pdomock://:pass@host:1234/name'],
             ['://user:pass@host:1234/name'],
             ['pdomock:/user:p@ss@host:1234/name'],
             ['pdomock://user:pass@host:/1234name'],
-            ['pdomock://user:pass@host:01234/name'],
         ];
     }
 

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -14,32 +14,6 @@ use UnexpectedValueException;
 class ConfigTest extends AbstractConfigTest
 {
     /**
-     * @covers \Phinx\Config\Config::__construct
-     * @covers \Phinx\Config\Config::getConfigFilePath
-     */
-    public function testConstructEmptyArguments()
-    {
-        $config = new Config([]);
-        // this option is set to its default value when not being passed in the constructor, so we can ignore it
-        unset($config['version_order']);
-        $this->assertAttributeEmpty('values', $config);
-        $this->assertAttributeEmpty('configFilePath', $config);
-        $this->assertNull($config->getConfigFilePath());
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::__construct
-     * @covers \Phinx\Config\Config::getConfigFilePath
-     */
-    public function testConstructByArray()
-    {
-        $config = new Config($this->getConfigArray());
-        $this->assertAttributeNotEmpty('values', $config);
-        $this->assertAttributeEmpty('configFilePath', $config);
-        $this->assertNull($config->getConfigFilePath());
-    }
-
-    /**
      * @covers \Phinx\Config\Config::getEnvironments
      */
     public function testGetEnvironmentsMethod()

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -16,14 +16,7 @@ class TableTest extends TestCase
     public function provideTimestampColumnNames()
     {
         $result = [];
-        $adapters = array_filter(
-            [
-                TESTS_PHINX_DB_ADAPTER_SQLSRV_ENABLED ? new SqlServerAdapter([]) : false,
-                TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED ? new MysqlAdapter([]) : false,
-                TESTS_PHINX_DB_ADAPTER_POSTGRES_ENABLED ? new PostgresAdapter([]) : false,
-                TESTS_PHINX_DB_ADAPTER_SQLITE_ENABLED ? new SQLiteAdapter([]) : false,
-            ]
-        );
+        $adapters = [new SqlServerAdapter([]), new MysqlAdapter([]), new PostgresAdapter([]), new SQLiteAdapter([])];
         foreach ($adapters as $adapter) {
             $result = array_merge(
                 $result,


### PR DESCRIPTION
This is preparation for replacing all the unit test defines with DB_DSN env variables similar to cakephp core.

The regex was replaced with the regex used by `StaticConfigTrait::parseDsn()` with two behavior changes:

- `name` does not include the leading `/`
- There is no `fragment` string parsed, only `query`

The only originally valid pattern that is now rejected is the random character string. The adapter names can't be completely arbitrary symbols now.