### PR TITLE
Fix having to set name in config when using sqlite memory option

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -9,6 +9,7 @@ namespace Phinx\Config;
 
 use Closure;
 use InvalidArgumentException;
+use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Util\Util;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
@@ -165,6 +166,14 @@ class Config implements ConfigInterface, NamespaceAwareInterface
             if (isset($this->values['environments']['default_migration_table'])) {
                 $environments[$name]['default_migration_table'] =
                     $this->values['environments']['default_migration_table'];
+            }
+
+            if (
+                isset($environments[$name]['adapter'])
+                && $environments[$name]['adapter'] === 'sqlite'
+                && !empty($environments[$name]['memory'])
+            ) {
+                $environments[$name]['name'] = SQLiteAdapter::MEMORY;
             }
 
             return $this->parseAgnosticDsn($environments[$name]);

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -30,7 +30,7 @@ use RuntimeException;
  */
 class SQLiteAdapter extends PdoAdapter
 {
-    protected const MEMORY = ':memory:';
+    public const MEMORY = ':memory:';
 
     /**
      * List of supported Phinx column types with their SQL equivalents

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -323,4 +323,53 @@ class ConfigTest extends AbstractConfigTest
             unset($_ENV['PHINX_TEST_CONFIG_SUFFIX']);
         }
     }
+
+    public function testSqliteMemorySetsName()
+    {
+        $config = new \Phinx\Config\Config([
+            'environments' => [
+                'production' => [
+                    'adapter' => 'sqlite',
+                    'memory' => true,
+                ],
+            ],
+        ]);
+        $this->assertSame(
+            ['adapter' => 'sqlite', 'memory' => true, 'name' => ':memory:'],
+            $config->getEnvironment('production')
+        );
+    }
+
+    public function testSqliteMemoryOverridesName()
+    {
+        $config = new \Phinx\Config\Config([
+            'environments' => [
+                'production' => [
+                    'adapter' => 'sqlite',
+                    'memory' => true,
+                    'name' => 'blah',
+                ],
+            ],
+        ]);
+        $this->assertSame(
+            ['adapter' => 'sqlite', 'memory' => true, 'name' => ':memory:'],
+            $config->getEnvironment('production')
+        );
+    }
+
+    public function testSqliteNonBooleanMemory()
+    {
+        $config = new \Phinx\Config\Config([
+            'environments' => [
+                'production' => [
+                    'adapter' => 'sqlite',
+                    'memory' => "yes",
+                ],
+            ],
+        ]);
+        $this->assertSame(
+            ['adapter' => 'sqlite', 'memory' => "yes", 'name' => ':memory:'],
+            $config->getEnvironment('production')
+        );
+    }
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -259,4 +259,49 @@ class MigrateTest extends TestCase
         $this->assertRegExp('/ordering by execution time/', $output);
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
+
+    public function testMigrateMemorySqlite()
+    {
+        $config = new Config([
+            'paths' => [
+                'migrations' => __FILE__,
+            ],
+            'environments' => [
+                'default_migration_table' => 'phinxlog',
+                'default_environment' => 'development',
+                'development' => [
+                    'adapter' => 'sqlite',
+                    'memory' => true,
+                ],
+            ],
+        ]);
+
+        $application = new PhinxApplication();
+        $application->add(new Migrate());
+
+        /** @var Migrate $command */
+        $command = $application->find('migrate');
+
+        // mock the manager class
+        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs([$config, $this->input, $this->output])
+            ->getMock();
+        $managerStub->expects($this->once())
+                    ->method('migrate');
+
+        $command->setConfig($config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
+
+        $this->assertStringContainsString(implode(PHP_EOL, [
+            "using environment development",
+            "using adapter sqlite",
+            "using database :memory:",
+            "ordering by creation time",
+        ]) . PHP_EOL, $commandTester->getDisplay());
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
+    }
 }


### PR DESCRIPTION
Closes #1116.
Opened this more focused PR as #1773 was focused too heavily on the refactoring, and the discussion got me to think of a more elegant fix that bypasses the need for any of the refactoring anyway.

While the config test covers the fix well enough, leaving in the tests for the three affected commands as that is where people were hitting this bug, and also for just general validation of command output is good (as the tests are kind of severely lacking it overall).

The phinx docs specify that you can do the following:

adapter: sqlite
memory: true

and it will give you the in-memory DB of sqlite to use. However, before this commit, this would throw an error in migrate saying that "name" was not set, requiring you to add "name" with a bogus value to the above to get it work. This commit fixes it by having it such that if memory option is set for sqlite, then just always set name to :memory: regardless of what name was set to, retaining BC and fixing the bug. Doing it this way also makes doing the above equivalent to doing:

adapter: sqlite
name: :memory:

which is more inline with the general sqlite documentation on how to think of the :memory: database name and phinx already had proper logic set-up to handle those values correctly.

Note: while the docs themselves expressly say to use `memory => true` for using the in-memory DB, the adapter itself does an `!empty($options['memory'])` check only, so mimicking that here.