### PR TITLE
remove extraneous argument to flightChecks

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -303,11 +303,9 @@ abstract class AbstractMigration implements MigrationInterface
      * Right now, the only check is if there is both a `change()` and
      * an `up()` or a `down()` method.
      *
-     * @param string|null $direction Direction
-     *
      * @return void
      */
-    public function preFlightCheck($direction = null)
+    public function preFlightCheck()
     {
         if (method_exists($this, MigrationInterface::CHANGE)) {
             if (
@@ -315,7 +313,7 @@ abstract class AbstractMigration implements MigrationInterface
                 method_exists($this, MigrationInterface::DOWN)
             ) {
                 $this->output->writeln(sprintf(
-                    '<comment>warning</comment> Migration contains both change() and/or up()/down() methods.  <options=bold>Ignoring up() and down()</>.'
+                    '<comment>warning</comment> Migration contains both change() and up()/down() methods.  <options=bold>Ignoring up() and down()</>.'
                 ));
             }
         }
@@ -326,13 +324,11 @@ abstract class AbstractMigration implements MigrationInterface
      *
      * Right now, the only check is whether all changes were committed
      *
-     * @param string|null $direction direction of migration
-     *
      * @throws \RuntimeException
      *
      * @return void
      */
-    public function postFlightCheck($direction = null)
+    public function postFlightCheck()
     {
         foreach ($this->tables as $table) {
             if ($table->hasPendingActions()) {

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -80,7 +80,7 @@ class Environment
         $startTime = time();
         $migration->setAdapter($this->getAdapter());
 
-        $migration->preFlightCheck($direction);
+        $migration->preFlightCheck();
 
         if (method_exists($migration, MigrationInterface::INIT)) {
             $migration->{MigrationInterface::INIT}();
@@ -118,7 +118,7 @@ class Environment
             }
         }
 
-        $migration->postFlightCheck($direction);
+        $migration->postFlightCheck();
 
         // Record it in the database
         $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -250,23 +250,19 @@ interface MigrationInterface
     public function table($tableName, $options);
 
     /**
-     * Perform checks on the migration, print a warning
+     * Perform checks on the migration, printing a warning
      * if there are potential problems.
-     *
-     * @param string|null $direction Direction
      *
      * @return void
      */
-    public function preFlightCheck($direction = null);
+    public function preFlightCheck();
 
     /**
      * Perform checks on the migration after completion
      *
      * Right now, the only check is whether all changes were committed
      *
-     * @param string|null $direction direction of migration
-     *
      * @return void
      */
-    public function postFlightCheck($direction = null);
+    public function postFlightCheck();
 }


### PR DESCRIPTION
The argument to the flight checks is unnecessary now with the change from #1873 as now `preFlightCheck` will be run after the `setMigratingUp` method has been called (previously it was not). This was change was not done in #1873 to allow that patch to land in 0.12.x release, while the clean-up here will coincide with other BC breaking changes to the interfaces.