### PR TITLE
run preFlightCheck and postFlightCheck immediately after migration

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -376,14 +376,12 @@ class Manager
             ' <info>' . $migration->getVersion() . ' ' . $migration->getName() . ':</info>' .
             ' <comment>' . ($direction === MigrationInterface::UP ? 'migrating' : 'reverting') . '</comment>'
         );
-        $migration->preFlightCheck($direction);
 
         // Execute the migration and log the time elapsed.
         $start = microtime(true);
         $this->getEnvironment($name)->executeMigration($migration, $direction, $fake);
         $end = microtime(true);
 
-        $migration->postFlightCheck($direction);
         $this->getOutput()->writeln(
             ' ==' .
             ' <info>' . $migration->getVersion() . ' ' . $migration->getName() . ':</info>' .

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -79,6 +79,9 @@ class Environment
 
         $startTime = time();
         $migration->setAdapter($this->getAdapter());
+
+        $migration->preFlightCheck($direction);
+
         if (method_exists($migration, MigrationInterface::INIT)) {
             $migration->{MigrationInterface::INIT}();
         }
@@ -114,6 +117,8 @@ class Environment
                 $this->getAdapter()->commitTransaction();
             }
         }
+
+        $migration->postFlightCheck($direction);
 
         // Record it in the database
         $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));


### PR DESCRIPTION
Closes #1818

This makes it so that the `preFlightCheck` and `postFlightCheck` are now run immediately before and immediately after the migration is run. This gives the advantage that one could run stuff against the adapter if they wanted to in the preFlightCheck, and that the `postFlightCheck` will run before the migration is logged as having run. This is especially beneficial in the latter's case given that by default, it will throw an exception if the user has incomplete table operations.

While this does slightly change the order things and run in, and that the checks are run within the migration timer, it's not really BC breaking enough to warrant necessarily going in the 0.13.x line only.