### PR TITLE
widen compatible phpunit range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "ext-json": "*",
         "ext-pdo": "*",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5|^9.3",
         "sebastian/comparator": ">=1.2.3",
         "cakephp/cakephp-codesniffer": "^3.0",
         "symfony/yaml": "^3.4|^4.0|^5.0"


### PR DESCRIPTION
Support for PHP 8 was added in the 9.x line. However, cannot upgrade to it singularly as 9.x also dropped support for PHP 7.2, which phinx still supports. As such, we allow the installation of either ^8.5 or ^9.3, to be resolved by composer on the system in question, which works for development as phinx repository does not provide a composer.lock file.