### PR TITLE
remove check on column type for setting collation / encoding

### DIFF
--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -637,21 +637,10 @@ class Column
      *
      * @param string $collation Collation
      *
-     * @throws \UnexpectedValueException If collation not allowed for type
-     *
      * @return $this
      */
     public function setCollation($collation)
     {
-        $allowedTypes = [
-            AdapterInterface::PHINX_TYPE_CHAR,
-            AdapterInterface::PHINX_TYPE_STRING,
-            AdapterInterface::PHINX_TYPE_TEXT,
-        ];
-        if (!in_array($this->getType(), $allowedTypes, true)) {
-            throw new UnexpectedValueException('Collation may be set only for types: ' . implode(', ', $allowedTypes));
-        }
-
         $this->collation = $collation;
 
         return $this;
@@ -672,21 +661,10 @@ class Column
      *
      * @param string $encoding Encoding
      *
-     * @throws \UnexpectedValueException If character set not allowed for type
-     *
      * @return $this
      */
     public function setEncoding($encoding)
     {
-        $allowedTypes = [
-            AdapterInterface::PHINX_TYPE_CHAR,
-            AdapterInterface::PHINX_TYPE_STRING,
-            AdapterInterface::PHINX_TYPE_TEXT,
-        ];
-        if (!in_array($this->getType(), $allowedTypes, true)) {
-            throw new UnexpectedValueException('Character set may be set only for types: ' . implode(', ', $allowedTypes));
-        }
-
         $this->encoding = $encoding;
 
         return $this;


### PR DESCRIPTION
Closes #1876 

This removes the exception thrown for setting a collation or encoding for an invalid column type, instead pushing it down to an expectation on the DB throwing an exception for us. It's probably preferable to do this as then phinx is not responsible for maintaining a list of valid types (some which may be only valid for specific adapters if collation is expanded to other DBs like postgres) and also avoiding a potential quagmire with dealing with someone using collation with a valid `Phinx\Util\Literal` (e.g. `Phinx\Util\Literal::from('longtext')`) or god forbid if they're allowed with custom types.

There was no prior test on the exception case for these functions, and there are existing types on the usage of collation / encoding, so no tests were introduced, changed, or removed.