### PR TITLE
Set default timezone if not set in php.ini for cli

### DIFF
--- a/app/phinx.php
+++ b/app/phinx.php
@@ -25,6 +25,10 @@
 
 $autoloader = require __DIR__ . '/../src/composer_autoloader.php';
 
+if (!ini_get('date.timezone')) {
+    date_default_timezone_set('UTC');
+}
+
 if (!$autoloader()) {
     die(
         'You need to set up the project dependencies using the following commands:' . PHP_EOL .


### PR DESCRIPTION
Closes #852 

If the php.ini setting is not set, then PHP will always fallback to UTC and issue a warning, which will get issued in the middle of a run. This just explicitly sets the timezone to UTC when using the CLI app if it's not set.

This maybe should issue a warning if we set it, or I guess just document it in the release notes that this happens, though given how little this was reported, it's also maybe probable this does not affect a ton of people.