### PR TITLE
add subsection on migration table to configuration doc

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -186,6 +186,22 @@ file:
 
     export PHINX_ENVIRONMENT=dev-`whoami`-`hostname`
 
+Migration Table
+---------------
+
+To keep track of the migration statuses for an environment, phinx creates
+a table to store this information. You can customize where this table
+is created by configuring ``default_migration_table``:
+
+.. code-block:: yaml
+
+    environment:
+        default_migration_table: phinxlog
+
+If this field is omitted, then it will default to ``phinxlog``. For adapters
+that support it (e.g. Postgres), you can prefix the value with a schema if
+you to have the table in a different schema as the rest of the environment,
+for example ``phinx.log`` to create a table ``log`` in the ``phinx`` schema.
 
 Table Prefix and Suffix
 -----------------------

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -198,10 +198,11 @@ is created by configuring ``default_migration_table``:
     environment:
         default_migration_table: phinxlog
 
-For databases that support it, e.g. Postgres, the schema name can be
-prefixed with a period separator (``.``). For example, ``phinx.log`` will
-create the table log in the ``phinx`` schema instead of ``phinxlog`` in
-the ``public`` (default) schema.
+If this field is omitted, then it will default to ``phinxlog``. For
+databases that support it, e.g. Postgres, the schema name can be prefixed
+with a period separator (``.``). For example, ``phinx.log`` will create
+the table log in the ``phinx`` schema instead of ``phinxlog`` in the
+``public`` (default) schema.
 
 Table Prefix and Suffix
 -----------------------

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -198,10 +198,10 @@ is created by configuring ``default_migration_table``:
     environment:
         default_migration_table: phinxlog
 
-If this field is omitted, then it will default to ``phinxlog``. For adapters
-that support it (e.g. Postgres), you can prefix the value with a schema if
-you to have the table in a different schema as the rest of the environment,
-for example ``phinx.log`` to create a table ``log`` in the ``phinx`` schema.
+For databases that support it, e.g. Postgres, the schema name can be
+prefixed with a period separator (``.``). For example, ``phinx.log`` will
+create the table log in the ``phinx`` schema instead of ``phinxlog`` in
+the ``public`` (default) schema.
 
 Table Prefix and Suffix
 -----------------------


### PR DESCRIPTION
As pointed out in #1813, there is no mention in the docs about setting the `default_migration_table` setting in the configuration. This adds such a subsection.