### PR TITLE
allow host parameter for postgres to be optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   global:
     - CODECOVERAGE=1
   matrix:
-    - PGSQL_DSN='pgsql://postgres@127.0.0.1/phinx'
+    - PGSQL_DSN='pgsql://postgres@127.0.0.1/phinx' POSTGRES_SOCKET=true
     - MYSQL_DSN='mysql://root@127.0.0.1/phinx' MYSQL_UNIX_SOCKET='/var/run/mysqld/mysqld.sock'
     - SQLITE_DSN='sqlite:///phinx'
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -61,7 +61,11 @@ class PostgresAdapter extends PdoAdapter
 
             $options = $this->getOptions();
 
-            $dsn = $dsn = 'pgsql:host=' . $options['host'] . ';dbname=' . $options['name'];
+            $dsn = 'pgsql:dbname=' . $options['name'];
+
+            if (isset($options['host'])) {
+                $dsn .= ';host=' . $options['host'];
+            }
 
             // if custom port is specified use it
             if (isset($options['port'])) {

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -110,6 +110,20 @@ class PostgresAdapterTest extends TestCase
         }
     }
 
+    public function testConnectionWithSocketConnection()
+    {
+        if (!getenv('POSTGRES_SOCKET')) {
+            $this->markTestSkipped('Postgres socket connection skipped.');
+        }
+
+        $options = PGSQL_DB_CONFIG;
+        unset($options['host']);
+        $adapter = new PostgresAdapter(PGSQL_DB_CONFIG, new ArrayInput([]), new NullOutput());
+        $adapter->connect();
+
+        $this->assertInstanceOf('\PDO', $this->adapter->getConnection());
+    }
+
     public function testCreatingTheSchemaTableOnConnect()
     {
         $this->adapter->connect();


### PR DESCRIPTION
Closes #1832

Allows the `host` parameter for a postgres connection to be optional. If not defined, it will fallback to attempting to use a socket connection for PDO.