### PR TITLE
Use ordinal_position for postgres getColumns

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -393,7 +393,8 @@ class PostgresAdapter extends PdoAdapter
              column_default, character_maximum_length, numeric_precision, numeric_scale,
              datetime_precision
              FROM information_schema.columns
-             WHERE table_schema = %s AND table_name = %s',
+             WHERE table_schema = %s AND table_name = %s
+             ORDER BY ordinal_position',
             $this->getConnection()->quote($parts['schema']),
             $this->getConnection()->quote($parts['table'])
         );


### PR DESCRIPTION
This ensures that getColumns will return results in column order and not potentially row order in the information_schema.columns table. While it's fairly impossible to get in this situation as the columns table is a view of an underlying system table, better to just follow best practices regardless in querying the table.

Due to the somewhat impossibility of actually getting columns to be out of order in the `getColumns` function to show a bug here (and without running the high risk of totally breaking postgres public schema), no test case is provided. However, as stated above, doing this is best practices, and does not leave phinx reliant on postgres implementation details that may or may not ever change. For reference, SQLServer already has the order by clause and MySQL and SQLite both get column definitions in a different fashion.