### PR TITLE
Use CakePHP 3 code standard for stickler

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,6 @@
 linters:
   phpcs:
-    standard: CakePHP
+    standard: CakePHP3
     fixer: true
 
 files:


### PR DESCRIPTION
As suggested on slack, this makes it so that stickler-ci should use the same standard as phpcs. This allows developers to test their code locally and expect it to then pass the stickler on PR creation reasonably (e.g. like in #1888), and vice versa.

The next step would be to look at `cakephp/cakephp-codesniffer:^4` for phpcs, but that will require a much greater scope of change which I think should be done peacemeal over time.