### PR TITLE
Consolidate environment and environmentOptions printing for commands

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -401,4 +401,73 @@ abstract class AbstractCommand extends Command
     {
         return __DIR__ . self::DEFAULT_SEED_TEMPLATE;
     }
+
+    /**
+     * Gets environment to use for command.
+     *
+     * @return string|null name of environment, null if could not be found
+     */
+    protected function getEnvironment(InputInterface $input, OutputInterface $output): ?string
+    {
+        $environment = $input->getOption('environment');
+
+        if ($environment === null) {
+            $environment = $this->getConfig()->getDefaultEnvironment();
+            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
+        } else {
+            $output->writeln('<info>using environment</info> ' . $environment);
+        }
+
+        if (!$this->getConfig()->hasEnvironment($environment)) {
+            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
+
+            return null;
+        }
+
+        return $environment;
+    }
+
+    /**
+     * Prints out general runtime information about loaded environment.
+     *
+     * @param array|null $envOptions environment options
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
+     * @return bool
+     */
+    protected function checkEnvironmentOptions(?array $envOptions, OutputInterface $output): bool
+    {
+        if (isset($envOptions['adapter'])) {
+            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
+        }
+
+        if (isset($envOptions['wrapper'])) {
+            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
+        }
+
+        if (
+            isset($envOptions['adapter'])
+            && $envOptions['adapter'] === 'sqlite'
+            && isset($envOptions['memory'])
+            && $envOptions['memory'] === true
+        ) {
+            $output->writeln('<info>using :memory: database</info>');
+        } elseif (isset($envOptions['name'])) {
+            $output->writeln('<info>using database</info> ' . $envOptions['name']);
+        } else {
+            $output->writeln(
+                '<error>Could not determine database name! Please specify a database name in your config file.</error>'
+            );
+
+            return false;
+        }
+
+        if (isset($envOptions['table_prefix'])) {
+            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix']);
+        }
+        if (isset($envOptions['table_suffix'])) {
+            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
+        }
+
+        return true;
+    }
 }

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -62,22 +62,13 @@ EOT
     {
         $this->bootstrap($input, $output);
 
-        $environment = $input->getOption('environment');
         $version = (int)$input->getOption('target') ?: null;
         $removeAll = $input->getOption('remove-all');
         $set = $input->getOption('set');
         $unset = $input->getOption('unset');
 
+        $environment = $this->getEnvironment($input, $output);
         if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
             return self::CODE_ERROR;
         }
 

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -63,45 +63,17 @@ EOT
         $this->bootstrap($input, $output);
 
         $version = $input->getOption('target');
-        $environment = $input->getOption('environment');
         $date = $input->getOption('date');
         $fake = (bool)$input->getOption('fake');
 
+        $environment = $this->getEnvironment($input, $output);
         if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
             return self::CODE_ERROR;
         }
 
         $envOptions = $this->getConfig()->getEnvironment($environment);
-        if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
-        }
-
-        if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
-        }
-
-        if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name']);
-        } else {
-            $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
-
+        if (!$this->checkEnvironmentOptions($envOptions, $output)) {
             return self::CODE_ERROR;
-        }
-
-        if (isset($envOptions['table_prefix'])) {
-            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix']);
-        }
-        if (isset($envOptions['table_suffix'])) {
-            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -70,38 +70,19 @@ EOT
     {
         $this->bootstrap($input, $output);
 
-        $environment = $input->getOption('environment');
         $version = $input->getOption('target');
         $date = $input->getOption('date');
         $force = (bool)$input->getOption('force');
         $fake = (bool)$input->getOption('fake');
 
-        $config = $this->getConfig();
-
+        $environment = $this->getEnvironment($input, $output);
         if ($environment === null) {
-            $environment = $config->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
             return self::CODE_ERROR;
         }
 
-        $envOptions = $config->getEnvironment($environment);
-        if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
-        }
-
-        if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
-        }
-
-        if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name']);
+        $envOptions = $this->getConfig()->getEnvironment($environment);
+        if (!$this->checkEnvironmentOptions($envOptions, $output)) {
+            return self::CODE_ERROR;
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -57,43 +57,14 @@ EOT
         $this->bootstrap($input, $output);
 
         $seedSet = $input->getOption('seed');
-        $environment = $input->getOption('environment');
-
+        $environment = $this->getEnvironment($input, $output);
         if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
             return self::CODE_ERROR;
         }
 
         $envOptions = $this->getConfig()->getEnvironment($environment);
-        if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
-        }
-
-        if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
-        }
-
-        if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name']);
-        } else {
-            $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
-
+        if (!$this->checkEnvironmentOptions($envOptions, $output)) {
             return self::CODE_ERROR;
-        }
-
-        if (isset($envOptions['table_prefix'])) {
-            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix']);
-        }
-        if (isset($envOptions['table_suffix'])) {
-            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
         }
 
         $start = microtime(true);

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -55,19 +55,10 @@ EOT
     {
         $this->bootstrap($input, $output);
 
-        $environment = $input->getOption('environment');
         $format = $input->getOption('format');
 
+        $environment = $this->getEnvironment($input, $output);
         if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
             return self::CODE_ERROR;
         }
 

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -232,4 +232,53 @@ class SeedRunTest extends TestCase
 
         $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
     }
+
+    public function testSeedRunMemorySqlite()
+    {
+        $config = new Config([
+            'paths' => [
+                'migrations' => __FILE__,
+                'seeds' => __FILE__,
+            ],
+            'environments' => [
+                'default_migration_table' => 'phinxlog',
+                'default_environment' => 'development',
+                'development' => [
+                    'adapter' => 'sqlite',
+                    'memory' => true,
+                ],
+            ],
+        ]);
+
+        $application = new PhinxApplication();
+        $application->add(new SeedRun());
+
+        /** @var SeedRun $command */
+        $command = $application->find('seed:run');
+
+        // mock the manager class
+        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$config, $this->input, $this->output])
+            ->getMock();
+        $managerStub->expects($this->once())
+                    ->method('seed')
+                    ->with('development', null);
+
+        $command->setConfig($config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute(
+            [
+                'command' => $command->getName(),
+                '--environment' => 'development',
+            ],
+            ['decorated' => false]
+        );
+
+        $eol = PHP_EOL;
+        $this->assertRegExp("/using environment development{$eol}using adapter sqlite{$eol}using :memory: database{$eol}/", $commandTester->getDisplay());
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
+    }
 }


### PR DESCRIPTION
Closes #1116

Several commands were using the same sequence of checks and outputs for getting the environment string, as well as then printing out details about the environment. This commit consolidates all of that repeated code into two functions within AbstractCommand. As part of this, also fixed the bug of not being able to use sqlite memory database without also setting a db name.