### PR TITLE
remove insert method from MigrationInterface

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -233,19 +233,6 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function insert($table, $data)
-    {
-        trigger_error('insert() is deprecated since 0.10.0. Use $this->table($tableName)->insert($data)->save() instead.', E_USER_DEPRECATED);
-        // convert to table object
-        if (is_string($table)) {
-            $table = new Table($table, [], $this->getAdapter());
-        }
-        $table->insert($data)->save();
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function createDatabase($name, $options)
     {
         $this->getAdapter()->createDatabase($name, $options);

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -187,18 +187,6 @@ interface MigrationInterface
     public function fetchAll($sql);
 
     /**
-     * Insert data into a table.
-     *
-     * @deprecated since 0.10.0. Use $this->table($tableName)->insert($data)->save() instead.
-     *
-     * @param string $tableName Table name
-     * @param array $data Data
-     *
-     * @return void
-     */
-    public function insert($tableName, $data);
-
-    /**
      * Create a new database.
      *
      * @param string $name Database Name

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -158,50 +158,6 @@ class AbstractMigrationTest extends TestCase
         $this->assertEquals([['0' => 'bar', 'foo' => 'bar']], $migrationStub->fetchAll('SELECT FOO FROM BAR'));
     }
 
-    public function testInsertTable()
-    {
-        // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
-
-        // stub adapter
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $adapterStub->expects($this->once())
-                    ->method('bulkinsert');
-
-        $table = new Table('testdb', [], $adapterStub);
-
-        $migrationStub->setAdapter($adapterStub);
-        @$migrationStub->insert($table, ['row' => 'value']);
-    }
-
-    public function testInsertString()
-    {
-        // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
-
-        // stub adapter
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $adapterStub->expects($this->once())
-            ->method('bulkinsert');
-
-        $migrationStub->setAdapter($adapterStub);
-        @$migrationStub->insert('testdb', ['row' => 'value']);
-    }
-
-    public function testInsertDeprecated()
-    {
-        // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
-
-        $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
-
-        $migrationStub->insert('testdb', ['row' => 'value']);
-    }
-
     public function testCreateDatabase()
     {
         // stub migration


### PR DESCRIPTION
This method was deprecated 2+ years ago. Given no one has complained about it, safe to remove I think, and make the recommended way the only way to do it.