### PR TITLE
fix postgres socket test to actually use socket options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   global:
     - CODECOVERAGE=1
   matrix:
-    - PGSQL_DSN='pgsql://postgres@127.0.0.1/phinx' POSTGRES_SOCKET=true
+    - PGSQL_DSN='pgsql://postgres@127.0.0.1/phinx' POSTGRES_TEST_SOCKETS=true
     - MYSQL_DSN='mysql://root@127.0.0.1/phinx' MYSQL_UNIX_SOCKET='/var/run/mysqld/mysqld.sock'
     - SQLITE_DSN='sqlite:///phinx'
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -112,13 +112,13 @@ class PostgresAdapterTest extends TestCase
 
     public function testConnectionWithSocketConnection()
     {
-        if (!getenv('POSTGRES_SOCKET')) {
+        if (!getenv('POSTGRES_TEST_SOCKETS')) {
             $this->markTestSkipped('Postgres socket connection skipped.');
         }
 
         $options = PGSQL_DB_CONFIG;
         unset($options['host']);
-        $adapter = new PostgresAdapter(PGSQL_DB_CONFIG, new ArrayInput([]), new NullOutput());
+        $adapter = new PostgresAdapter($options, new ArrayInput([]), new NullOutput());
         $adapter->connect();
 
         $this->assertInstanceOf('\PDO', $this->adapter->getConnection());


### PR DESCRIPTION
Fixes using the wrong variable from #1849 when passing the options to the new adapter instance.

Also updates the name of the environment variable per @othercorey's suggestion.