### PR TITLE
Fixes problems in SQLite Adapter in foreign key creation

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -454,7 +454,7 @@ class SQLiteAdapter extends PdoAdapter
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      *
      * SQLiteAdapter does not implement this functionality, and so will always throw an exception if used.
      *
@@ -1331,7 +1331,7 @@ PCRE_PATTERN;
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      *
      * SQLiteAdapter does not implement this functionality, and so will always throw an exception if used.
      *


### PR DESCRIPTION
Remake of #1847 with added testcase.

This fixes SQLite losing foreign keys when creating them in conjunction with indexes.

Closes #1840
Closes #1841

There's a good chance this will also close #988 and #1489 which the above issues seem to be duplicates of.