### PR TITLE
Fix docstring return type for child methods that always throw

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -453,7 +453,7 @@ class SQLiteAdapter extends PdoAdapter
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * SQLiteAdapter does not implement this functionality, and so will always throw an exception if used.
      *
@@ -1291,7 +1291,7 @@ PCRE_PATTERN;
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * SQLiteAdapter does not implement this functionality, and so will always throw an exception if used.
      *

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -455,9 +455,9 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * {@inheritDoc}
      *
-     * @throws \BadMethodCallException
+     * SQLiteAdapter does not implement this functionality, and so will always throw an exception if used.
      *
-     * @return void
+     * @throws \BadMethodCallException
      */
     protected function getChangeCommentInstructions(Table $table, $newComment)
     {
@@ -1293,9 +1293,9 @@ PCRE_PATTERN;
     /**
      * {@inheritDoc}
      *
-     * @throws \BadMethodCallException
+     * SQLiteAdapter does not implement this functionality, and so will always throw an exception if used.
      *
-     * @return void
+     * @throws \BadMethodCallException
      */
     protected function getDropForeignKeyInstructions($tableName, $constraint)
     {

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -329,7 +329,7 @@ class SqlServerAdapter extends PdoAdapter
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * SqlServer does not implement this functionality, and so will always throw an exception if used.
      *

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -331,13 +331,13 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * {@inheritDoc}
      *
-     * @throws \BadMethodCallException
+     * SqlServer does not implement this functionality, and so will always throw an exception if used.
      *
-     * @return void
+     * @throws \BadMethodCallException
      */
     protected function getChangeCommentInstructions(Table $table, $newComment)
     {
-        throw new BadMethodCallException('SQLite does not have table comments');
+        throw new BadMethodCallException('SqlServer does not have table comments');
     }
 
     /**


### PR DESCRIPTION
phpstan 0.12.24 added the capacity to handle merging phpdocs, which was not the case for three functions which always threw, and so defined themselves as returning void. This removes the incompatible return, and adds a note to the functions that they always throw.