### PR TITLE
Use capitalized references to INFORMATION_SCHEMA for mysql

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -726,14 +726,14 @@ class MysqlAdapter extends PdoAdapter
         $options = $this->getOptions();
         $rows = $this->fetchAll(sprintf(
             "SELECT
-                k.constraint_name,
-                k.column_name
-            FROM information_schema.table_constraints t
-            JOIN information_schema.key_column_usage k
-                USING(constraint_name,table_name)
-            WHERE t.constraint_type='PRIMARY KEY'
-                AND t.table_schema='%s'
-                AND t.table_name='%s'",
+                k.CONSTRAINT_NAME,
+                k.COLUMN_NAME
+            FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS t
+            JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE k
+                USING(CONSTRAINT_NAME,TABLE_NAME)
+            WHERE t.CONSTRAINT_TYPE='PRIMARY KEY'
+                AND t.TABLE_SCHEMA='%s'
+                AND t.TABLE_NAME='%s'",
             $options['name'],
             $tableName
         ));
@@ -742,8 +742,8 @@ class MysqlAdapter extends PdoAdapter
             'columns' => [],
         ];
         foreach ($rows as $row) {
-            $primaryKey['constraint'] = $row['constraint_name'];
-            $primaryKey['columns'][] = $row['column_name'];
+            $primaryKey['constraint'] = $row['CONSTRAINT_NAME'];
+            $primaryKey['columns'][] = $row['COLUMN_NAME'];
         }
 
         return $primaryKey;

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -197,17 +197,17 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
 
         $rows = $this->adapter->fetchAll(sprintf(
-            "SELECT table_name, column_name, referenced_table_name, referenced_column_name
+            "SELECT TABLE_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
              FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-             WHERE table_schema='%s' AND REFERENCED_TABLE_NAME='ntable_tag'",
+             WHERE TABLE_SCHEMA='%s' AND REFERENCED_TABLE_NAME='ntable_tag'",
             MYSQL_DB_CONFIG['name']
         ));
         $foreignKey = $rows[0];
 
-        $this->assertEquals($foreignKey['table_name'], 'ntable');
-        $this->assertEquals($foreignKey['column_name'], 'tag_id');
-        $this->assertEquals($foreignKey['referenced_table_name'], 'ntable_tag');
-        $this->assertEquals($foreignKey['referenced_column_name'], 'id');
+        $this->assertEquals($foreignKey['TABLE_NAME'], 'ntable');
+        $this->assertEquals($foreignKey['COLUMN_NAME'], 'tag_id');
+        $this->assertEquals($foreignKey['REFERENCED_TABLE_NAME'], 'ntable_tag');
+        $this->assertEquals($foreignKey['REFERENCED_COLUMN_NAME'], 'id');
     }
 
     public function testCreateTableCustomIdColumn()


### PR DESCRIPTION
This fixes the failing tests under MySQL 8.0.21+. As part of MySQL 8, the INFORMATION_SCHEMA tables were supposed to always return their columns as capitalized always (see . I guess pre 8.0.21, some tables would still return lowercase if the query was lowercase. This is related to changes done in #1759 along this same vein.

This should render #1836 unnecessary, and can leave phinx running against the latest version of mysql.