### PR TITLE
bump version of docker-compose postgres to currently supported version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
             - 3306:3306
 
     postgres:
-        image: postgres:9.2
+        image: postgres:9.4
         environment:
             - POSTGRES_DB=phinx_testing
         ports:


### PR DESCRIPTION
Phinx is no longer compatible with postgres 9.2 (it throws an error on a simple migration, did not look deeply into why), and so the docker-compose image is no longer usable as is. Given that the CI tests the minimal version of 9.4, update the docker-compose file to match that.