### PR TITLE
mark return type of SeedInterface::query as mixed

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -297,7 +297,9 @@ interface AdapterInterface
     public function getQueryBuilder();
 
     /**
-     * Executes a SQL statement and returns the result as an array.
+     * Executes a SQL statement.
+     *
+     * The return type depends on the underlying adapter being used.
      *
      * @param string $sql SQL
      *

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -143,11 +143,12 @@ interface MigrationInterface
     public function execute($sql);
 
     /**
-     * Executes a SQL statement and returns the result as an array.
+     * Executes a SQL statement.
      *
-     * To improve IDE auto-completion possibility, you can overwrite the query method
-     * phpDoc in your (typically custom abstract parent) migration class, where you can set
-     * the return type by the adapter in your current use.
+     * The return type depends on the underlying adapter being used. To improve
+     * IDE auto-completion possibility, you can overwrite the query method
+     * phpDoc in your (typically custom abstract parent) migration class, where
+     * you can set the return type by the adapter in your current use.
      *
      * @param string $sql SQL
      *

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -100,11 +100,16 @@ interface SeedInterface
     public function execute($sql);
 
     /**
-     * Executes a SQL statement and returns the result as an array.
+     * Executes a SQL statement.
+     *
+     * The return type depends on the underlying adapter being used. To improve
+     * IDE auto-completion possibility, you can overwrite the query method
+     * phpDoc in your (typically custom abstract parent) seed class, where
+     * you can set the return type by the adapter in your current use.
      *
      * @param string $sql SQL
      *
-     * @return array
+     * @return mixed
      */
     public function query($sql);
 


### PR DESCRIPTION
This is a continuation of work done in #1691, where it only updated the return type of the `MigrationInterface`, and not the `SeedInterface`.

The underlying driver by default will always return a `PDOStatement`, and never an array, so the typehint here causes issues downstream in typing help. Changed it to mixed as the above PR notes, a custom adapter may implement any return type, and so cannot make it more specific than that here.

I also updated the docstrings of two other query methods to indicate that they do not infact return arrays, and their return type is based on the underlying adapter implementation.