### PR TITLE
Add support for BinaryUUID to SqlServer

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -34,6 +34,7 @@ class SqlServerAdapter extends PdoAdapter
      */
     protected static $specificColumnTypes = [
         self::PHINX_TYPE_FILESTREAM,
+        self::PHINX_TYPE_BINARYUUID,
     ];
 
     /**
@@ -1078,6 +1079,7 @@ ORDER BY T.[name], I.[index_id];";
                 return ['name' => 'varbinary'];
             case static::PHINX_TYPE_BOOLEAN:
                 return ['name' => 'bit'];
+            case static::PHINX_TYPE_BINARYUUID:
             case static::PHINX_TYPE_UUID:
                 return ['name' => 'uniqueidentifier'];
             case static::PHINX_TYPE_FILESTREAM:

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -234,6 +234,34 @@ WHERE t.name='ntable'");
         $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_email']));
     }
 
+    public function testCreateTableWithPrimaryKeyAsUuid()
+    {
+        $options = [
+            'id' => false,
+            'primary_key' => 'id',
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table->addColumn('id', 'uuid')->save();
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
+    public function testCreateTableWithPrimaryKeyAsBinaryUuid()
+    {
+        $options = [
+            'id' => false,
+            'primary_key' => 'id',
+        ];
+        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table->addColumn('id', 'binaryuuid')->save();
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
     public function testCreateTableWithMultipleIndexes()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);


### PR DESCRIPTION
Continuation of #1734
Closes #1746 

Adds `PHINX_TYPE_BINARYUUID` to SqlServer in a similar fashion to Postgres where it aliases to the same thing as `PHINX_TYPE_UUID` which is already a binary uuid field (`uniqueidentifier` in the case of SqlServer).

The tests here mimic the ones added for the other adapters from the above PR.