### PR TITLE
* fix issue when setting datetime or timestamp default values

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1273,6 +1273,8 @@ class MysqlAdapter extends PdoAdapter
      */
     protected function getColumnSqlDefinition(Column $column)
     {
+        $limit = null;
+
         if ($column->getType() instanceof Literal) {
             $def = (string)$column->getType();
         } else {
@@ -1282,7 +1284,8 @@ class MysqlAdapter extends PdoAdapter
         if ($column->getPrecision() && $column->getScale()) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         } elseif (isset($sqlType['limit'])) {
-            $def .= '(' . $sqlType['limit'] . ')';
+            $limit = $sqlType['limit'];
+            $def  .= '(' . $limit . ')';
         }
         if (($values = $column->getValues()) && is_array($values)) {
             $def .= "(" . implode(", ", array_map(function ($value) {
@@ -1312,7 +1315,7 @@ class MysqlAdapter extends PdoAdapter
         }
 
         $def .= $column->isIdentity() ? ' AUTO_INCREMENT' : '';
-        $def .= $this->getDefaultValueDefinition($column->getDefault(), $column->getType());
+        $def .= $this->getDefaultValueDefinition($column->getDefault(), $column->getType(), $limit);
 
         if ($column->getComment()) {
             $def .= ' COMMENT ' . $this->getConnection()->quote($column->getComment());

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -576,13 +576,20 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param mixed $default Default value
      * @param string|null $columnType column type added
+     * @param int|null $precision datetime/timestamp column default value limit/precision
      *
      * @return string
      */
-    protected function getDefaultValueDefinition($default, $columnType = null)
+    protected function getDefaultValueDefinition($default, $columnType = null, $precision = null)
     {
-        if (is_string($default) && $default !== 'CURRENT_TIMESTAMP') {
-            $default = $this->getConnection()->quote($default);
+        if (is_string($default)) {
+            if (str_starts_with($default, 'CURRENT_TIMESTAMP')) {
+                if ($precision !== null) {
+                    $default .= '(' . $precision . ')';
+                }
+            } else {
+                $default = $this->getConnection()->quote($default);
+            }
         } elseif (is_bool($default)) {
             $default = $this->castToBool($default);
         } elseif ($default !== null && $columnType === static::PHINX_TYPE_BOOLEAN) {


### PR DESCRIPTION
	- CURRENT_TIMESTAMP must match the precision of the defined column
	- applies to MySQL 5.6+
	- ref: https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html

eg.
        $this->table('test_table')->addColumn('created_at', 'timestamp', ['limit' => 6, 'default' => 'CURRENT_TIMESTAMP'])