### PR TITLE
update gh action to run on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Phinx CI
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
Updates the GH action workflow to run on all branches. As is, for in-progress work of mine, I cannot use GH actions to see if the test suite would pass or not, instead having to create a PR on my own repo to get the results. This greatly diminishes the valuableness of GH to me before I try opening a PR.