### PR TITLE
add createSchema and dropSchema methods on MigrationInterface

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -262,6 +262,22 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
+    public function createSchema($name)
+    {
+        $this->getAdapter()->createSchema($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dropSchema($name)
+    {
+        $this->getAdapter()->dropSchema($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function hasTable($tableName)
     {
         return $this->getAdapter()->hasTable($tableName);

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -218,6 +218,28 @@ interface MigrationInterface
     public function dropDatabase($name);
 
     /**
+     * Creates schema.
+     *
+     * This will thrown an error for adapters that do not support schemas.
+     *
+     * @param string $name Schema name
+     * @return void
+     * @throws \BadMethodCallException
+     */
+    public function createSchema($name);
+
+    /**
+     * Drops schema.
+     *
+     * This will thrown an error for adapters that do not support schemas.
+     *
+     * @param string $name Schema name
+     * @return void
+     * @throws \BadMethodCallException
+     */
+    public function dropSchema($name);
+
+    /**
      * Checks to see if a table exists.
      *
      * @param string $tableName Table name

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -236,6 +236,40 @@ class AbstractMigrationTest extends TestCase
         $migrationStub->dropDatabase('testdb');
     }
 
+    public function testCreateSchema()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+
+        // stub adapter
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+                    ->method('createSchema')
+                    ->with('testschema');
+
+        $migrationStub->setAdapter($adapterStub);
+        $migrationStub->createSchema('testschema');
+    }
+
+    public function testDropSchema()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+
+        // stub adapter
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+                    ->method('dropSchema')
+                    ->with('testschema');
+
+        $migrationStub->setAdapter($adapterStub);
+        $migrationStub->dropSchema('testschema');
+    }
+
     public function testHasTable()
     {
         // stub migration


### PR DESCRIPTION
Closes #1870 

Given that there's no docs right now for `createDatabase` either, did not elect to add them here (as not sure where to place them). For now, it should at least make it a bit easier for user discovery.

PR made against 0.13 due to breaking change on the MigrationInterface