### PR TITLE
Changed migration template to adopt strict types

### DIFF
--- a/src/Phinx/Migration/Migration.template.php.dist
+++ b/src/Phinx/Migration/Migration.template.php.dist
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 $namespaceDefinition
 use $useClassName;
 
-class $className extends $baseClassName
+final class $className extends $baseClassName
 {
     /**
      * Change Method.
@@ -15,7 +17,7 @@ class $className extends $baseClassName
      * Remember to call "create()" or "update()" and NOT "save()" when working
      * with the Table class.
      */
-    public function change()
+    public function change(): void
     {
 
     }

--- a/src/Phinx/Migration/Migration.template.php.dist
+++ b/src/Phinx/Migration/Migration.template.php.dist
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
-
 $namespaceDefinition
 use $useClassName;
 

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -98,7 +98,7 @@ class CreateTest extends TestCase
         $this->assertRegExp("/^[0-9]{14}.php/", $fileName);
         $date = substr($fileName, 0, 14);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
-        $prefix = "<?php\n\nuse Phinx\\Migration\\AbstractMigration;\n\nclass V{$date} extends AbstractMigration";
+        $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
         $this->assertStringStartsWith($prefix, file_get_contents($this->config->getMigrationPaths()[0] . DIRECTORY_SEPARATOR . $fileName));
     }
 
@@ -125,9 +125,8 @@ class CreateTest extends TestCase
         $this->assertCount(1, $files);
         $fileName = current($files);
         $this->assertRegExp("/^[0-9]{14}_my_migration.php/", $fileName);
-        $date = substr($fileName, 0, 14);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
-        $prefix = "<?php\n\nuse Phinx\\Migration\\AbstractMigration;\n\nclass MyMigration extends AbstractMigration";
+        $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class MyMigration extends AbstractMigration\n";
         $this->assertStringStartsWith($prefix, file_get_contents($this->config->getMigrationPaths()[0] . DIRECTORY_SEPARATOR . $fileName));
     }
 


### PR DESCRIPTION
Since Phinx targets PHP >= 7.2, it is safe and probably a good idea to include the `strict_types` declaration. How good of an idea? Well, not *very* good, because Phinx's API appears to be entirely devoid of scalar type hints and also misses `array` type hints in [places where only arrays are valid](https://github.com/cakephp/phinx/blob/ac22eb22bd6bc36fab58610f385bc1f12d7f2150/src/Phinx/Db/Table.php#L295). However, once these areas are updated, templates from now on will be configured correctly to take advantage of type hints and the errors generated by mismatching types. Without these type hints, PHP just emits warnings such as `Invalid argument supplied for foreach() `, but continues regardless until something worse blows up later on.

You will also notice I added a few other bonuses which can be reverted if it's too many changes for this PR. First is a `final` type declaration to signal that migrations are not intended to be inherited (there should be no use case for this). The second is the `void` return type hint just to keep static analysers happy. Again, either of these can be reverted but it is not expected to be particularly contentious.