### PR TITLE
Add GH action badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # [Phinx](https://phinx.org): Simple PHP Database Migrations
 
+[![Build Status](https://github.com/cakephp/phinx/workflows/Phinx%20CI/badge.svg?branch=master&event=push)](https://github.com/cakephp/phinx/actions?query=workflow%3A%22Phinx+CI%22+branch%3Amaster+event%3Apush)
 [![Build Status](https://img.shields.io/travis/com/cakephp/phinx?style=flat-square)](https://travis-ci.com/cakephp/phinx)
 [![Build status](https://ci.appveyor.com/api/projects/status/9vag4892hfq6effr)](https://ci.appveyor.com/project/robmorgan/phinx)
 [![Code Coverage](https://img.shields.io/coveralls/cakephp/phinx/master.svg?style=flat-square)](https://coveralls.io/r/cakephp/phinx?branch=master)


### PR DESCRIPTION
This adds a badge for GH actions to the README. The badge shows the status of the latest push to master (which is also where the link leads).