### PR TITLE
replace phinx.yml with more generic words in docs

### DIFF
--- a/docs/en/commands.rst
+++ b/docs/en/commands.rst
@@ -50,7 +50,7 @@ CamelCase format.
 
 Open the new migration file in your text editor to add your database
 transformations. Phinx creates migration files using the path specified in your
-``phinx.yml`` file. Please see the :doc:`Configuration <configuration>` chapter
+phinx configuration file. Please see the :doc:`Configuration <configuration>` chapter
 for more information.
 
 You are able to override the template file used by Phinx by supplying an
@@ -180,7 +180,7 @@ Use ``--dry-run`` to print the queries to standard output without executing them
 
         When rolling back, Phinx orders the executed migrations using
         the order specified in the ``version_order`` option of your
-        ``phinx.yml`` file.
+        phinx configuration file.
         Please see the :doc:`Configuration <configuration>` chapter for more information.
 
 The Status Command
@@ -212,7 +212,7 @@ in CamelCase format.
         $ phinx seed:create MyNewSeeder
 
 Open the new seed file in your text editor to add your database seed commands.
-Phinx creates seed files using the path specified in your ``phinx.yml`` file.
+Phinx creates seed files using the path specified in your configuration file.
 Please see the :doc:`Configuration <configuration>` chapter for more information.
 
 The Seed Run Command
@@ -336,7 +336,7 @@ Luckily, Symfony makes doing this sort of "meta" command straight-forward:
         $arguments = [
             'command'         => 'migrate',
             '--environment'   => 'production',
-            '--configuration' => '/path/to/config/phinx.yml'
+            '--configuration' => '/path/to/phinx/config/file'
         ];
 
         $input = new ArrayInput($arguments);

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -57,10 +57,10 @@ The first option specifies the path to your migration directory. Phinx uses
 .. note::
 
     ``%%PHINX_CONFIG_DIR%%`` is a special token and is automatically replaced
-    with the root directory where your ``phinx.yml`` file is stored.
+    with the root directory where your phinx configuration file is stored.
 
 In order to overwrite the default ``%%PHINX_CONFIG_DIR%%/db/migrations``, you
-need to add the following to the yaml configuration.
+need to add the following to the configuration.
 
 .. code-block:: yaml
 
@@ -112,7 +112,7 @@ The second option specifies the path to your seed directory. Phinx uses
 .. note::
 
     ``%%PHINX_CONFIG_DIR%%`` is a special token and is automatically replaced
-    with the root directory where your ``phinx.yml`` file is stored.
+    with the root directory where your configuration file is stored.
 
 In order to overwrite the default ``%%PHINX_CONFIG_DIR%%/db/seeds``, you
 need to add the following to the yaml configuration.


### PR DESCRIPTION
The docs used `phinx.yml file` in a number of places where it would be better to use a more generic phrase like `phinx configuration file`, which better reflects that the config file could be in multiple different formats.