### PR TITLE
Do not set precision for integer columns coming from postgres DB

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -440,10 +440,15 @@ class PostgresAdapter extends PdoAdapter
 
             if (in_array($columnType, [static::PHINX_TYPE_TIME, static::PHINX_TYPE_DATETIME], true)) {
                 $column->setPrecision($columnInfo['datetime_precision']);
-            } else {
+            } elseif (
+                !in_array($columnType, [
+                    self::PHINX_TYPE_SMALL_INTEGER,
+                    self::PHINX_TYPE_INTEGER,
+                    self::PHINX_TYPE_BIG_INTEGER,
+                ], true)
+            ) {
                 $column->setPrecision($columnInfo['numeric_precision']);
             }
-
             $columns[] = $column;
         }
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -599,6 +599,10 @@ class PostgresAdapterTest extends TestCase
     public function providerIgnoresLimit(): array
     {
         return [
+            [AbstractAdapter::PHINX_TYPE_TINY_INTEGER, AbstractAdapter::PHINX_TYPE_SMALL_INTEGER],
+            [AbstractAdapter::PHINX_TYPE_SMALL_INTEGER],
+            [AbstractAdapter::PHINX_TYPE_INTEGER],
+            [AbstractAdapter::PHINX_TYPE_BIG_INTEGER],
             [AbstractAdapter::PHINX_TYPE_BOOLEAN],
             [AbstractAdapter::PHINX_TYPE_TEXT],
             [AbstractAdapter::PHINX_TYPE_BINARY],
@@ -608,7 +612,7 @@ class PostgresAdapterTest extends TestCase
     /**
      * @dataProvider providerIgnoresLimit
      */
-    public function testAddColumnIgnoresLimit($column_type)
+    public function testAddColumnIgnoresLimit(string $column_type, ?string $actual_type = null): void
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->save();
@@ -619,7 +623,7 @@ class PostgresAdapterTest extends TestCase
         $this->assertCount(2, $columns);
         $column = $columns[1];
         $this->assertSame('column1', $column->getName());
-        $this->assertSame($column_type, $column->getType());
+        $this->assertSame($actual_type ?? $column_type, $column->getType());
         $this->assertNull($column->getLimit());
     }
 


### PR DESCRIPTION
The code would use the value of numeric_precision to set a limit on integer columns. For integer values, this is set to the max range of the type (e.g. 2^32 for integer), but is not actually something the user can meaningfully use, nor has a counterpart for info coming into postgres in a migration, so better to just report null for limit instead.