### PR TITLE
use php as default configuration file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ tests/log
 /db/
 /migrations/
 /phinx.yml
+/phinx.yaml
+/phinx.php
+/phinx.json
 
 # python artifacts
 *.pyc

--- a/docs/en/commands.rst
+++ b/docs/en/commands.rst
@@ -77,27 +77,30 @@ The Init Command
 ----------------
 
 The Init command (short for initialize) is used to prepare your project for
-Phinx. This command generates the ``phinx.yml`` file in the root of your
-project directory.
+Phinx. This command generates the phinx configuration file in the root of your
+project directory. By default, this file will be named ``phinx.php``.
 
 .. code-block:: bash
 
-        $ cd yourapp
         $ phinx init
 
 Optionally you can specify a custom location for Phinx's config file:
 
 .. code-block:: bash
 
-        $ cd yourapp
         $ phinx init ./custom/location/
 
 You can also specify a custom file name:
 
 .. code-block:: bash
 
-        $ cd yourapp
         $ phinx init custom-config.yml
+
+As well as a different format from php, yml, and json. For example, to create yml file:
+
+... code-block:: bash
+
+        $ phinx init --format yml
 
 Open this file in your text editor to setup your project configuration. Please
 see the :doc:`Configuration <configuration>` chapter for more information.

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -31,6 +31,7 @@ abstract class AbstractCommand extends Command
     public const FORMAT_YML_ALIAS = 'yaml';
     public const FORMAT_YML = 'yml';
     public const FORMAT_PHP = 'php';
+    public const FORMAT_DEFAULT = 'php';
 
     /**
      * The location of the default migration template.
@@ -229,7 +230,7 @@ abstract class AbstractCommand extends Command
 
         $cwd = getcwd();
 
-        // locate the phinx config file (default: phinx.yml)
+        // locate the phinx config file
         // In future walk the tree in reverse (max 10 levels)
         $locator = new FileLocator([
             $cwd . DIRECTORY_SEPARATOR,
@@ -276,13 +277,14 @@ abstract class AbstractCommand extends Command
                 case self::FORMAT_JSON:
                     $parser = self::FORMAT_JSON;
                     break;
-                case self::FORMAT_PHP:
-                    $parser = self::FORMAT_PHP;
-                    break;
                 case self::FORMAT_YML_ALIAS:
                 case self::FORMAT_YML:
-                default:
                     $parser = self::FORMAT_YML;
+                    break;
+                case self::FORMAT_PHP:
+                default:
+                    $parser = self::FORMAT_DEFAULT;
+                    break;
             }
         }
 

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -41,7 +41,13 @@ class Init extends Command
     protected function configure()
     {
         $this->setDescription('Initialize the application for Phinx')
-            ->addOption('--format', '-f', InputArgument::OPTIONAL, 'What format should we use to initialize?', 'yml')
+            ->addOption(
+                '--format',
+                '-f',
+                InputArgument::OPTIONAL,
+                'What format should we use to initialize?',
+                AbstractCommand::FORMAT_DEFAULT
+            )
             ->addArgument('path', InputArgument::OPTIONAL, 'Which path should we initialize for Phinx?')
             ->setHelp(sprintf(
                 '%sInitializes the application for Phinx%s',
@@ -133,7 +139,7 @@ class Init extends Command
      *
      * @return void
      */
-    protected function writeConfig($path, $format = AbstractCommand::FORMAT_YML)
+    protected function writeConfig($path, $format = AbstractCommand::FORMAT_DEFAULT)
     {
         // Check if dir is writable
         $dirname = dirname($path);

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -54,7 +54,7 @@ class InitTest extends TestCase
     public function testDefaultConfigIsWritten()
     {
         $this->writeConfig();
-        $this->assertFileExists(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.yml', 'Default format was not yaml');
+        $this->assertFileExists(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.php', 'Default format was not php');
     }
 
     public function formatDataProvider()
@@ -95,12 +95,12 @@ class InitTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
         $this->assertRegExp(
-            "/created (.*)[\/\\\\]phinx.yml\\n/",
+            "/created (.*)[\/\\\\]phinx\.php\\n/",
             $commandTester->getDisplay(true)
         );
 
         $this->assertFileExists(
-            'phinx.yml',
+            'phinx.php',
             'Phinx configuration not existent'
         );
 
@@ -134,7 +134,7 @@ class InitTest extends TestCase
 
     public function testThrowsExceptionWhenConfigFilePresent()
     {
-        touch(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.yml');
+        touch(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.php');
         $application = new PhinxApplication();
         $application->add(new Init());
 


### PR DESCRIPTION
Wasn't sure if this should be on 0.13 or 0.12 as on the one hand it's a BC break, on the other hand, the current default (yml) does not work out of the box on 0.12 due to the making optional of symfony/yaml.

In 0.12, the symfony/yaml extension was made optional, which means it may no longer be available in a user's environment. As such, phinx should not default to using it for `init` as it may generate a file the user cannot actually use. Instead, we use `php` as the default as it's guaranteed to always work and be an available parser (as `ext_json` is equally optional).

Closes #1726