### PR TITLE
Ignore limit option for binary type in postgres

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1163,12 +1163,14 @@ class PostgresAdapter extends PdoAdapter
                     $buffer[] = strtoupper('with time zone');
                 }
             } elseif (
-                !in_array($sqlType['name'], [
+                !in_array($column->getType(), [
+                    self::PHINX_TYPE_TINY_INTEGER,
+                    self::PHINX_TYPE_SMALL_INTEGER,
                     self::PHINX_TYPE_INTEGER,
-                    'smallint',
-                    'bigint',
+                    self::PHINX_TYPE_BIG_INTEGER,
                     self::PHINX_TYPE_BOOLEAN,
                     self::PHINX_TYPE_TEXT,
+                    self::PHINX_TYPE_BINARY,
                 ], true)
             ) {
                 if ($column->getLimit() || isset($sqlType['limit'])) {

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use Phinx\Db\Adapter\AbstractAdapter;
 use Phinx\Db\Adapter\PostgresAdapter;
 use Phinx\Db\Adapter\UnsupportedColumnTypeException;
 use Phinx\Db\Table\Column;
@@ -592,6 +593,33 @@ class PostgresAdapterTest extends TestCase
         $this->assertSame('limit_bool_false', $column->getName());
         $this->assertNotNull($column->getDefault());
         $this->assertSame('false', $column->getDefault());
+        $this->assertNull($column->getLimit());
+    }
+
+    public function providerIgnoresLimit(): array
+    {
+        return [
+            [AbstractAdapter::PHINX_TYPE_BOOLEAN],
+            [AbstractAdapter::PHINX_TYPE_TEXT],
+            [AbstractAdapter::PHINX_TYPE_BINARY],
+        ];
+    }
+
+    /**
+     * @dataProvider providerIgnoresLimit
+     */
+    public function testAddColumnIgnoresLimit($column_type)
+    {
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table->save();
+        $table->addColumn('column1', $column_type, ['limit' => 1]);
+        $table->save();
+
+        $columns = $this->adapter->getColumns('table1');
+        $this->assertCount(2, $columns);
+        $column = $columns[1];
+        $this->assertSame('column1', $column->getName());
+        $this->assertSame($column_type, $column->getType());
         $this->assertNull($column->getLimit());
     }
 


### PR DESCRIPTION
Closes #1736

The binary type (bytesa) in postgres does not accept a limit option and will throw an error if attempting to use one (e.g. bytesa (32)). This fixes it so that the limit clause is properly ignored for it.