### PR TITLE
addTimestamps: update updated_at timestamp on row update

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -551,6 +551,7 @@ class Table
              ->addColumn($updatedAt, 'timestamp', [
                  'null' => true,
                  'default' => null,
+                 'update' => 'CURRENT_TIMESTAMP',
                  'timezone' => $withTimezone,
              ]);
 

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -131,7 +131,7 @@ class TableTest extends TestCase
         $this->assertEquals($expectedUpdatedAtColumnName, $columns[1]->getName());
         $this->assertEquals('timestamp', $columns[1]->getType());
         $this->assertEquals($withTimezone, $columns[1]->getTimezone());
-        $this->assertEquals('', $columns[1]->getUpdate());
+        $this->assertEquals('CURRENT_TIMESTAMP', $columns[1]->getUpdate());
         $this->assertTrue($columns[1]->isNull());
         $this->assertNull($columns[1]->getDefault());
     }
@@ -167,7 +167,7 @@ class TableTest extends TestCase
         $this->assertEquals($expectedUpdatedAtColumnName, $columns[1]->getName());
         $this->assertEquals('timestamp', $columns[1]->getType());
         $this->assertEquals(true, $columns[1]->getTimezone());
-        $this->assertEquals('', $columns[1]->getUpdate());
+        $this->assertEquals('CURRENT_TIMESTAMP', $columns[1]->getUpdate());
         $this->assertTrue($columns[1]->isNull());
         $this->assertNull($columns[1]->getDefault());
     }


### PR DESCRIPTION
Link #868 . Updates don't reflect in the updated_at column for the default convenience methods.