### PR TITLE
Allow name to be optional for create command

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -41,7 +41,7 @@ class Create extends AbstractCommand
         parent::configure();
 
         $this->setDescription('Create a new migration')
-            ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the migration (in CamelCase)?')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Class name of the migration (in CamelCase)')
             ->setHelp(sprintf(
                 '%sCreates a new database migration%s',
                 PHP_EOL,
@@ -165,12 +165,20 @@ class Create extends AbstractCommand
 
         $path = realpath($path);
         $className = $input->getArgument('name');
+        if ($className === null) {
+            $currentTimestamp = Util::getCurrentTimestamp();
+            $className = "V" . $currentTimestamp;
+            $fileName = $currentTimestamp . '.php';
+        } else {
+            if (!Util::isValidPhinxClassName($className)) {
+                throw new InvalidArgumentException(sprintf(
+                    'The migration class name "%s" is invalid. Please use CamelCase format.',
+                    $className
+                ));
+            }
 
-        if (!Util::isValidPhinxClassName($className)) {
-            throw new InvalidArgumentException(sprintf(
-                'The migration class name "%s" is invalid. Please use CamelCase format.',
-                $className
-            ));
+            // Compute the file path
+            $fileName = Util::mapClassNameToFileName($className);
         }
 
         if (!Util::isUniqueMigrationClassName($className, $path)) {
@@ -181,8 +189,6 @@ class Create extends AbstractCommand
             ));
         }
 
-        // Compute the file path
-        $fileName = Util::mapClassNameToFileName($className);
         $filePath = $path . DIRECTORY_SEPARATOR . $fileName;
 
         if (is_file($filePath)) {

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -26,6 +26,11 @@ class Util
     /**
      * @var string
      */
+    protected const MIGRATION_FILE_NAME_NO_NAME_PATTERN = '/^[0-9]{14}\.php$/';
+
+    /**
+     * @var string
+     */
     protected const SEED_FILE_NAME_PATTERN = '/^([a-z][a-z\d]*)\.php$/i';
 
     /**
@@ -116,11 +121,13 @@ class Util
      *
      * @return string
      */
-    public static function mapFileNameToClassName($fileName)
+    public static function mapFileNameToClassName(string $fileName): string
     {
         $matches = [];
         if (preg_match(static::MIGRATION_FILE_NAME_PATTERN, $fileName, $matches)) {
             $fileName = $matches[1];
+        } elseif (preg_match(static::MIGRATION_FILE_NAME_NO_NAME_PATTERN, $fileName)) {
+            return "V" . substr($fileName, 0, strlen($fileName) - 4);
         }
 
         $className = str_replace('_', '', ucwords($fileName, '_'));
@@ -174,9 +181,12 @@ class Util
      *
      * @return bool
      */
-    public static function isValidMigrationFileName($fileName)
+    public static function isValidMigrationFileName(string $fileName): bool
     {
-        return (bool)preg_match(static::MIGRATION_FILE_NAME_PATTERN, $fileName);
+        return (
+            (bool)preg_match(static::MIGRATION_FILE_NAME_PATTERN, $fileName)
+            || (bool)preg_match(static::MIGRATION_FILE_NAME_NO_NAME_PATTERN, $fileName)
+        );
     }
 
     /**

--- a/tests/Phinx/TestUtils.php
+++ b/tests/Phinx/TestUtils.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Test\Phinx;
+
+class TestUtils
+{
+    /**
+     * Recursive rmdir
+     *
+     * It will delete all files under the directory, and then the directory.
+     *
+     * @param string $path path to directory to delete
+     */
+    public static function recursiveRmdir(string $path): void
+    {
+        if (!file_exists($path)) {
+            return;
+        }
+        if (!is_dir($path)) {
+            unlink($path);
+
+            return;
+        }
+        $dir = new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS);
+        $iter = new \RecursiveIteratorIterator($dir, \RecursiveIteratorIterator::CHILD_FIRST);
+        foreach ($iter as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -47,52 +47,66 @@ class UtilTest extends TestCase
         $this->assertLessThanOrEqual($expected + 2, $current);
     }
 
-    public function testMapClassNameToFileName()
+    public function providerMapClassNameToFileName(): array
     {
-        $expectedResults = [
-            'CamelCase87afterSomeBooze' => '/^\d{14}_camel_case_87after_some_booze\.php$/',
-            'CreateUserTable' => '/^\d{14}_create_user_table\.php$/',
-            'LimitResourceNamesTo30Chars' => '/^\d{14}_limit_resource_names_to_30_chars\.php$/',
+        return [
+            ['CamelCase87afterSomeBooze', '/^\d{14}_camel_case_87after_some_booze\.php$/'],
+            ['CreateUserTable', '/^\d{14}_create_user_table\.php$/'],
+            ['LimitResourceNamesTo30Chars', '/^\d{14}_limit_resource_names_to_30_chars\.php$/'],
         ];
-
-        foreach ($expectedResults as $input => $expectedResult) {
-            $this->assertRegExp($expectedResult, Util::mapClassNameToFileName($input));
-        }
     }
 
-    public function testMapFileNameToClassName()
+    /**
+     * @dataProvider providerMapClassNameToFileName
+     */
+    public function testMapClassNameToFileName(string $name, string $pattern): void
     {
-        $expectedResults = [
-            '20150902094024_create_user_table.php' => 'CreateUserTable',
-            '20150902102548_my_first_migration2.php' => 'MyFirstMigration2',
-            '20200412012035_camel_case_87after_some_booze.php' => 'CamelCase87afterSomeBooze',
-            '20200412012036_limit_resource_names_to_30_chars.php' => 'LimitResourceNamesTo30Chars',
-            '20200412012037_back_compat_names_to30_chars.php' => 'BackCompatNamesTo30Chars',
-        ];
-
-        foreach ($expectedResults as $input => $expectedResult) {
-            $this->assertEquals($expectedResult, Util::mapFileNameToClassName($input));
-        }
+        $this->assertRegExp($pattern, Util::mapClassNameToFileName($name));
     }
 
-    public function testisValidPhinxClassName()
+    public function providerMapFileName(): array
     {
-        $expectedResults = [
-            'camelCase' => false,
-            'CreateUserTable' => true,
-            'UserSeeder' => true,
-            'Test' => true,
-            'test' => false,
-            'Q' => true,
-            'XMLTriggers' => true,
-            'Form_Cards' => false,
-            'snake_high_scores' => false,
-            'Code2319Incidents' => true,
+        return [
+            ['20150902094024_create_user_table.php', 'CreateUserTable'],
+            ['20150902102548_my_first_migration2.php', 'MyFirstMigration2'],
+            ['20200412012035_camel_case_87after_some_booze.php', 'CamelCase87afterSomeBooze'],
+            ['20200412012036_limit_resource_names_to_30_chars.php', 'LimitResourceNamesTo30Chars'],
+            ['20200412012037_back_compat_names_to30_chars.php', 'BackCompatNamesTo30Chars'],
+            ['20200412012037.php', 'V20200412012037'],
         ];
+    }
 
-        foreach ($expectedResults as $input => $expectedResult) {
-            $this->assertEquals($expectedResult, Util::isValidPhinxClassName($input));
-        }
+    /**
+     * @dataProvider providerMapFileName
+     */
+    public function testMapFileNameToClassName(string $fileName, string $className)
+    {
+        $this->assertEquals($className, Util::mapFileNameToClassName($fileName));
+    }
+
+    public function providerValidClassName(): array
+    {
+        return [
+            ['camelCase', false],
+            ['CreateUserTable', true],
+            ['UserSeeder', true],
+            ['Test', true],
+            ['test', false],
+            ['Q', true],
+            ['XMLTriggers', true],
+            ['Form_Cards', false],
+            ['snake_high_scores', false],
+            ['Code2319Incidents', true],
+            ['V20200509232007', true],
+        ];
+    }
+
+    /**
+     * @dataProvider providerValidClassName
+     */
+    public function testIsValidPhinxClassName(string $className, bool $valid): void
+    {
+        $this->assertSame($valid, Util::isValidPhinxClassName($className));
     }
 
     public function testGlobPath()


### PR DESCRIPTION
Closes #566 (if it wasn't already closed for being "inactive"...)

Currently, the create command requires a name to be provided, and this is used for a suffix on the filename and then as the class name. This PR makes the name optional, such that if it is omitted, the system will automatically generate a name that is valid. The filename is "<datetime>_migration.php" and the class name is "V<Datetime>".

The filename is set-up such as the way it is since the classname must start with a string, and the `V` is for a future suggestion of potentially making phinx migration files be PSR-4 discoverable.