### PR TITLE
Fix gh-actions mysql8 workflow

### DIFF
--- a/.github/workflows/mysql8.yml
+++ b/.github/workflows/mysql8.yml
@@ -38,5 +38,5 @@ jobs:
 
     - name: Run PHPUnit
       env:
-        MYSQL_DSN='mysql://root@127.0.0.1/phinx_testing'
+        MYSQL_DSN: 'mysql://root@127.0.0.1/phinx_testing'
       run: vendor/bin/phpunit --verbose --no-configuration --bootstrap tests/phpunit-bootstrap.php tests/


### PR DESCRIPTION
#1782 broke the mysql8 github actions workflow as it converted the environment variable to an invalid yaml key/value, using a `=` instead of a `:` between the key and value in a dictionary.

Example of broken run: https://github.com/cakephp/phinx/actions/runs/107320570