### PR TITLE
remove deprecated hasSchemaTable function

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -289,14 +289,6 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
-     * @inheritdoc
-     */
-    public function hasSchemaTable()
-    {
-        return $this->hasTable($this->getSchemaTableName());
-    }
-
-    /**
      * @inheritDoc
      *
      * @throws \InvalidArgumentException

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -204,15 +204,6 @@ interface AdapterInterface
     public function unsetBreakpoint(MigrationInterface $migration);
 
     /**
-     * Does the schema table exist?
-     *
-     * @deprecated use hasTable instead.
-     *
-     * @return bool
-     */
-    public function hasSchemaTable();
-
-    /**
      * Creates the schema table.
      *
      * @return void

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -263,14 +263,6 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasSchemaTable()
-    {
-        return $this->getAdapter()->hasSchemaTable();
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function createSchemaTable()
     {
         $this->getAdapter()->createSchemaTable();

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -115,7 +115,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         $this->connection = $connection;
 
         // Create the schema table if it doesn't already exist
-        if (!$this->hasSchemaTable()) {
+        if (!$this->hasTable($this->getSchemaTableName())) {
             $this->createSchemaTable();
         } else {
             $table = new DbTable($this->getSchemaTableName(), [], $this);


### PR DESCRIPTION
Removes the deprecated function hasSchemaTable. This has been deprecated for 6+ years, and is probably safe to remove in terms of giving advance notice.