### PR TITLE
trigger deprecation notice when using default_database

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -214,6 +214,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
 
         // deprecated: to be removed 0.13
         if (isset($this->values['environments']['default_database'])) {
+            trigger_error('default_database in the config has been deprecated since 0.12, use default_environment instead.', E_USER_DEPRECATED);
             $this->values['environments']['default_environment'] = $this->values['environments']['default_database'];
         }
 

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -103,6 +103,20 @@ class ConfigTest extends AbstractConfigTest
     }
 
     /**
+     * @covers \Phinx\Config\Config::getDefaultEnvironment
+     */
+    public function testDeprecatedDefaultDatabase()
+    {
+        $configArray = $this->getConfigArray();
+        $configArray['environments']['default_database'] = 'production';
+        $config = new Config($configArray);
+
+        $this->expectDeprecation();
+        $this->expectExceptionMessage('default_database in the config has been deprecated since 0.12, use default_environment instead.');
+        $this->assertEquals('production', $config->getDefaultEnvironment());
+    }
+
+    /**
      * @covers \Phinx\Config\Config::offsetGet
      * @covers \Phinx\Config\Config::offsetSet
      * @covers \Phinx\Config\Config::offsetExists

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -105,7 +105,25 @@ class ConfigTest extends AbstractConfigTest
     /**
      * @covers \Phinx\Config\Config::getDefaultEnvironment
      */
-    public function testDeprecatedDefaultDatabase()
+    public function testGetDefaultEnvironmentUsingDefaultDatabase()
+    {
+        $configArray = $this->getConfigArray();
+        $configArray['environments']['default_database'] = 'production';
+        $config = new Config($configArray);
+
+        $errorReporting = error_reporting();
+        try {
+            error_reporting(E_ALL ^ E_USER_DEPRECATED);
+            $this->assertEquals('production', $config->getDefaultEnvironment());
+        } finally {
+            error_reporting($errorReporting);
+        }
+    }
+
+    /**
+     * @covers \Phinx\Config\Config::getDefaultEnvironment
+     */
+    public function testDefaultDatabaseThrowsDeprecatedNotice()
     {
         $configArray = $this->getConfigArray();
         $configArray['environments']['default_database'] = 'production';
@@ -113,7 +131,7 @@ class ConfigTest extends AbstractConfigTest
 
         $this->expectDeprecation();
         $this->expectExceptionMessage('default_database in the config has been deprecated since 0.12, use default_environment instead.');
-        $this->assertEquals('production', $config->getDefaultEnvironment());
+        $config->getDefaultEnvironment();
     }
 
     /**

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -97,7 +97,7 @@ class ConfigTest extends AbstractConfigTest
     public function testGetDefaultEnvironmentUsingDatabaseKey()
     {
         $configArray = $this->getConfigArray();
-        $configArray['environments']['default_database'] = 'production';
+        $configArray['environments']['default_environment'] = 'production';
         $config = new Config($configArray);
         $this->assertEquals('production', $config->getDefaultEnvironment());
     }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -98,7 +98,7 @@ class MigrateTest extends TestCase
             ],
             'environments' => [
                 'default_migration_table' => 'phinxlog',
-                'default_database' => 'development',
+                'default_environment' => 'development',
                 'development' => [
                     'dsn' => 'mysql://fakehost:3006/development',
                 ],

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -97,7 +97,7 @@ class SeedRunTest extends TestCase
             ],
             'environments' => [
                 'default_migration_table' => 'phinxlog',
-                'default_database' => 'development',
+                'default_environment' => 'development',
                 'development' => [
                     'dsn' => 'mysql://fakehost:3006/development',
                 ],

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -111,7 +111,7 @@ class StatusTest extends TestCase
             ],
             'environments' => [
                 'default_migration_table' => 'phinxlog',
-                'default_database' => 'development',
+                'default_environment' => 'development',
                 'development' => [
                     'dsn' => 'pgsql://fakehost:5433/development',
                 ],


### PR DESCRIPTION
This was deprecated with the 0.12 release, but was only deprecated within the release notes. This adds a deprecation notice into the codebase that is triggered on usage to hopefully help ensure users are not surprised when this does actually get removed.