### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Phinx/Config/ConfigFileTest.php
+++ b/tests/Phinx/Config/ConfigFileTest.php
@@ -16,13 +16,13 @@ class ConfigFileTest extends TestCase
 
     private $baseDir;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->previousDir = getcwd();
         $this->baseDir = realpath(__DIR__ . '/_rootDirectories');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         chdir($this->previousDir);
     }

--- a/tests/Phinx/Config/ConfigReplaceTokensTest.php
+++ b/tests/Phinx/Config/ConfigReplaceTokensTest.php
@@ -25,7 +25,7 @@ class ConfigReplaceTokensTest extends AbstractConfigTest
     /**
      * Pass vars to $_SERVER
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         foreach (static::$server as $name => $value) {
             $_SERVER[$name] = $value;
@@ -35,7 +35,7 @@ class ConfigReplaceTokensTest extends AbstractConfigTest
     /**
      * Clean-up
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         foreach (static::$server as $name => $value) {
              unset($_SERVER[$name]);

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -41,7 +41,7 @@ class BreakpointTest extends TestCase
     /**
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         @mkdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations', 0777, true);
         $this->config = new Config(

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -39,7 +39,7 @@ class CreateTest extends TestCase
      */
     protected $output;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         TestUtils::recursiveRmdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations');
         @mkdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations', 0777, true);

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class InitTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         foreach (['.yaml', '.yml', '.json', '.php'] as $format) {
             $file = sys_get_temp_dir() . '/phinx' . $format;

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -32,7 +32,7 @@ class MigrateTest extends TestCase
      */
     protected $output;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -41,7 +41,7 @@ class RollbackTest extends TestCase
     /**
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -32,7 +32,7 @@ class SeedCreateTest extends TestCase
      */
     protected $output;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -32,7 +32,7 @@ class SeedRunTest extends TestCase
      */
     protected $output;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -40,7 +40,7 @@ class StatusTest extends TestCase
     /**
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->config = new Config([
             'paths' => [

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -13,12 +13,12 @@ class AdapterFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->factory = AdapterFactory::instance();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->factory);
     }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -22,7 +22,7 @@ class MysqlAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (!defined('MYSQL_DB_CONFIG')) {
             $this->markTestSkipped('Mysql tests disabled.');
@@ -38,7 +38,7 @@ class MysqlAdapterTest extends TestCase
         $this->adapter->disconnect();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->adapter);
     }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -38,12 +38,12 @@ class PdoAdapterTest extends TestCase
 {
     private $adapter;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', [['foo' => 'bar']]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->adapter);
     }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -37,7 +37,7 @@ class PostgresAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (!defined('PGSQL_DB_CONFIG')) {
             $this->markTestSkipped('Postgres tests disabled.');
@@ -61,7 +61,7 @@ class PostgresAdapterTest extends TestCase
         $this->adapter->disconnect();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if ($this->adapter) {
             $this->adapter->dropAllSchemas();

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -13,7 +13,7 @@ class ProxyAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $stub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
             ->setConstructorArgs([[]])
@@ -27,7 +27,7 @@ class ProxyAdapterTest extends TestCase
         $this->adapter = new ProxyAdapter($stub);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->adapter);
     }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -22,7 +22,7 @@ class SQLiteAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (!defined('SQLITE_DB_CONFIG')) {
             $this->markTestSkipped('SQLite tests disabled.');
@@ -40,7 +40,7 @@ class SQLiteAdapterTest extends TestCase
         $this->adapter->disconnect();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->adapter);
     }

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -20,7 +20,7 @@ class SqlServerAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (!defined('SQLSRV_DB_CONFIG')) {
             $this->markTestSkipped('SqlServer tests disabled.');
@@ -36,7 +36,7 @@ class SqlServerAdapterTest extends TestCase
         $this->adapter->disconnect();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (!empty($this->adapter)) {
             $this->adapter->disconnect();

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -32,7 +32,7 @@ class TablePrefixAdapterTest extends TestCase
      */
     private $mock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $options = [
             'table_prefix' => 'pre_',
@@ -69,7 +69,7 @@ class TablePrefixAdapterTest extends TestCase
         $this->adapter = new TablePrefixAdapter($this->mock);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->adapter);
         unset($this->mock);

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -15,7 +15,7 @@ class ForeignKeyTest extends TestCase
      */
     private $fk = null;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fk = new ForeignKey();
     }

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -50,7 +50,7 @@ class EnvironmentTest extends TestCase
      */
     protected $environment;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->environment = new Environment('test', []);
     }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -33,7 +33,7 @@ class ManagerTest extends TestCase
      */
     private $manager;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->config = new Config($this->getConfigArray());
         $this->input = new ArrayInput([]);
@@ -82,7 +82,7 @@ class ManagerTest extends TestCase
         return $config;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->manager = null;
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void` and `protected function tearDown(): void`.