### PR TITLE
make utf8mb4_unicode_ci default collation for new mysql tables

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -170,8 +170,8 @@ specified under the ``environments`` nested collection. For example:
             user: root
             pass: ''
             port: 3306
-            charset: utf8
-            collation: utf8_unicode_ci
+            charset: utf8mb4
+            collation: utf8mb4_unicode_ci
 
 would define a new environment called ``production``.
 

--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -478,7 +478,7 @@ Option     Description
 comment    set a text comment on the table
 row_format set the table row format
 engine     define table engine *(defaults to ``InnoDB``)*
-collation  define table collation *(defaults to ``utf8_general_ci``)*
+collation  define table collation *(defaults to ``utf8mb4_unicode_ci``)*
 signed     whether the primary key is ``signed``  *(defaults to ``true``)*
 ========== ===========
 
@@ -924,7 +924,11 @@ third argument array.
 Limit Option and MySQL
 ~~~~~~~~~~~~~~~~~~~~~~
 
-When using the MySQL adapter, additional hinting of database column type can be
+When using the MySQL adapter, there are a couple things to consider when working with limits:
+
+- When using a ``string`` primary key or index on MySQL 5.7 or below and the default charset of ``utf8mb4_unicode_ci``, you
+must specify a limit less than or equal to 191, or use a different charset.
+- Additional hinting of database column type can be
 made for ``integer``, ``text``, ``blob``, ``tinyblob``, ``mediumblob``, ``longblob`` columns. Using ``limit`` with
 one the following options will modify the column type accordingly:
 

--- a/docs/fr/configuration.rst
+++ b/docs/fr/configuration.rst
@@ -159,8 +159,8 @@ specified under the ``environments`` nested collection. For example:
             user: root
             pass: ''
             port: 3306
-            charset: utf8
-            collation: utf8_unicode_ci
+            charset: utf8mb4
+            collation: utf8mb4_unicode_ci
 
 would define a new environment called ``production``.
 

--- a/docs/fr/migrations.rst
+++ b/docs/fr/migrations.rst
@@ -482,7 +482,7 @@ Option    Description
 ========= ===========
 comment   set a text comment on the table
 engine    define table engine *(defaults to `InnoDB`)*
-collation define table collation *(defaults to `utf8_general_ci`)*
+collation define table collation *(defaults to `utf8mb4_unicode_ci`)*
 signed    whether the primary key is ``signed``
 ========= ===========
 

--- a/docs/ja/configuration.rst
+++ b/docs/ja/configuration.rst
@@ -157,8 +157,8 @@ Phinx の主な機能の1つは、複数のデータベース環境をサポー�
             user: root
             pass: ''
             port: 3306
-            charset: utf8
-            collation: utf8_unicode_ci
+            charset: utf8mb4
+            collation: utf8mb4_unicode_ci
 
 上記は ``production`` と呼ばれる新しい環境を定義します。
 

--- a/docs/ja/migrations.rst
+++ b/docs/ja/migrations.rst
@@ -474,7 +474,7 @@ username と email カラムの両方に一意なインデックスを作成し�
 ========== ===========
 comment    テーブルにテキストコメントを設定
 engine     テーブルエンジンの定義 *(デフォルトは `InnoDB`)*
-collation  テーブル照合順序の定義 *(デフォルトは `utf8_general_ci`)*
+collation  テーブル照合順序の定義 *(デフォルトは `utf8mb4_unicode_ci`)*
 signed     主キーが ``符号付き`` かどうか
 ========== ===========
 

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -243,7 +243,7 @@ class MysqlAdapter extends PdoAdapter
         // This method is based on the MySQL docs here: http://dev.mysql.com/doc/refman/5.1/en/create-index.html
         $defaultOptions = [
             'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci',
+            'collation' => 'utf8mb4_unicode_ci',
         ];
 
         $options = array_merge(

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -141,7 +141,7 @@ class MysqlAdapterTest extends TestCase
     {
         $sql = "CREATE TABLE `discouraged.naming.convention`
                 (id INT(11) NOT NULL)
-                ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci";
+                ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
         $this->adapter->execute($sql);
         $this->assertTrue($this->adapter->hasTable('discouraged.naming.convention'));
     }
@@ -348,7 +348,7 @@ class MysqlAdapterTest extends TestCase
     public function testCreateTableWithUniqueIndexes()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
-        $table->addColumn('email', 'string')
+        $table->addColumn('email', 'string', ['limit' => 191])
               ->addIndex('email', ['unique' => true])
               ->save();
         $this->assertTrue($this->adapter->hasIndex('table1', ['email']));
@@ -394,8 +394,8 @@ class MysqlAdapterTest extends TestCase
     public function testCreateTableAndInheritDefaultCollation()
     {
         $options = MYSQL_DB_CONFIG + [
-            'charset' => 'utf8',
-            'collation' => 'utf8_unicode_ci',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
         ];
         $adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
 
@@ -409,7 +409,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $this->assertTrue($adapter->hasTable('table_with_default_collation'));
         $row = $adapter->fetchRow(sprintf("SHOW TABLE STATUS WHERE Name = '%s'", 'table_with_default_collation'));
-        $this->assertEquals('utf8_unicode_ci', $row['Collation']);
+        $this->assertEquals('utf8mb4_unicode_ci', $row['Collation']);
     }
 
     public function testCreateTableWithLatin1Collate()
@@ -742,14 +742,14 @@ class MysqlAdapterTest extends TestCase
 
     public function testAddStringColumnWithCustomCollation()
     {
-        $table = new \Phinx\Db\Table('table_custom_collation', ['collation' => 'utf8_general_ci'], $this->adapter);
+        $table = new \Phinx\Db\Table('table_custom_collation', ['collation' => 'utf8mb4_unicode_ci'], $this->adapter);
         $table->save();
         $this->assertFalse($table->hasColumn('string_collation_default'));
         $this->assertFalse($table->hasColumn('string_collation_custom'));
         $table->addColumn('string_collation_default', 'string', [])->save();
         $table->addColumn('string_collation_custom', 'string', ['collation' => 'utf8mb4_unicode_ci'])->save();
         $rows = $this->adapter->fetchAll('SHOW FULL COLUMNS FROM table_custom_collation');
-        $this->assertEquals('utf8_general_ci', $rows[1]['Collation']);
+        $this->assertEquals('utf8mb4_unicode_ci', $rows[1]['Collation']);
         $this->assertEquals('utf8mb4_unicode_ci', $rows[2]['Collation']);
     }
 
@@ -1733,7 +1733,7 @@ class MysqlAdapterTest extends TestCase
             ->save();
 
         $expectedOutput = <<<'OUTPUT'
-CREATE TABLE `table1` (`id` INT(11) NOT NULL AUTO_INCREMENT, `column1` VARCHAR(255) NOT NULL, `column2` INT(11) NOT NULL, `column3` VARCHAR(255) NOT NULL DEFAULT 'test', PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
+CREATE TABLE `table1` (`id` INT(11) NOT NULL AUTO_INCREMENT, `column1` VARCHAR(255) NOT NULL, `column2` INT(11) NOT NULL, `column3` VARCHAR(255) NOT NULL DEFAULT 'test', PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
         $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');
@@ -1850,7 +1850,7 @@ OUTPUT;
         ])->save();
 
         $expectedOutput = <<<'OUTPUT'
-CREATE TABLE `table1` (`column1` VARCHAR(255) NOT NULL, `column2` INT(11) NOT NULL, PRIMARY KEY (`column1`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
+CREATE TABLE `table1` (`column1` VARCHAR(255) NOT NULL, `column2` INT(11) NOT NULL, PRIMARY KEY (`column1`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 INSERT INTO `table1` (`column1`, `column2`) VALUES ('id1', 1);
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();

--- a/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205056_first_fk_index_migration.php
+++ b/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205056_first_fk_index_migration.php
@@ -10,8 +10,8 @@ class FirstFkIndexMigration extends AbstractMigration
                 'id' => false,
                 'primary_key' => ['id'],
                 'engine' => 'InnoDB',
-                'encoding' => 'utf8',
-                'collation' => 'utf8_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
                 'comment' => '',
                 'row_format' => 'DYNAMIC',
             ])
@@ -26,8 +26,8 @@ class FirstFkIndexMigration extends AbstractMigration
                 'id' => false,
                 'primary_key' => ['id'],
                 'engine' => 'InnoDB',
-                'encoding' => 'utf8',
-                'collation' => 'utf8_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
                 'comment' => '',
                 'row_format' => 'DYNAMIC',
             ])
@@ -42,8 +42,8 @@ class FirstFkIndexMigration extends AbstractMigration
                 'id' => false,
                 'primary_key' => ['id'],
                 'engine' => 'InnoDB',
-                'encoding' => 'utf8',
-                'collation' => 'utf8_unicode_ci',
+                'encoding' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
                 'comment' => '',
                 'row_format' => 'DYNAMIC',
             ])
@@ -88,8 +88,8 @@ class FirstFkIndexMigration extends AbstractMigration
             'id' => false,
             'primary_key' => ['id'],
             'engine' => 'InnoDB',
-            'encoding' => 'utf8',
-            'collation' => 'utf8_unicode_ci',
+            'encoding' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
             'comment' => '',
             'row_format' => 'DYNAMIC',
         ])

--- a/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205060_second_fk_index_migration.php
+++ b/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205060_second_fk_index_migration.php
@@ -11,7 +11,7 @@ class SecondFkIndexMigration extends AbstractMigration
             'primary_key' => ['id'],
             'engine' => 'InnoDB',
             'encoding' => 'utf8',
-            'collation' => 'utf8_unicode_ci',
+            'collation' => 'utf8mb4_unicode_ci',
             'comment' => '',
             'row_format' => 'DYNAMIC',
         ])


### PR DESCRIPTION
closes #1763

This makes `utf8mb4_general_ci` the default collation for MySQL tables over `utf8_general_ci`. The prior default made sense 7+ years ago when computing power for servers was more limited, but nowadays, the performance gained is increasingly minimal over the necessary deal of handling the greater nuances of capitalization of different languages and their characters by default that the original `utf8` schema lacked for MySQL.