### PR TITLE
Improve assertions usage

### DIFF
--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1049,7 +1049,7 @@ class MysqlAdapterTest extends TestCase
         $table->addColumn('column1', 'datetime')->save();
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
-        $this->assertEquals(null, $sqlType['limit']);
+        $this->assertNull($sqlType['limit']);
     }
 
     public function testDatetimeColumnLimit()
@@ -1969,7 +1969,7 @@ INPUT;
 
         $this->adapter->execute("INSERT INTO table1 (`geom`) VALUES (ST_GeomFromText('{$geom}', 4326))");
         $rows = $this->adapter->fetchAll('SELECT ST_AsWKT(geom) as wkt, ST_SRID(geom) as srid FROM table1');
-        $this->assertSame(1, count($rows));
+        $this->assertCount(1, $rows);
         $this->assertSame($geom, $rows[0]['wkt']);
         $this->assertSame('4326', $rows[0]['srid']);
     }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1722,9 +1722,9 @@ class PostgresAdapterTest extends TestCase
             ->save();
 
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
-        $this->assertSame(true, $rows[0]['column1']);
-        $this->assertSame(false, $rows[1]['column1']);
-        $this->assertSame(null, $rows[2]['column1']);
+        $this->assertTrue($rows[0]['column1']);
+        $this->assertFalse($rows[1]['column1']);
+        $this->assertNull($rows[2]['column1']);
     }
 
     public function testInsertData()
@@ -1771,9 +1771,9 @@ class PostgresAdapterTest extends TestCase
             ->save();
 
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
-        $this->assertSame(true, $rows[0]['column1']);
-        $this->assertSame(false, $rows[1]['column1']);
-        $this->assertSame(null, $rows[2]['column1']);
+        $this->assertTrue($rows[0]['column1']);
+        $this->assertFalse($rows[1]['column1']);
+        $this->assertNull($rows[2]['column1']);
     }
 
     public function testInsertDataWithSchema()
@@ -1848,10 +1848,10 @@ class PostgresAdapterTest extends TestCase
             ->save();
 
         $rows = $this->adapter->fetchAll('SELECT * FROM schema1.table1');
-        $this->assertEquals(2, count($rows));
+        $this->assertCount(2, $rows);
         $table->truncate();
         $rows = $this->adapter->fetchAll('SELECT * FROM schema1.table1');
-        $this->assertEquals(0, count($rows));
+        $this->assertCount(0, $rows);
 
         $this->adapter->dropSchema('schema1');
     }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -153,8 +153,8 @@ class SQLiteAdapterTest extends TestCase
         //ensure the primary key is not nullable
         /** @var \Phinx\Db\Table\Column $idColumn */
         $idColumn = $this->adapter->getColumns('ntable')[0];
-        $this->assertEquals(true, $idColumn->getIdentity());
-        $this->assertEquals(false, $idColumn->isNull());
+        $this->assertTrue($idColumn->getIdentity());
+        $this->assertFalse($idColumn->isNull());
     }
 
     public function testCreateTableIdentityIdColumn()
@@ -168,7 +168,7 @@ class SQLiteAdapterTest extends TestCase
 
         /** @var \Phinx\Db\Table\Column $idColumn */
         $idColumn = $this->adapter->getColumns('ntable')[0];
-        $this->assertEquals(true, $idColumn->getIdentity());
+        $this->assertTrue($idColumn->getIdentity());
     }
 
     public function testCreateTableWithNoPrimaryKey()
@@ -854,7 +854,7 @@ class SQLiteAdapterTest extends TestCase
         $this->assertEquals(1, $rows[0]['column2']);
         $this->assertEquals(2, $rows[1]['column2']);
         $this->assertEquals(3, $rows[2]['column2']);
-        $this->assertEquals(null, $rows[3]['column2']);
+        $this->assertNull($rows[3]['column2']);
     }
 
     public function testInsertData()
@@ -895,7 +895,7 @@ class SQLiteAdapterTest extends TestCase
         $this->assertEquals(1, $rows[0]['column2']);
         $this->assertEquals(2, $rows[1]['column2']);
         $this->assertEquals(3, $rows[2]['column2']);
-        $this->assertEquals(null, $rows[3]['column2']);
+        $this->assertNull($rows[3]['column2']);
     }
 
     public function testBulkInsertDataEnum()
@@ -912,7 +912,7 @@ class SQLiteAdapterTest extends TestCase
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
 
         $this->assertEquals('a', $rows[0]['column1']);
-        $this->assertEquals(null, $rows[0]['column2']);
+        $this->assertNull($rows[0]['column2']);
         $this->assertEquals('c', $rows[0]['column3']);
     }
 
@@ -939,19 +939,19 @@ class SQLiteAdapterTest extends TestCase
         $dd = $columns[4];
 
         $this->assertEquals("aa", $aa->getName());
-        $this->assertEquals(true, $aa->isNull());
-        $this->assertEquals(null, $aa->getDefault());
+        $this->assertTrue($aa->isNull());
+        $this->assertNull($aa->getDefault());
 
         $this->assertEquals("bb", $bb->getName());
-        $this->assertEquals(false, $bb->isNull());
-        $this->assertEquals(null, $bb->getDefault());
+        $this->assertFalse($bb->isNull());
+        $this->assertNull($bb->getDefault());
 
         $this->assertEquals("cc", $cc->getName());
-        $this->assertEquals(true, $cc->isNull());
+        $this->assertTrue($cc->isNull());
         $this->assertEquals("some1", $cc->getDefault());
 
         $this->assertEquals("dd", $dd->getName());
-        $this->assertEquals(false, $dd->isNull());
+        $this->assertFalse($dd->isNull());
         $this->assertEquals("some2", $dd->getDefault());
     }
 

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -161,12 +161,12 @@ class TableTest extends TestCase
         $this->assertEquals($expectedCreatedAtColumnName, $columns[0]->getName());
         $this->assertEquals('timestamp', $columns[0]->getType());
         $this->assertEquals('CURRENT_TIMESTAMP', $columns[0]->getDefault());
-        $this->assertEquals(true, $columns[0]->getTimezone());
+        $this->assertTrue($columns[0]->getTimezone());
         $this->assertEquals('', $columns[0]->getUpdate());
 
         $this->assertEquals($expectedUpdatedAtColumnName, $columns[1]->getName());
         $this->assertEquals('timestamp', $columns[1]->getType());
-        $this->assertEquals(true, $columns[1]->getTimezone());
+        $this->assertTrue($columns[1]->getTimezone());
         $this->assertEquals('CURRENT_TIMESTAMP', $columns[1]->getUpdate());
         $this->assertTrue($columns[1]->isNull());
         $this->assertNull($columns[1]->getDefault());
@@ -309,7 +309,7 @@ class TableTest extends TestCase
         $columns = ["column1"];
         $data = [["value1"]];
         $table->insert($columns, $data);
-        $this->assertEquals(true, $table->hasPendingActions());
+        $this->assertTrue($table->hasPendingActions());
     }
 
     public function testPendingAfterAddingColumn()
@@ -322,7 +322,7 @@ class TableTest extends TestCase
             ->willReturn(true);
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $table->addColumn("column1", "integer", ['null' => true]);
-        $this->assertEquals(true, $table->hasPendingActions());
+        $this->assertTrue($table->hasPendingActions());
     }
 
     public function testGetColumn()


### PR DESCRIPTION
# Changed log

- Using the `assertTrue` to assert expected value is `true`.
- Using the `assertFalse` to assert expected value is `false`.
- Using the `assertNull` to assert expected value is `null`.
- Using the `assertCount` to assert expected count is same as result count.