### PR TITLE
Mysql - Ensure a default of CURRENT_TIMESTAMP(3) is not quoted

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -581,7 +581,8 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     protected function getDefaultValueDefinition($default, $columnType = null)
     {
-        if (is_string($default) && $default !== 'CURRENT_TIMESTAMP') {
+        // Ensure a defaults of CURRENT_TIMESTAMP(3) is not quoted.
+        if (is_string($default) && strpos($default, 'CURRENT_TIMESTAMP') !== 0) {
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {
             $default = $this->castToBool($default);

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2019,7 +2019,7 @@ INPUT;
     public function testCreateTableWithPrecisionCurrentTimestamp()
     {
         $this->adapter->connect();
-        (new \Phinx\Db\Table('exampleCurrentTimestamp3', ['id' => false,], $this->adapter))
+        (new \Phinx\Db\Table('exampleCurrentTimestamp3', ['id' => false], $this->adapter))
             ->addColumn('timestamp_3', 'timestamp', [
                 'null' => false,
                 'default' => 'CURRENT_TIMESTAMP(3)',

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2015,4 +2015,23 @@ INPUT;
         $this->assertTrue(in_array('mediumblob', $validTypes, true));
         $this->assertTrue(in_array('longblob', $validTypes, true));
     }
+
+    public function testCreateTableWithPrecisionCurrentTimestamp()
+    {
+        $tableComment = 'Table comment';
+        $this->table('exampleCurrentTimestamp3', ['id' => false,])
+            ->addColumn('timestamp_3', 'timestamp', [
+                'null' => false,
+                'default' => 'CURRENT_TIMESTAMP(3)',
+                'limit' => 3
+            ])
+            ->create();
+
+        $rows = $this->adapter->fetchAll(sprintf(
+            "SELECT COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='exampleCurrentTimestamp3'",
+            MYSQL_DB_CONFIG['name']
+        ));
+        $colDef = $rows[0];
+        $this->assertEquals($tableComment, $colDef['COLUMN_DEFAULT'], 'CURRENT_TIMESTAMP(3)');
+    }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2018,8 +2018,8 @@ INPUT;
 
     public function testCreateTableWithPrecisionCurrentTimestamp()
     {
-        $tableComment = 'Table comment';
-        $this->table('exampleCurrentTimestamp3', ['id' => false,])
+        $this->adapter->connect();
+        (new \Phinx\Db\Table('exampleCurrentTimestamp3', ['id' => false,], $this->adapter))
             ->addColumn('timestamp_3', 'timestamp', [
                 'null' => false,
                 'default' => 'CURRENT_TIMESTAMP(3)',
@@ -2032,6 +2032,6 @@ INPUT;
             MYSQL_DB_CONFIG['name']
         ));
         $colDef = $rows[0];
-        $this->assertEquals($tableComment, $colDef['COLUMN_DEFAULT'], 'CURRENT_TIMESTAMP(3)');
+        $this->assertEquals('CURRENT_TIMESTAMP(3)', $colDef['COLUMN_DEFAULT']);
     }
 }


### PR DESCRIPTION
Allow for the following:
```
$this->table('exampleFailure', [
	'id' => false,
])
	->addColumn('created_at', 'timestamp', [
		'null' => false,
		'default' => 'CURRENT_TIMESTAMP(3)',
		'limit' => 3,
		'after' => 'displayType',
	])
	->create();
```
which before gave the following "Syntax error or access violation: 1067 Invalid default value for 'created_at'" as it was a quoted string of