### PR TITLE
use quoteTableName when caching table name operations

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -365,6 +365,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     protected function addCreatedTable($tableName)
     {
+        $tableName = $this->quoteTableName($tableName);
         if (substr_compare($tableName, 'phinxlog', -strlen('phinxlog')) !== 0) {
             $this->createdTables[] = $tableName;
         }
@@ -380,6 +381,8 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     protected function updateCreatedTableName($tableName, $newTableName)
     {
+        $tableName = $this->quoteTableName($tableName);
+        $newTableName = $this->quoteTableName($newTableName);
         $key = array_search($tableName, $this->createdTables, true);
         if ($key !== false) {
             $this->createdTables[$key] = $newTableName;
@@ -395,6 +398,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     protected function removeCreatedTable($tableName)
     {
+        $tableName = $this->quoteTableName($tableName);
         $key = array_search($tableName, $this->createdTables, true);
         if ($key !== false) {
             unset($this->createdTables[$key]);
@@ -410,6 +414,8 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     protected function hasCreatedTable($tableName)
     {
+        $tableName = $this->quoteTableName($tableName);
+
         return in_array($tableName, $this->createdTables, true);
     }
 }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1261,6 +1261,7 @@ class MysqlAdapter extends PdoAdapter
     public function dropDatabase($name)
     {
         $this->execute(sprintf('DROP DATABASE IF EXISTS `%s`', $name));
+        $this->createdTables = [];
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1108,6 +1108,7 @@ class PostgresAdapter extends PdoAdapter
     {
         $this->disconnect();
         $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $name));
+        $this->createdTables = [];
         $this->connect();
     }
 
@@ -1336,6 +1337,12 @@ class PostgresAdapter extends PdoAdapter
     {
         $sql = sprintf('DROP SCHEMA IF EXISTS %s CASCADE', $this->quoteSchemaName($schemaName));
         $this->execute($sql);
+
+        foreach ($this->createdTables as $idx => $createdTable) {
+            if ($this->getSchemaName($createdTable)['schema'] === $this->quoteSchemaName($schemaName)) {
+                unset($this->createdTables[$idx]);
+            }
+        }
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1453,6 +1453,7 @@ PCRE_PATTERN;
      */
     public function dropDatabase($name)
     {
+        $this->createdTables = [];
         if ($this->getOption('memory')) {
             $this->disconnect();
             $this->connect();

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1198,6 +1198,7 @@ ALTER DATABASE [$name] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
 DROP DATABASE [$name];
 SQL;
         $this->execute($sql);
+        $this->createdTables = [];
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2010,12 +2010,9 @@ OUTPUT;
         $this->adapter->setOutput($consoleOutput);
 
         $table = new \Phinx\Db\Table('schema1.table1', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
-
         $table->addColumn('column1', 'string')
             ->addColumn('column2', 'integer')
             ->save();
-
-        $expectedOutput = 'C';
 
         $table = new \Phinx\Db\Table('schema1.table1', [], $this->adapter);
         $table->insert([


### PR DESCRIPTION
This rewrites the `createdTables` cached to use the quoted table names, instead of just the table names as provided to the function. This fixes an issue where if a user on postgres created a table `table1` and then did `hasTable('public.table1')`, the cache would be missed as it would contain just `table1`, even though both things refer to the same thing. Interestingly, this showed an issue where the schema table (phinxlog) was being added somewhat inconsistently to the cache such that on dropping the database / schema, and then recreating it, the phinxlog table was entering the cache in slightly different ways, and so had to clear the cache on the reset of things (which makes sense anyway) or else the phinxlog table would complain about not existing when the system attempted to refer to it.