### PR TITLE
MySQL use schema name in getPrimaryKey

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -720,6 +720,7 @@ class MysqlAdapter extends PdoAdapter
      */
     public function getPrimaryKey($tableName)
     {
+        $options = $this->getOptions();
         $rows = $this->fetchAll(sprintf(
             "SELECT
                 k.constraint_name,
@@ -728,7 +729,9 @@ class MysqlAdapter extends PdoAdapter
             JOIN information_schema.key_column_usage k
                 USING(constraint_name,table_name)
             WHERE t.constraint_type='PRIMARY KEY'
+                AND t.table_schema='%s'
                 AND t.table_name='%s'",
+            $options['name'],
             $tableName
         ));
 


### PR DESCRIPTION
MySQL now only checks current database schema for Primary Key, rather than the entire server for a table name. #1799