### PR TITLE
specify that on_update is only usable on mysql

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -856,7 +856,7 @@ For ``timestamp`` columns:
 Option   Description
 ======== ===========
 default  set default value (use with ``CURRENT_TIMESTAMP``)
-update   set an action to be triggered when the row is updated (use with ``CURRENT_TIMESTAMP``)
+update   set an action to be triggered when the row is updated (use with ``CURRENT_TIMESTAMP``) *(only applies to MySQL)*
 timezone enable or disable the ``with time zone`` option for ``time`` and ``timestamp`` columns *(only applies to Postgres)*
 ======== ===========
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1480,10 +1480,6 @@ PCRE_PATTERN;
         $def .= $this->getDefaultValueDefinition($default, $column->getType());
         $def .= $column->isIdentity() ? ' PRIMARY KEY AUTOINCREMENT' : '';
 
-        if ($column->getUpdate()) {
-            $def .= ' ON UPDATE ' . $column->getUpdate();
-        }
-
         $def .= $this->getCommentDefinition($column);
 
         return $def;


### PR DESCRIPTION
This also removes the attempt to use it in SQLite as that's incorrect and doing so will cause SQLite to error. Only MySQL uses the update clause now and this is clarified in the docs. Supporting it in other adapters will require the usage of triggers and such.