### PR TITLE
support looking up foreign key by name in sqlite3

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1180,7 +1180,7 @@ PCRE_PATTERN;
     {
         if ($constraint !== null) {
             return preg_match(
-                "/,?\sCONSTRAINT\s" . preg_quote($this->quoteColumnName($constraint)) . " FOREIGN KEY/",
+                "/,?\sCONSTRAINT\s" . preg_quote($this->quoteColumnName($constraint)) . ' FOREIGN KEY/',
                 $this->getDeclaringSql($tableName)
             ) === 1;
         }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1174,14 +1174,15 @@ PCRE_PATTERN;
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @throws \InvalidArgumentException
+     * @inheritDoc
      */
     public function hasForeignKey($tableName, $columns, $constraint = null)
     {
         if ($constraint !== null) {
-            throw new InvalidArgumentException('SQLite does not support named constraints.');
+            return preg_match(
+                "/,?\sCONSTRAINT\s" . preg_quote($this->quoteColumnName($constraint)) . " FOREIGN KEY/",
+                $this->getDeclaringSql($tableName)
+            ) === 1;
         }
 
         $columns = array_map('strtolower', (array)$columns);


### PR DESCRIPTION
Closes #1857 

Adds support in `hasForeignKey` for named constraints in sqlite. Like the other providers, if you pass in both columns and constraint name, it will only look at the constraint name, and ignore the columns argument. Sqlite still does not have the capacity to drop foreign keys via name, which will come in a follow-up PR.