### PR TITLE
Update docker-compose/phpunit mysql and postgres to match DSN values

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,15 @@ services:
     mysql:
         image: mysql:5.6
         environment:
-            - MYSQL_DATABASE=phinx_testing
-            - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+            - MYSQL_DATABASE=phinx
+            - MYSQL_ROOT_PASSWORD=root
         ports:
             - 3306:3306
 
     postgres:
         image: postgres:9.2
         environment:
-            - POSTGRES_DB=phinx_testing
+            - POSTGRES_DB=phinx
+            - POSTGRES_PASSWORD=postgres
         ports:
             - 5432:5432

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,10 +19,10 @@
         <env name="SQLSRV_DSN" value="sqlsrv://user:pass@localhost/test"/>
         -->
         <!-- MySQL
-        <env name="MYSQL_DSN" value="mysql://root@127.0.0.1/test"/>
+        <env name="MYSQL_DSN" value="mysql://root:root@127.0.0.1/phinx"/>
         -->
         <!-- PostgreSQL
-        <env name="PGSQL_DSN" value="pgsql://postgres@127.0.0.1/test"/>
+        <env name="PGSQL_DSN" value="pgsql://postgres:postgres@127.0.0.1/phinx"/>
         -->
         <!-- SQLite
         <env name="SQLITE_DSN" value="sqlite:///:memory:"/>


### PR DESCRIPTION
The default phpunit DSN for mysql and postgres differed slightly from that used by docker-compose to set up these resources. Additionally, both differed from the DSN values used by the CI test suite under github actions. This unifies the values of phpunit and docker-compose to match each other, and that of the values used for CI.