### PR TITLE
simplify PdoAdapter fetch functions

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -214,9 +214,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function fetchRow($sql)
     {
-        $result = $this->query($sql);
-
-        return $result->fetch();
+        return $this->query($sql)->fetch();
     }
 
     /**
@@ -224,13 +222,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function fetchAll($sql)
     {
-        $rows = [];
-        $result = $this->query($sql);
-        while ($row = $result->fetch()) {
-            $rows[] = $row;
-        }
-
-        return $rows;
+        return $this->query($sql)->fetchAll();
     }
 
     /**


### PR DESCRIPTION
Simplifies the fetch functions in the PDOAdapter as they defined temporary variables they did not need, and `fetchAll` used a while loop to collect results instead of just using the native fetchAll function off the PDO class.