### PR TITLE
Correct usage of CamelCase to PascalCase

### DIFF
--- a/docs/en/commands.rst
+++ b/docs/en/commands.rst
@@ -42,7 +42,7 @@ The Create Command
 
 The Create command is used to create a new migration file. It requires one
 argument: the name of the migration. The migration name should be specified in
-CamelCase format.
+PascalCase format.
 
 .. code-block:: bash
 
@@ -208,7 +208,7 @@ The Seed Create Command
 
 The Seed Create command can be used to create new database seed classes. It
 requires one argument, the name of the class. The class name should be specified
-in CamelCase format.
+in PascalCase format.
 
 .. code-block:: bash
 

--- a/docs/es/commands.rst
+++ b/docs/es/commands.rst
@@ -23,7 +23,7 @@ Abre este archivo en tu editor de texto para configurar tu projecto. Por favot m
 Comando de creación.
 --------------------
 
-El comando de creación se usa para crear un nuevo archivo de migración. Requiere un argumento: el nombre de la migración. El nombre de la migracion debera especificarse en el formato CamelCase:
+El comando de creación se usa para crear un nuevo archivo de migración. Requiere un argumento: el nombre de la migración. El nombre de la migracion debera especificarse en el formato PascalCase:
 
 .. code-block:: bash
 
@@ -160,7 +160,7 @@ Los puntos de interrupción son visibles cuando ejecuta el comando de estado.
 "Database Seeding"
 ------------------
 
-El comando Crear semilla se puede usar para crear nuevas clases de base de datos. Requiere un argumento, el nombre de la clase. El nombre de la clase debe especificarse en formato CamelCase.
+El comando Crear semilla se puede usar para crear nuevas clases de base de datos. Requiere un argumento, el nombre de la clase. El nombre de la clase debe especificarse en formato PascalCase.
 
 .. code-block:: bash
 

--- a/docs/fr/commands.rst
+++ b/docs/fr/commands.rst
@@ -28,7 +28,7 @@ The Create Command
 
 The Create command is used to create a new migration file. It requires one
 argument: the name of the migration. The migration name should be specified in
-CamelCase format.
+PascalCase format.
 
 .. code-block:: bash
 
@@ -190,7 +190,7 @@ The Seed Create Command
 
 The Seed Create command can be used to create new database seed classes. It
 requires one argument, the name of the class. The class name should be specified
-in CamelCase format.
+in PascalCase format.
 
 .. code-block:: bash
 

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -41,7 +41,7 @@ class Create extends AbstractCommand
         parent::configure();
 
         $this->setDescription('Create a new migration')
-            ->addArgument('name', InputArgument::OPTIONAL, 'Class name of the migration (in CamelCase)')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Class name of the migration (in PascalCase)')
             ->setHelp(sprintf(
                 '%sCreates a new database migration%s',
                 PHP_EOL,
@@ -172,7 +172,7 @@ class Create extends AbstractCommand
         } else {
             if (!Util::isValidPhinxClassName($className)) {
                 throw new InvalidArgumentException(sprintf(
-                    'The migration class name "%s" is invalid. Please use CamelCase format.',
+                    'The migration class name "%s" is invalid. Please use PascalCase format.',
                     $className
                 ));
             }

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -151,7 +151,7 @@ class SeedCreate extends AbstractCommand
 
         if (!Util::isValidPhinxClassName($className)) {
             throw new InvalidArgumentException(sprintf(
-                'The seed class name "%s" is invalid. Please use CamelCase format',
+                'The seed class name "%s" is invalid. Please use PascalCase format',
                 $className
             ));
         }

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -160,7 +160,7 @@ class Util
     /**
      * Check if a migration/seed class name is valid.
      *
-     * Migration & Seed class names must be in CamelCase format.
+     * Migration & Seed class names must be in PascalCase format.
      * e.g: CreateUserTable, AddIndexToPostsTable or UserSeeder.
      *
      * Single words are not allowed on their own.

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -107,7 +107,7 @@ class SeedCreateTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class name "badseedname" is invalid. Please use CamelCase format');
+        $this->expectExceptionMessage('The seed class name "badseedname" is invalid. Please use PascalCase format');
 
         $commandTester->execute(['command' => $command->getName(), 'name' => 'badseedname'], ['decorated' => false]);
     }

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -50,7 +50,7 @@ class UtilTest extends TestCase
     public function providerMapClassNameToFileName(): array
     {
         return [
-            ['CamelCase87afterSomeBooze', '/^\d{14}_camel_case_87after_some_booze\.php$/'],
+            ['PascalCase87afterSomeBooze', '/^\d{14}_pascal_case_87after_some_booze\.php$/'],
             ['CreateUserTable', '/^\d{14}_create_user_table\.php$/'],
             ['LimitResourceNamesTo30Chars', '/^\d{14}_limit_resource_names_to_30_chars\.php$/'],
         ];
@@ -69,7 +69,7 @@ class UtilTest extends TestCase
         return [
             ['20150902094024_create_user_table.php', 'CreateUserTable'],
             ['20150902102548_my_first_migration2.php', 'MyFirstMigration2'],
-            ['20200412012035_camel_case_87after_some_booze.php', 'CamelCase87afterSomeBooze'],
+            ['20200412012035_pascal_case_87after_some_booze.php', 'PascalCase87afterSomeBooze'],
             ['20200412012036_limit_resource_names_to_30_chars.php', 'LimitResourceNamesTo30Chars'],
             ['20200412012037_back_compat_names_to30_chars.php', 'BackCompatNamesTo30Chars'],
             ['20200412012037.php', 'V20200412012037'],
@@ -87,6 +87,7 @@ class UtilTest extends TestCase
     public function providerValidClassName(): array
     {
         return [
+            ['PascalCase', true],
             ['camelCase', false],
             ['CreateUserTable', true],
             ['UserSeeder', true],


### PR DESCRIPTION
The codebase uses the term `CamelCase` to reference the titling of migrations and seeds and such, though as pointed out in #164, this is incorrect as camel case is that middle words are capitalized with a lowercase start (`camelCase`) and that what phinx is actually using is `PascalCase`. I agree with @kafoso in https://github.com/cakephp/phinx/issues/164#issuecomment-649309841 that just because there's people who incorrectly mistake the two, phinx should not and should use the proper one.