### PR TITLE
fix renaming columns in mixed case table in postgres

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -525,7 +525,7 @@ class PostgresAdapter extends PdoAdapter
         $instructions->addPostStep(
             sprintf(
                 'ALTER TABLE %s RENAME COLUMN %s TO %s',
-                $tableName,
+                $this->quoteTableName($tableName),
                 $this->quoteColumnName($columnName),
                 $this->quoteColumnName($newColumnName)
             )

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2096,4 +2096,26 @@ OUTPUT;
 
         $this->assertEquals(1, $stm->rowCount());
     }
+
+    public function testRenameMixedCaseTableAndColumns()
+    {
+        $table = new \Phinx\Db\Table('OrganizationSettings', [], $this->adapter);
+        $table->addColumn('SettingType', 'string')
+            ->create();
+
+        $this->assertTrue($this->adapter->hasTable('OrganizationSettings'));
+        $this->assertTrue($this->adapter->hasColumn('OrganizationSettings', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('OrganizationSettings', 'SettingType'));
+        $this->assertFalse($this->adapter->hasColumn('OrganizationSettings', 'SettingTypeId'));
+
+        $table = new \Phinx\Db\Table('OrganizationSettings', [], $this->adapter);
+        $table
+        	->renameColumn('SettingType', 'SettingTypeId')
+            ->update();
+
+        $this->assertTrue($this->adapter->hasTable('OrganizationSettings'));
+        $this->assertTrue($this->adapter->hasColumn('OrganizationSettings', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('OrganizationSettings', 'SettingTypeId'));
+        $this->assertFalse($this->adapter->hasColumn('OrganizationSettings', 'SettingType'));
+    }
 }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2110,7 +2110,7 @@ OUTPUT;
 
         $table = new \Phinx\Db\Table('OrganizationSettings', [], $this->adapter);
         $table
-        	->renameColumn('SettingType', 'SettingTypeId')
+            ->renameColumn('SettingType', 'SettingTypeId')
             ->update();
 
         $this->assertTrue($this->adapter->hasTable('OrganizationSettings'));


### PR DESCRIPTION
Closes #1851

The PostgresAdapter for rename column instructions does not quote the table name, causing it to use the default DB behavior which is to auto-cast everything to lowercase, which then fails to find the table to rename the column in. This patch makes it so that the table is properly quoted in the SQL instruction, and so that having it be mixed case works as expected.

Without the change, the test failed with this message:

```
1) Test\Phinx\Db\Adapter\PostgresAdapterTest::testMixedCaseColumns
PDOException: SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "organizationsettings" does not exist

/Users/mpeveler/Work/Github/phinx/src/Phinx/Db/Adapter/PdoAdapter.php:181
/Users/mpeveler/Work/Github/phinx/src/Phinx/Db/Util/AlterInstructions.php:123
/Users/mpeveler/Work/Github/phinx/src/Phinx/Db/Adapter/PdoAdapter.php:606
/Users/mpeveler/Work/Github/phinx/src/Phinx/Db/Adapter/PdoAdapter.php:981
/Users/mpeveler/Work/Github/phinx/src/Phinx/Db/Plan/Plan.php:153
/Users/mpeveler/Work/Github/phinx/src/Phinx/Db/Table.php:722
/Users/mpeveler/Work/Github/phinx/src/Phinx/Db/Table.php:629
/Users/mpeveler/Work/Github/phinx/tests/Phinx/Db/Adapter/PostgresAdapterTest.php:2114
```

After the change, test passed as expected.