### PR TITLE
update gitignore rules for doc builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,12 @@ tests/log
 /migrations/
 /phinx.yml
 
+# python artifacts
+*.pyc
+
 # sphinx generates HTML files for the documentation here
 docs/_build
+docs/*/_build/
 
 # composer installed dependencies
 vendor/


### PR DESCRIPTION
Running sphinx build generated a number of files that are not currently caught by .gitignore.