### PR TITLE
Enable most of cakephp-codesniffer 4

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,6 @@
 linters:
   phpcs:
-    standard: CakePHP3
+    standard: CakePHP
     fixer: true
 
 files:

--- a/app/web.php
+++ b/app/web.php
@@ -63,8 +63,8 @@ if (!isset($routes[$command])) {
 }
 
 // Get the environment and target version parameters.
-$env = isset($_GET['e']) ? $_GET['e'] : null;
-$target = isset($_GET['t']) ? $_GET['t'] : null;
+$env = $_GET['e'] ?? null;
+$target = $_GET['t'] ?? null;
 
 // Check if debugging is enabled.
 $debug = !empty($_GET['debug']) && filter_var($_GET['debug'], FILTER_VALIDATE_BOOLEAN);

--- a/composer.json
+++ b/composer.json
@@ -59,8 +59,8 @@
             "@test",
             "@cs-check"
         ],
-        "cs-check": "phpcs",
-        "cs-fix": "phpcbf",
+        "cs-check": "phpcs -nps --colors",
+        "cs-fix": "phpcbf -nps --colors",
         "stan": "phpstan analyse src/",
         "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 && mv composer.backup composer.json",
         "test": "phpunit --colors=always"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,8 +6,11 @@
     <file>src</file>
     <file>tests</file>
 
-    <arg name="colors"/>
-    <arg value="np"/>
+    <exclude-pattern>*/tests/*/_files*</exclude-pattern>
 
     <rule ref="CakePHP" />
+
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing">
+        <severity>0</severity>
+    </rule>
 </ruleset>

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -58,9 +58,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * Create a new instance of the config class using a Yaml file path.
      *
      * @param string $configFilePath Path to the Yaml File
-     *
      * @throws \RuntimeException
-     *
      * @return \Phinx\Config\Config
      */
     public static function fromYaml($configFilePath)
@@ -88,16 +86,14 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * Create a new instance of the config class using a JSON file path.
      *
      * @param string $configFilePath Path to the JSON File
-     *
      * @throws \RuntimeException
-     *
      * @return \Phinx\Config\Config
      */
     public static function fromJson($configFilePath)
     {
         if (!function_exists('json_decode')) {
             // @codeCoverageIgnoreStart
-            throw new RuntimeException("Need to install JSON PHP extension to use JSON config");
+            throw new RuntimeException('Need to install JSON PHP extension to use JSON config');
             // @codeCoverageIgnoreEnd
         }
 
@@ -116,16 +112,14 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * Create a new instance of the config class using a PHP file path.
      *
      * @param string $configFilePath Path to the PHP File
-     *
      * @throws \RuntimeException
-     *
      * @return \Phinx\Config\Config
      */
     public static function fromPhp($configFilePath)
     {
         ob_start();
         /** @noinspection PhpIncludeInspection */
-        $configArray = include($configFilePath);
+        $configArray = include $configFilePath;
 
         // Hide console output
         ob_end_clean();
@@ -191,7 +185,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      */
     public function hasEnvironment($name)
     {
-        return ($this->getEnvironment($name) !== null);
+        return $this->getEnvironment($name) !== null;
     }
 
     /**
@@ -266,7 +260,6 @@ class Config implements ConfigInterface, NamespaceAwareInterface
 
     /**
      * @inheritDoc
-     *
      * @throws \UnexpectedValueException
      */
     public function getMigrationPaths()
@@ -286,7 +279,6 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * Gets the base class name for migrations.
      *
      * @param bool $dropNamespace Return the base migration class name without the namespace.
-     *
      * @return string
      */
     public function getMigrationBaseClassName($dropNamespace = true)
@@ -298,7 +290,6 @@ class Config implements ConfigInterface, NamespaceAwareInterface
 
     /**
      * @inheritDoc
-     *
      * @throws \UnexpectedValueException
      */
     public function getSeedPaths()
@@ -423,7 +414,6 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * Replace tokens in the specified array.
      *
      * @param array $arr Array to replace
-     *
      * @return array
      */
     protected function replaceTokens(array $arr)
@@ -452,7 +442,6 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param array $arr Array to recurse
      * @param string[] $tokens Array of tokens to search for
-     *
      * @return array
      */
     protected function recurseArrayForTokens($arr, $tokens)
@@ -480,7 +469,6 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * Parse a database-agnostic DSN into individual options.
      *
      * @param array $options Options
-     *
      * @return array
      */
     protected function parseAgnosticDsn(array $options)
@@ -505,7 +493,6 @@ class Config implements ConfigInterface, NamespaceAwareInterface
 
     /**
      * @inheritDoc
-     *
      * @throws \InvalidArgumentException
      */
     public function offsetGet($id)

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -33,7 +33,6 @@ interface ConfigInterface extends ArrayAccess
      * doesn't exist.
      *
      * @param string $name Environment Name
-     *
      * @return array|null
      */
     public function getEnvironment($name);
@@ -42,7 +41,6 @@ interface ConfigInterface extends ArrayAccess
      * Does the specified environment exist in the configuration file?
      *
      * @param string $name Environment Name
-     *
      * @return bool
      */
     public function hasEnvironment($name);
@@ -51,7 +49,6 @@ interface ConfigInterface extends ArrayAccess
      * Gets the default environment name.
      *
      * @throws \RuntimeException
-     *
      * @return string
      */
     public function getDefaultEnvironment();
@@ -60,7 +57,6 @@ interface ConfigInterface extends ArrayAccess
      * Get the aliased value from a supplied alias.
      *
      * @param string $alias Alias
-     *
      * @return string|null
      */
     public function getAlias($alias);
@@ -146,7 +142,6 @@ interface ConfigInterface extends ArrayAccess
      * Gets the base class name for migrations.
      *
      * @param bool $dropNamespace Return the base migration class name without the namespace.
-     *
      * @return string
      */
     public function getMigrationBaseClassName($dropNamespace = true);

--- a/src/Phinx/Config/NamespaceAwareInterface.php
+++ b/src/Phinx/Config/NamespaceAwareInterface.php
@@ -19,7 +19,6 @@ interface NamespaceAwareInterface
      * Get Migration Namespace associated with path.
      *
      * @param string $path Path
-     *
      * @return string|null
      */
     public function getMigrationNamespaceByPath($path);
@@ -28,7 +27,6 @@ interface NamespaceAwareInterface
      * Get Seed Namespace associated with path.
      *
      * @param string $path Path
-     *
      * @return string|null
      */
     public function getSeedNamespaceByPath($path);

--- a/src/Phinx/Config/NamespaceAwareTrait.php
+++ b/src/Phinx/Config/NamespaceAwareTrait.php
@@ -34,7 +34,6 @@ trait NamespaceAwareTrait
      *
      * @param string $needle Needle
      * @param string[] $haystack Haystack
-     *
      * @return string|null
      */
     protected function searchNamespace($needle, $haystack)
@@ -51,7 +50,6 @@ trait NamespaceAwareTrait
      * Get Migration Namespace associated with path.
      *
      * @param string $path Path
-     *
      * @return string|null
      */
     public function getMigrationNamespaceByPath($path)
@@ -65,7 +63,6 @@ trait NamespaceAwareTrait
      * Get Seed Namespace associated with path.
      *
      * @param string $path Path
-     *
      * @return string|null
      */
     public function getSeedNamespaceByPath($path)

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -60,18 +60,21 @@ abstract class AbstractCommand extends Command
 
     /**
      * Exit code for when command executes successfully
+     *
      * @var int
      */
     public const CODE_SUCCESS = 0;
 
     /**
      * Exit code for when command hits a non-recoverable error during execution
+     *
      * @var int
      */
     public const CODE_ERROR = 1;
 
     /**
      * Exit code for when status command is run and there are missing migrations
+     *
      * @var int
      */
     public const CODE_STATUS_MISSING = 2;
@@ -79,6 +82,7 @@ abstract class AbstractCommand extends Command
     /**
      * Exit code for when status command is run and there are no missing migations,
      * but does have down migrations
+     *
      * @var int
      */
     public const CODE_STATUS_DOWN = 3;
@@ -99,7 +103,6 @@ abstract class AbstractCommand extends Command
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return void
      */
     public function bootstrap(InputInterface $input, OutputInterface $output)
@@ -112,7 +115,8 @@ abstract class AbstractCommand extends Command
 
         $this->loadManager($input, $output);
 
-        if ($bootstrap = $this->getConfig()->getBootstrapFile()) {
+        $bootstrap = $this->getConfig()->getBootstrapFile();
+        if ($bootstrap) {
             $output->writeln('<info>using bootstrap</info> ' . Util::relativePath($bootstrap) . ' ');
             Util::loadPhpFile($bootstrap);
         }
@@ -143,7 +147,6 @@ abstract class AbstractCommand extends Command
      * Sets the config.
      *
      * @param \Phinx\Config\ConfigInterface $config Config
-     *
      * @return $this
      */
     public function setConfig(ConfigInterface $config)
@@ -167,7 +170,6 @@ abstract class AbstractCommand extends Command
      * Sets the database adapter.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Adapter
-     *
      * @return $this
      */
     public function setAdapter(AdapterInterface $adapter)
@@ -191,7 +193,6 @@ abstract class AbstractCommand extends Command
      * Sets the migration manager.
      *
      * @param \Phinx\Migration\Manager $manager Manager
-     *
      * @return $this
      */
     public function setManager(Manager $manager)
@@ -215,7 +216,6 @@ abstract class AbstractCommand extends Command
      * Returns config file path
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     *
      * @return string
      */
     protected function locateConfigFile(InputInterface $input)
@@ -257,9 +257,7 @@ abstract class AbstractCommand extends Command
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     protected function loadConfig(InputInterface $input, OutputInterface $output)
@@ -313,7 +311,6 @@ abstract class AbstractCommand extends Command
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return void
      */
     protected function loadManager(InputInterface $input, OutputInterface $output)
@@ -336,9 +333,7 @@ abstract class AbstractCommand extends Command
      * Verify that the migration directory exists and is writable.
      *
      * @param string $path Path
-     *
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     protected function verifyMigrationDirectory($path)
@@ -362,9 +357,7 @@ abstract class AbstractCommand extends Command
      * Verify that the seed directory exists and is writable.
      *
      * @param string $path Path
-     *
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     protected function verifySeedDirectory($path)

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -53,9 +53,7 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @throws \InvalidArgumentException
-     *
      * @return int integer 0 on success, or an error code.
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -74,7 +74,6 @@ class Create extends AbstractCommand
      * Get the question that allows the user to select which migration path to use.
      *
      * @param string[] $paths Paths
-     *
      * @return \Symfony\Component\Console\Question\ChoiceQuestion
      */
     protected function getSelectMigrationPathQuestion(array $paths)
@@ -87,9 +86,7 @@ class Create extends AbstractCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @throws \Exception
-     *
      * @return string
      */
     protected function getMigrationPath(InputInterface $input, OutputInterface $output)
@@ -135,10 +132,8 @@ class Create extends AbstractCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     *
      * @return int 0 on success
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -167,7 +162,7 @@ class Create extends AbstractCommand
         $className = $input->getArgument('name');
         if ($className === null) {
             $currentTimestamp = Util::getCurrentTimestamp();
-            $className = "V" . $currentTimestamp;
+            $className = 'V' . $currentTimestamp;
             $fileName = $currentTimestamp . '.php';
         } else {
             if (!Util::isValidPhinxClassName($className)) {
@@ -184,7 +179,7 @@ class Create extends AbstractCommand
         if (!Util::isUniqueMigrationClassName($className, $path)) {
             throw new InvalidArgumentException(sprintf(
                 'The migration class name "%s%s" already exists',
-                $namespace ? ($namespace . '\\') : '',
+                $namespace ? $namespace . '\\' : '',
                 $className
             ));
         }

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -61,7 +61,6 @@ class Init extends Command
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Interface implemented by all input classes.
      * @param \Symfony\Component\Console\Output\OutputInterface $output Interface implemented by all output classes.
-     *
      * @return int 0 on success
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -80,9 +79,7 @@ class Init extends Command
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Interface implemented by all input classes.
      * @param string $format Format to resolve for
-     *
      * @throws \InvalidArgumentException
-     *
      * @return string
      */
     protected function resolvePath(InputInterface $input, $format)
@@ -133,10 +130,8 @@ class Init extends Command
      *
      * @param string $path Config file's path.
      * @param string $format Format to use for config file
-     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
-     *
      * @return void
      */
     protected function writeConfig($path, $format = AbstractCommand::FORMAT_DEFAULT)

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -36,7 +36,6 @@ class ListAliases extends AbstractCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return int 0 on success
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -55,7 +55,6 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return int integer 0 on success, or an error code.
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -63,7 +63,6 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return int integer 0 on success, or an error code.
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -134,9 +133,7 @@ EOT
      * Get Target from Date
      *
      * @param string $date The date to convert to a target.
-     *
      * @throws \InvalidArgumentException
-     *
      * @return string The target
      */
     public function getTargetFromDate($date)

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -60,7 +60,6 @@ class SeedCreate extends AbstractCommand
      * Get the question that allows the user to select which seed path to use.
      *
      * @param string[] $paths Paths
-     *
      * @return \Symfony\Component\Console\Question\ChoiceQuestion
      */
     protected function getSelectSeedPathQuestion(array $paths)
@@ -73,9 +72,7 @@ class SeedCreate extends AbstractCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @throws \Exception
-     *
      * @return string
      */
     protected function getSeedPath(InputInterface $input, OutputInterface $output)
@@ -121,10 +118,8 @@ class SeedCreate extends AbstractCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     *
      * @return int 0 on success
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -49,7 +49,6 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return int integer 0 on success, or an error code.
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -48,7 +48,6 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return int 0 if all migrations are up, or an error code
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -75,7 +74,7 @@ EOT
             $output->writeln('<info>using format</info> ' . $format);
         }
 
-        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder() . " time");
+        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder() . ' time');
 
         // print the status
         $result = $this->getManager()->printStatus($environment, $format);

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -53,9 +53,7 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @throws \InvalidArgumentException
-     *
      * @return int 0 on success
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -54,7 +54,6 @@ class PhinxApplication extends Application
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input An Input instance
      * @param \Symfony\Component\Console\Output\OutputInterface $output An Output instance
-     *
      * @return int 0 if everything went fine, or an error code
      */
     public function doRun(InputInterface $input, OutputInterface $output)

--- a/src/Phinx/Db/Action/AddColumn.php
+++ b/src/Phinx/Db/Action/AddColumn.php
@@ -38,7 +38,6 @@ class AddColumn extends Action
      * @param string $columnName The column name
      * @param mixed $type The column type
      * @param mixed $options The column options
-     *
      * @return \Phinx\Db\Action\AddColumn
      */
     public static function build(Table $table, $columnName, $type = null, $options = [])

--- a/src/Phinx/Db/Action/AddForeignKey.php
+++ b/src/Phinx/Db/Action/AddForeignKey.php
@@ -41,7 +41,6 @@ class AddForeignKey extends Action
      * @param string|string[] $referencedColumns The columns in the referenced table
      * @param array $options Extra options for the foreign key
      * @param string|null $name The name of the foreign key
-     *
      * @return \Phinx\Db\Action\AddForeignKey
      */
     public static function build(Table $table, $columns, $referencedTable, $referencedColumns = ['id'], array $options = [], $name = null)

--- a/src/Phinx/Db/Action/AddIndex.php
+++ b/src/Phinx/Db/Action/AddIndex.php
@@ -38,7 +38,6 @@ class AddIndex extends Action
      * @param \Phinx\Db\Table\Table $table The table to add the index to
      * @param mixed $columns The columns to index
      * @param array $options Additional options for the index creation
-     *
      * @return \Phinx\Db\Action\AddIndex
      */
     public static function build(Table $table, $columns, array $options = [])

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -53,7 +53,6 @@ class ChangeColumn extends Action
      * @param mixed $columnName The name of the column to change
      * @param mixed $type The type of the column
      * @param mixed $options Additional options for the column
-     *
      * @return \Phinx\Db\Action\ChangeColumn
      */
     public static function build(Table $table, $columnName, $type = null, $options = [])

--- a/src/Phinx/Db/Action/DropForeignKey.php
+++ b/src/Phinx/Db/Action/DropForeignKey.php
@@ -38,7 +38,6 @@ class DropForeignKey extends Action
      * @param \Phinx\Db\Table\Table $table The table to delete the foreign key from
      * @param string|string[] $columns The columns participating in the foreign key
      * @param string|null $constraint The constraint name
-     *
      * @return \Phinx\Db\Action\DropForeignKey
      */
     public static function build(Table $table, $columns, $constraint = null)

--- a/src/Phinx/Db/Action/DropIndex.php
+++ b/src/Phinx/Db/Action/DropIndex.php
@@ -37,7 +37,6 @@ class DropIndex extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the index is
      * @param string[] $columns the indexed columns
-     *
      * @return \Phinx\Db\Action\DropIndex
      */
     public static function build(Table $table, array $columns = [])
@@ -54,7 +53,6 @@ class DropIndex extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the index is
      * @param string $name The name of the index
-     *
      * @return \Phinx\Db\Action\DropIndex
      */
     public static function buildFromName(Table $table, $name)

--- a/src/Phinx/Db/Action/RemoveColumn.php
+++ b/src/Phinx/Db/Action/RemoveColumn.php
@@ -37,7 +37,6 @@ class RemoveColumn extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the column is
      * @param mixed $columnName The name of the column to drop
-     *
      * @return \Phinx\Db\Action\RemoveColumn
      */
     public static function build(Table $table, $columnName)

--- a/src/Phinx/Db/Action/RenameColumn.php
+++ b/src/Phinx/Db/Action/RenameColumn.php
@@ -47,7 +47,6 @@ class RenameColumn extends Action
      * @param \Phinx\Db\Table\Table $table The table where the column is
      * @param mixed $columnName The name of the column to be changed
      * @param mixed $newName The new name for the column
-     *
      * @return \Phinx\Db\Action\RenameColumn
      */
     public static function build(Table $table, $columnName, $newName)

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -58,7 +58,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param \Symfony\Component\Console\Input\InputInterface|null $input Input Interface
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output Interface
      */
-    public function __construct(array $options, InputInterface $input = null, OutputInterface $output = null)
+    public function __construct(array $options, ?InputInterface $input = null, ?OutputInterface $output = null)
     {
         $this->setOptions($options);
         if ($input !== null) {
@@ -158,7 +158,6 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      * @inheritDoc
-     *
      * @return array
      */
     public function getVersions()
@@ -182,7 +181,6 @@ abstract class AbstractAdapter implements AdapterInterface
      * Sets the schema table name.
      *
      * @param string $schemaTableName Schema Table Name
-     *
      * @return $this
      */
     public function setSchemaTableName($schemaTableName)
@@ -298,9 +296,7 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      * @inheritDoc
-     *
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     public function createSchemaTable()
@@ -353,14 +349,13 @@ abstract class AbstractAdapter implements AdapterInterface
         /** @var \Symfony\Component\Console\Input\InputInterface|null $input */
         $input = $this->getInput();
 
-        return ($input && $input->hasOption('dry-run')) ? (bool)$input->getOption('dry-run') : false;
+        return $input && $input->hasOption('dry-run') ? (bool)$input->getOption('dry-run') : false;
     }
 
     /**
      * Adds user-created tables (e.g. not phinxlog) to a cached list
      *
      * @param string $tableName The name of the table
-     *
      * @return void
      */
     protected function addCreatedTable($tableName)
@@ -376,7 +371,6 @@ abstract class AbstractAdapter implements AdapterInterface
      *
      * @param string $tableName Original name of the table
      * @param string $newTableName New name of the table
-     *
      * @return void
      */
     protected function updateCreatedTableName($tableName, $newTableName)
@@ -393,7 +387,6 @@ abstract class AbstractAdapter implements AdapterInterface
      * Removes table from the cached created list
      *
      * @param string $tableName The name of the table
-     *
      * @return void
      */
     protected function removeCreatedTable($tableName)
@@ -409,7 +402,6 @@ abstract class AbstractAdapter implements AdapterInterface
      * Check if the table is in the cached list of created tables
      *
      * @param string $tableName The name of the table
-     *
      * @return bool
      */
     protected function hasCreatedTable($tableName)

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -65,9 +65,7 @@ class AdapterFactory
      *
      * @param string $name Name
      * @param string $class Class
-     *
      * @throws \RuntimeException
-     *
      * @return $this
      */
     public function registerAdapter($name, $class)
@@ -87,9 +85,7 @@ class AdapterFactory
      * Get an adapter class by name.
      *
      * @param string $name Name
-     *
      * @throws \RuntimeException
-     *
      * @return string
      */
     protected function getClass($name)
@@ -109,7 +105,6 @@ class AdapterFactory
      *
      * @param string $name Name
      * @param array $options Options
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter($name, array $options)
@@ -124,9 +119,7 @@ class AdapterFactory
      *
      * @param string $name Name
      * @param string $class Class
-     *
      * @throws \RuntimeException
-     *
      * @return $this
      */
     public function registerWrapper($name, $class)
@@ -146,9 +139,7 @@ class AdapterFactory
      * Get a wrapper class by name.
      *
      * @param string $name Name
-     *
      * @throws \RuntimeException
-     *
      * @return string
      */
     protected function getWrapperClass($name)
@@ -168,7 +159,6 @@ class AdapterFactory
      *
      * @param string $name Name
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Adapter
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getWrapper($name, AdapterInterface $adapter)

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -85,7 +85,6 @@ interface AdapterInterface
      * Set adapter configuration options.
      *
      * @param array $options Options
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setOptions(array $options);
@@ -101,7 +100,6 @@ interface AdapterInterface
      * Check if an option has been set.
      *
      * @param string $name Name
-     *
      * @return bool
      */
     public function hasOption($name);
@@ -110,7 +108,6 @@ interface AdapterInterface
      * Get a single adapter option, or null if the option does not exist.
      *
      * @param string $name Name
-     *
      * @return mixed
      */
     public function getOption($name);
@@ -119,7 +116,6 @@ interface AdapterInterface
      * Sets the console input.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setInput(InputInterface $input);
@@ -135,7 +131,6 @@ interface AdapterInterface
      * Sets the console output.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setOutput(OutputInterface $output);
@@ -164,7 +159,6 @@ interface AdapterInterface
      * @param string $direction Direction
      * @param string $startTime Start Time
      * @param string $endTime End Time
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime);
@@ -173,7 +167,6 @@ interface AdapterInterface
      * Toggle a migration breakpoint.
      *
      * @param \Phinx\Migration\MigrationInterface $migration Migration
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function toggleBreakpoint(MigrationInterface $migration);
@@ -189,7 +182,6 @@ interface AdapterInterface
      * Set a migration breakpoint.
      *
      * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint set
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setBreakpoint(MigrationInterface $migration);
@@ -198,7 +190,6 @@ interface AdapterInterface
      * Unset a migration breakpoint.
      *
      * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint unset
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function unsetBreakpoint(MigrationInterface $migration);
@@ -207,7 +198,6 @@ interface AdapterInterface
      * Does the schema table exist?
      *
      * @deprecated use hasTable instead.
-     *
      * @return bool
      */
     public function hasSchemaTable();
@@ -230,7 +220,6 @@ interface AdapterInterface
      * Initializes the database connection.
      *
      * @throws \RuntimeException When the requested database driver is not installed.
-     *
      * @return void
      */
     public function connect();
@@ -274,7 +263,6 @@ interface AdapterInterface
      * Executes a SQL statement and returns the number of affected rows.
      *
      * @param string $sql SQL
-     *
      * @return int
      */
     public function execute($sql);
@@ -284,7 +272,6 @@ interface AdapterInterface
      *
      * @param \Phinx\Db\Table\Table $table The table to execute the actions for
      * @param \Phinx\Db\Action\Action[] $actions The table to execute the actions for
-     *
      * @return void
      */
     public function executeActions(Table $table, array $actions);
@@ -302,7 +289,6 @@ interface AdapterInterface
      * The return type depends on the underlying adapter being used.
      *
      * @param string $sql SQL
-     *
      * @return mixed
      */
     public function query($sql);
@@ -311,7 +297,6 @@ interface AdapterInterface
      * Executes a query and returns only one row as an array.
      *
      * @param string $sql SQL
-     *
      * @return array
      */
     public function fetchRow($sql);
@@ -320,7 +305,6 @@ interface AdapterInterface
      * Executes a query and returns an array of rows.
      *
      * @param string $sql SQL
-     *
      * @return array
      */
     public function fetchAll($sql);
@@ -330,7 +314,6 @@ interface AdapterInterface
      *
      * @param \Phinx\Db\Table\Table $table Table where to insert data
      * @param array $row Row
-     *
      * @return void
      */
     public function insert(Table $table, $row);
@@ -340,7 +323,6 @@ interface AdapterInterface
      *
      * @param \Phinx\Db\Table\Table $table Table where to insert data
      * @param array $rows Rows
-     *
      * @return void
      */
     public function bulkinsert(Table $table, $rows);
@@ -349,7 +331,6 @@ interface AdapterInterface
      * Quotes a table name for use in a query.
      *
      * @param string $tableName Table name
-     *
      * @return string
      */
     public function quoteTableName($tableName);
@@ -358,7 +339,6 @@ interface AdapterInterface
      * Quotes a column name for use in a query.
      *
      * @param string $columnName Table name
-     *
      * @return string
      */
     public function quoteColumnName($columnName);
@@ -367,7 +347,6 @@ interface AdapterInterface
      * Checks to see if a table exists.
      *
      * @param string $tableName Table name
-     *
      * @return bool
      */
     public function hasTable($tableName);
@@ -378,7 +357,6 @@ interface AdapterInterface
      * @param \Phinx\Db\Table\Table $table Table
      * @param \Phinx\Db\Table\Column[] $columns List of columns in the table
      * @param \Phinx\Db\Table\Index[] $indexes List of indexes for the table
-     *
      * @return void
      */
     public function createTable(Table $table, array $columns = [], array $indexes = []);
@@ -387,7 +365,6 @@ interface AdapterInterface
      * Truncates the specified table
      *
      * @param string $tableName Table name
-     *
      * @return void
      */
     public function truncateTable($tableName);
@@ -396,7 +373,6 @@ interface AdapterInterface
      * Returns table columns
      *
      * @param string $tableName Table name
-     *
      * @return \Phinx\Db\Table\Column[]
      */
     public function getColumns($tableName);
@@ -406,7 +382,6 @@ interface AdapterInterface
      *
      * @param string $tableName Table name
      * @param string $columnName Column name
-     *
      * @return bool
      */
     public function hasColumn($tableName, $columnName);
@@ -416,7 +391,6 @@ interface AdapterInterface
      *
      * @param string $tableName Table name
      * @param string|string[] $columns Column(s)
-     *
      * @return bool
      */
     public function hasIndex($tableName, $columns);
@@ -426,7 +400,6 @@ interface AdapterInterface
      *
      * @param string $tableName Table name
      * @param string $indexName Index name
-     *
      * @return bool
      */
     public function hasIndexByName($tableName, $indexName);
@@ -437,7 +410,6 @@ interface AdapterInterface
      * @param string $tableName Table name
      * @param string|string[] $columns Column(s)
      * @param string|null $constraint Constraint name
-     *
      * @return bool
      */
     public function hasPrimaryKey($tableName, $columns, $constraint = null);
@@ -448,7 +420,6 @@ interface AdapterInterface
      * @param string $tableName Table name
      * @param string|string[] $columns Column(s)
      * @param string|null $constraint Constraint name
-     *
      * @return bool
      */
     public function hasForeignKey($tableName, $columns, $constraint = null);
@@ -464,7 +435,6 @@ interface AdapterInterface
      * Checks that the given column is of a supported type.
      *
      * @param \Phinx\Db\Table\Column $column Column
-     *
      * @return bool
      */
     public function isValidColumnType(Column $column);
@@ -474,7 +444,6 @@ interface AdapterInterface
      *
      * @param string $type Type
      * @param int|null $limit Limit
-     *
      * @return array
      */
     public function getSqlType($type, $limit = null);
@@ -484,7 +453,6 @@ interface AdapterInterface
      *
      * @param string $name Database Name
      * @param array $options Options
-     *
      * @return void
      */
     public function createDatabase($name, $options = []);
@@ -493,7 +461,6 @@ interface AdapterInterface
      * Checks to see if a database exists.
      *
      * @param string $name Database Name
-     *
      * @return bool
      */
     public function hasDatabase($name);
@@ -502,7 +469,6 @@ interface AdapterInterface
      * Drops the specified database.
      *
      * @param string $name Database Name
-     *
      * @return void
      */
     public function dropDatabase($name);
@@ -512,7 +478,6 @@ interface AdapterInterface
      * if there is no support for it.
      *
      * @param string $schemaName Schema Name
-     *
      * @return void
      */
     public function createSchema($schemaName = 'public');
@@ -522,7 +487,6 @@ interface AdapterInterface
      * if there is no support for it.
      *
      * @param string $schemaName Schema name
-     *
      * @return void
      */
     public function dropSchema($schemaName);
@@ -531,7 +495,6 @@ interface AdapterInterface
      * Cast a value to a boolean appropriate for the adapter.
      *
      * @param mixed $value The value to be cast
-     *
      * @return mixed
      */
     public function castToBool($value);

--- a/src/Phinx/Db/Adapter/DirectActionInterface.php
+++ b/src/Phinx/Db/Adapter/DirectActionInterface.php
@@ -23,7 +23,6 @@ interface DirectActionInterface
      *
      * @param string $tableName Table name
      * @param string $newName New Name
-     *
      * @return void
      */
     public function renameTable($tableName, $newName);
@@ -32,7 +31,6 @@ interface DirectActionInterface
      * Drops the specified database table.
      *
      * @param string $tableName Table name
-     *
      * @return void
      */
     public function dropTable($tableName);
@@ -42,7 +40,6 @@ interface DirectActionInterface
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param string|string[]|null $newColumns Column name(s) to belong to the primary key, or null to drop the key
-     *
      * @return void
      */
     public function changePrimaryKey(Table $table, $newColumns);
@@ -52,7 +49,6 @@ interface DirectActionInterface
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param string|null $newComment New comment string, or null to drop the comment
-     *
      * @return void
      */
     public function changeComment(Table $table, $newComment);
@@ -62,7 +58,6 @@ interface DirectActionInterface
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param \Phinx\Db\Table\Column $column Column
-     *
      * @return void
      */
     public function addColumn(Table $table, Column $column);
@@ -73,7 +68,6 @@ interface DirectActionInterface
      * @param string $tableName Table name
      * @param string $columnName Column Name
      * @param string $newColumnName New Column Name
-     *
      * @return void
      */
     public function renameColumn($tableName, $columnName, $newColumnName);
@@ -84,7 +78,6 @@ interface DirectActionInterface
      * @param string $tableName Table name
      * @param string $columnName Column Name
      * @param \Phinx\Db\Table\Column $newColumn New Column
-     *
      * @return void
      */
     public function changeColumn($tableName, $columnName, Column $newColumn);
@@ -94,7 +87,6 @@ interface DirectActionInterface
      *
      * @param string $tableName Table name
      * @param string $columnName Column Name
-     *
      * @return void
      */
     public function dropColumn($tableName, $columnName);
@@ -104,7 +96,6 @@ interface DirectActionInterface
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param \Phinx\Db\Table\Index $index Index
-     *
      * @return void
      */
     public function addIndex(Table $table, Index $index);
@@ -114,7 +105,6 @@ interface DirectActionInterface
      *
      * @param string $tableName the name of the table
      * @param mixed $columns Column(s)
-     *
      * @return void
      */
     public function dropIndex($tableName, $columns);
@@ -124,7 +114,6 @@ interface DirectActionInterface
      *
      * @param string $tableName The table name where the index is
      * @param string $indexName The name of the index
-     *
      * @return void
      */
     public function dropIndexByName($tableName, $indexName);
@@ -134,7 +123,6 @@ interface DirectActionInterface
      *
      * @param \Phinx\Db\Table\Table $table The table to add the foreign key to
      * @param \Phinx\Db\Table\ForeignKey $foreignKey The foreign key to add
-     *
      * @return void
      */
     public function addForeignKey(Table $table, ForeignKey $foreignKey);
@@ -145,7 +133,6 @@ interface DirectActionInterface
      * @param string $tableName The table to drop the foreign key from
      * @param string[] $columns Column(s)
      * @param string|null $constraint Constraint name
-     *
      * @return void
      */
     public function dropForeignKey($tableName, $columns, $constraint = null);

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -50,7 +50,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Writes a message to stdout if verbose output is on
      *
      * @param string $message The message to show
-     *
      * @return void
      */
     protected function verboseLog($message)
@@ -107,7 +106,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Sets the database connection.
      *
      * @param \PDO $connection Connection
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setConnection(PDO $connection)
@@ -201,7 +199,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Executes a query and returns PDOStatement.
      *
      * @param string $sql SQL
-     *
      * @return \PDOStatement
      */
     public function query($sql)
@@ -257,7 +254,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Quotes a database value.
      *
      * @param mixed $value The value to quote
-     *
      * @return mixed
      */
     protected function quoteValue($value)
@@ -277,7 +273,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Quotes a database string.
      *
      * @param string $value The string to quote
-     *
      * @return string
      */
     protected function quoteString($value)
@@ -471,7 +466,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint
      * @param bool $state The required state of the breakpoint
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     protected function markBreakpoint(MigrationInterface $migration, $state)
@@ -495,7 +489,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function createSchema($schemaName = 'public')
@@ -507,7 +500,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropSchema($name)
@@ -561,9 +553,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Retrieve a database connection attribute
      *
      * @see http://php.net/manual/en/pdo.getattribute.php
-     *
      * @param int $attribute One of the PDO::ATTR_* constants
-     *
      * @return mixed
      */
     public function getAttribute($attribute)
@@ -576,7 +566,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param mixed $default Default value
      * @param string|null $columnType column type added
-     *
      * @return string
      */
     protected function getDefaultValueDefinition($default, $columnType = null)
@@ -598,7 +587,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param string $tableName The table name to use in the ALTER statement
      * @param \Phinx\Db\Util\AlterInstructions $instructions The object containing the alter sequence
-     *
      * @return void
      */
     protected function executeAlterSteps($tableName, AlterInstructions $instructions)
@@ -621,7 +609,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param \Phinx\Db\Table\Column $column Column
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getAddColumnInstructions(Table $table, Column $column);
@@ -641,7 +628,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $tableName Table name
      * @param string $columnName Column Name
      * @param string $newColumnName New Column Name
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getRenameColumnInstructions($tableName, $columnName, $newColumnName);
@@ -661,7 +647,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $tableName Table name
      * @param string $columnName Column Name
      * @param \Phinx\Db\Table\Column $newColumn New Column
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getChangeColumnInstructions($tableName, $columnName, Column $newColumn);
@@ -680,7 +665,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param string $tableName Table name
      * @param string $columnName Column Name
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getDropColumnInstructions($tableName, $columnName);
@@ -699,7 +683,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param \Phinx\Db\Table\Index $index Index
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getAddIndexInstructions(Table $table, Index $index);
@@ -718,7 +701,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param string $tableName The name of of the table where the index is
      * @param mixed $columns Column(s)
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getDropIndexByColumnsInstructions($tableName, $columns);
@@ -737,7 +719,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param string $tableName The table name whe the index is
      * @param string $indexName The name of the index
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getDropIndexByNameInstructions($tableName, $indexName);
@@ -779,7 +760,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param string $tableName The table where the foreign key constraint is
      * @param string $constraint Constraint name
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getDropForeignKeyInstructions($tableName, $constraint);
@@ -789,7 +769,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param string $tableName The table where the foreign key constraint is
      * @param string[] $columns The list of column names
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getDropForeignKeyByColumnsInstructions($tableName, $columns);
@@ -807,7 +786,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Returns the instructions to drop the specified database table.
      *
      * @param string $tableName Table name
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getDropTableInstructions($tableName);
@@ -826,7 +804,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param string $tableName Table name
      * @param string $newTableName New Name
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getRenameTableInstructions($tableName, $newTableName);
@@ -845,7 +822,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param string|string[]|null $newColumns Column name(s) to belong to the primary key, or null to drop the key
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getChangePrimaryKeyInstructions(Table $table, $newColumns);
@@ -864,7 +840,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param string|null $newComment New comment string, or null to drop the comment
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     abstract protected function getChangeCommentInstructions(Table $table, $newComment);
@@ -873,7 +848,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * {@inheritDoc}
      *
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     public function executeActions(Table $table, array $actions)
@@ -882,19 +856,19 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
 
         foreach ($actions as $action) {
             switch (true) {
-                case ($action instanceof AddColumn):
+                case $action instanceof AddColumn:
                     $instructions->merge($this->getAddColumnInstructions($table, $action->getColumn()));
                     break;
 
-                case ($action instanceof AddIndex):
+                case $action instanceof AddIndex:
                     $instructions->merge($this->getAddIndexInstructions($table, $action->getIndex()));
                     break;
 
-                case ($action instanceof AddForeignKey):
+                case $action instanceof AddForeignKey:
                     $instructions->merge($this->getAddForeignKeyInstructions($table, $action->getForeignKey()));
                     break;
 
-                case ($action instanceof ChangeColumn):
+                case $action instanceof ChangeColumn:
                     $instructions->merge($this->getChangeColumnInstructions(
                         $table->getName(),
                         $action->getColumnName(),
@@ -902,48 +876,48 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     ));
                     break;
 
-                case ($action instanceof DropForeignKey && !$action->getForeignKey()->getConstraint()):
+                case $action instanceof DropForeignKey && !$action->getForeignKey()->getConstraint():
                     $instructions->merge($this->getDropForeignKeyByColumnsInstructions(
                         $table->getName(),
                         $action->getForeignKey()->getColumns()
                     ));
                     break;
 
-                case ($action instanceof DropForeignKey && $action->getForeignKey()->getConstraint()):
+                case $action instanceof DropForeignKey && $action->getForeignKey()->getConstraint():
                     $instructions->merge($this->getDropForeignKeyInstructions(
                         $table->getName(),
                         $action->getForeignKey()->getConstraint()
                     ));
                     break;
 
-                case ($action instanceof DropIndex && $action->getIndex()->getName() !== null):
+                case $action instanceof DropIndex && $action->getIndex()->getName() !== null:
                     $instructions->merge($this->getDropIndexByNameInstructions(
                         $table->getName(),
                         $action->getIndex()->getName()
                     ));
                     break;
 
-                case ($action instanceof DropIndex && $action->getIndex()->getName() == null):
+                case $action instanceof DropIndex && $action->getIndex()->getName() == null:
                     $instructions->merge($this->getDropIndexByColumnsInstructions(
                         $table->getName(),
                         $action->getIndex()->getColumns()
                     ));
                     break;
 
-                case ($action instanceof DropTable):
+                case $action instanceof DropTable:
                     $instructions->merge($this->getDropTableInstructions(
                         $table->getName()
                     ));
                     break;
 
-                case ($action instanceof RemoveColumn):
+                case $action instanceof RemoveColumn:
                     $instructions->merge($this->getDropColumnInstructions(
                         $table->getName(),
                         $action->getColumn()->getName()
                     ));
                     break;
 
-                case ($action instanceof RenameColumn):
+                case $action instanceof RenameColumn:
                     $instructions->merge($this->getRenameColumnInstructions(
                         $table->getName(),
                         $action->getColumn()->getName(),
@@ -951,21 +925,21 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     ));
                     break;
 
-                case ($action instanceof RenameTable):
+                case $action instanceof RenameTable:
                     $instructions->merge($this->getRenameTableInstructions(
                         $table->getName(),
                         $action->getNewName()
                     ));
                     break;
 
-                case ($action instanceof ChangePrimaryKey):
+                case $action instanceof ChangePrimaryKey:
                     $instructions->merge($this->getChangePrimaryKeyInstructions(
                         $table,
                         $action->getNewColumns()
                     ));
                     break;
 
-                case ($action instanceof ChangeComment):
+                case $action instanceof ChangeComment:
                     $instructions->merge($this->getChangeCommentInstructions(
                         $table,
                         $action->getNewComment()

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -47,7 +47,6 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     public function connect()
@@ -141,7 +140,6 @@ class PostgresAdapter extends PdoAdapter
      * Quotes a schema name for use in a query.
      *
      * @param string $schemaName Schema Name
-     *
      * @return string
      */
     public function quoteSchemaName($schemaName)
@@ -333,7 +331,7 @@ class PostgresAdapter extends PdoAdapter
         $instructions = new AlterInstructions();
 
         // passing 'null' is to remove table comment
-        $newComment = ($newComment !== null)
+        $newComment = $newComment !== null
             ? $this->getConnection()->quote($newComment)
             : 'NULL';
         $sql = sprintf(
@@ -617,7 +615,6 @@ class PostgresAdapter extends PdoAdapter
      * Get an array of indexes from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return array
      */
     protected function getIndexes($tableName)
@@ -762,7 +759,7 @@ class PostgresAdapter extends PdoAdapter
         }
 
         if ($constraint) {
-            return ($primaryKey['constraint'] === $constraint);
+            return $primaryKey['constraint'] === $constraint;
         } else {
             if (is_string($columns)) {
                 $columns = [$columns]; // str to array
@@ -777,7 +774,6 @@ class PostgresAdapter extends PdoAdapter
      * Get the primary key from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return array
      */
     public function getPrimaryKey($tableName)
@@ -840,7 +836,6 @@ class PostgresAdapter extends PdoAdapter
      * Get an array of foreign keys from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return array
      */
     protected function getForeignKeys($tableName)
@@ -1012,9 +1007,7 @@ class PostgresAdapter extends PdoAdapter
      * Returns Phinx type by SQL type
      *
      * @param string $sqlType SQL type
-     *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
-     *
      * @return string Phinx type
      */
     public function getPhinxType($sqlType)
@@ -1117,7 +1110,6 @@ class PostgresAdapter extends PdoAdapter
      *
      * @param mixed $default default value
      * @param string|null $columnType column type added
-     *
      * @return string
      */
     protected function getDefaultValueDefinition($default, $columnType = null)
@@ -1137,7 +1129,6 @@ class PostgresAdapter extends PdoAdapter
      * Gets the PostgreSQL Column Definition for a Column object.
      *
      * @param \Phinx\Db\Table\Column $column Column
-     *
      * @return string
      */
     protected function getColumnSqlDefinition(Column $column)
@@ -1204,13 +1195,12 @@ class PostgresAdapter extends PdoAdapter
      *
      * @param \Phinx\Db\Table\Column $column Column
      * @param string $tableName Table name
-     *
      * @return string
      */
     protected function getColumnCommentSqlDefinition(Column $column, $tableName)
     {
         // passing 'null' is to remove column comment
-        $comment = (strcasecmp($column->getComment(), 'NULL') !== 0)
+        $comment = strcasecmp($column->getComment(), 'NULL') !== 0
                  ? $this->getConnection()->quote($column->getComment())
                  : 'NULL';
 
@@ -1227,7 +1217,6 @@ class PostgresAdapter extends PdoAdapter
      *
      * @param \Phinx\Db\Table\Index $index Index
      * @param string $tableName Table name
-     *
      * @return string
      */
     protected function getIndexSqlDefinition(Index $index, $tableName)
@@ -1255,7 +1244,6 @@ class PostgresAdapter extends PdoAdapter
      *
      * @param \Phinx\Db\Table\ForeignKey $foreignKey Foreign key
      * @param string $tableName Table name
-     *
      * @return string
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, $tableName)
@@ -1316,7 +1304,6 @@ class PostgresAdapter extends PdoAdapter
      * Creates the specified schema.
      *
      * @param string $schemaName Schema Name
-     *
      * @return void
      */
     public function createSchema($schemaName = 'public')
@@ -1330,7 +1317,6 @@ class PostgresAdapter extends PdoAdapter
      * Checks to see if a schema exists.
      *
      * @param string $schemaName Schema Name
-     *
      * @return bool
      */
     public function hasSchema($schemaName)
@@ -1350,7 +1336,6 @@ class PostgresAdapter extends PdoAdapter
      * Drops the specified schema table.
      *
      * @param string $schemaName Schema name
-     *
      * @return void
      */
     public function dropSchema($schemaName)
@@ -1410,14 +1395,13 @@ class PostgresAdapter extends PdoAdapter
     public function isValidColumnType(Column $column)
     {
         // If not a standard column type, maybe it is array type?
-        return (parent::isValidColumnType($column) || $this->isArrayType($column->getType()));
+        return parent::isValidColumnType($column) || $this->isArrayType($column->getType());
     }
 
     /**
      * Check if the given column is an array of a valid type.
      *
      * @param string $columnType Column type
-     *
      * @return bool
      */
     protected function isArrayType($columnType)
@@ -1433,7 +1417,6 @@ class PostgresAdapter extends PdoAdapter
 
     /**
      * @param string $tableName Table name
-     *
      * @return array
      */
     protected function getSchemaName($tableName)

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -64,7 +64,6 @@ class ProxyAdapter extends AdapterWrapper
      * Gets an array of the recorded commands in reverse.
      *
      * @throws \Phinx\Migration\IrreversibleMigrationException if a command cannot be reversed.
-     *
      * @return \Phinx\Db\Plan\Intent
      */
     public function getInvertedCommands()

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -126,7 +126,6 @@ class SQLiteAdapter extends PdoAdapter
      * Indicates whether the database library version is at least the specified version
      *
      * @param string $ver The version to check against e.g. '3.28.0'
-     *
      * @return bool
      */
     public function databaseVersionAtLeast($ver)
@@ -141,7 +140,6 @@ class SQLiteAdapter extends PdoAdapter
      *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     public function connect()
@@ -253,7 +251,6 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @param string $tableName Table name
      * @param bool $quoted Whether to return the schema name and table name escaped and quoted. If quoted, the schema (if any) will also be appended with a dot
-     *
      * @return array
      */
     protected function getSchemaName($tableName, $quoted = false)
@@ -279,7 +276,6 @@ class SQLiteAdapter extends PdoAdapter
      *
      * @param string $tableName The table to query
      * @param string $pragma The pragma to query
-     *
      * @return array
      */
     protected function getTableInfo($tableName, $pragma = 'table_info')
@@ -295,7 +291,6 @@ class SQLiteAdapter extends PdoAdapter
      * If no schema was specified and the table does not exist the "main" schema is returned
      *
      * @param string $tableName The name of the table to find
-     *
      * @return array
      */
     protected function resolveTable($tableName)
@@ -521,7 +516,6 @@ class SQLiteAdapter extends PdoAdapter
      *
      * @param mixed $v The default-value expression to interpret
      * @param string $t The Phinx type of the column
-     *
      * @return mixed
      */
     protected function parseDefaultValue($v, $t)
@@ -594,7 +588,6 @@ PCRE_PATTERN;
      * The process of finding an identity column is somewhat convoluted as SQLite has no direct way of querying whether a given column is an alias for the table's row ID
      *
      * @param string $tableName The name of the table
-     *
      * @return string|null
      */
     protected function resolveIdentity($tableName)
@@ -722,7 +715,6 @@ PCRE_PATTERN;
      * Returns the original CREATE statement for the give table
      *
      * @param string $tableName The table name to get the create statement for
-     *
      * @return string
      */
     protected function getDeclaringSql($tableName)
@@ -766,7 +758,6 @@ PCRE_PATTERN;
      * @param string $tmpTableName The tmp table name where the data is stored
      * @param string[] $writeColumns The list of columns in the target table
      * @param string[] $selectColumns The list of columns in the tmp table
-     *
      * @return void
      */
     protected function copyDataToNewTable($tableName, $tmpTableName, $writeColumns, $selectColumns)
@@ -787,7 +778,6 @@ PCRE_PATTERN;
      *
      * @param \Phinx\Db\Util\AlterInstructions $instructions The instructions to modify
      * @param string $tableName The table name to copy the data to
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     protected function copyAndDropTmpTable($instructions, $tableName)
@@ -820,9 +810,7 @@ PCRE_PATTERN;
      * @param string $tableName The table to modify
      * @param string|false $columnName The column name that is about to change
      * @param string|false $newColumnName Optionally the new name for the column
-     *
      * @throws \InvalidArgumentException
-     *
      * @return array
      */
     protected function calculateNewTableColumns($tableName, $columnName, $newColumnName)
@@ -867,7 +855,6 @@ PCRE_PATTERN;
      * create-copy-drop strategy
      *
      * @param string $tableName The table to modify
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     protected function beginAlterByCopyTable($tableName)
@@ -990,7 +977,6 @@ PCRE_PATTERN;
      * Get an array of indexes from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return array
      */
     protected function getIndexes($tableName)
@@ -1016,7 +1002,6 @@ PCRE_PATTERN;
      *
      * @param string $tableName The table to which the index belongs
      * @param string|string[] $columns The columns of the index
-     *
      * @return array
      */
     protected function resolveIndex($tableName, $columns)
@@ -1155,7 +1140,6 @@ PCRE_PATTERN;
      * Get the primary key from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return string[]
      */
     protected function getPrimaryKey($tableName)
@@ -1204,7 +1188,6 @@ PCRE_PATTERN;
      * Get an array of foreign keys from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return array
      */
     protected function getForeignKeys($tableName)
@@ -1226,7 +1209,6 @@ PCRE_PATTERN;
     /**
      * @param \Phinx\Db\Table\Table $table The Table
      * @param string $column Column Name
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     protected function getAddPrimaryKeyInstructions(Table $table, $column)
@@ -1270,7 +1252,6 @@ PCRE_PATTERN;
     /**
      * @param \Phinx\Db\Table\Table $table Table
      * @param string $column Column Name
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     protected function getDropPrimaryKeyInstructions($table, $column)
@@ -1426,7 +1407,6 @@ PCRE_PATTERN;
      * Returns Phinx type by SQL type
      *
      * @param string|null $sqlTypeDef SQL Type definition
-     *
      * @return array
      */
     public function getPhinxType($sqlTypeDef)
@@ -1507,7 +1487,6 @@ PCRE_PATTERN;
      * Gets the SQLite Column Definition for a Column object.
      *
      * @param \Phinx\Db\Table\Column $column Column
-     *
      * @return string
      */
     protected function getColumnSqlDefinition(Column $column)
@@ -1543,7 +1522,6 @@ PCRE_PATTERN;
      * Gets the comment Definition for a Column object.
      *
      * @param \Phinx\Db\Table\Column $column Column
-     *
      * @return string
      */
     protected function getCommentDefinition(Column $column)
@@ -1560,7 +1538,6 @@ PCRE_PATTERN;
      *
      * @param \Phinx\Db\Table\Table $table Table
      * @param \Phinx\Db\Table\Index $index Index
-     *
      * @return string
      */
     protected function getIndexSqlDefinition(Table $table, Index $index)
@@ -1596,7 +1573,6 @@ PCRE_PATTERN;
      * Gets the SQLite Foreign Key Definition for an ForeignKey object.
      *
      * @param \Phinx\Db\Table\ForeignKey $foreignKey Foreign key
-     *
      * @return string
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey)

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -56,7 +56,6 @@ class SqlServerAdapter extends PdoAdapter
      * {@inheritDoc}
      *
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     public function connect()
@@ -111,7 +110,6 @@ class SqlServerAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
-     *
      * @return void
      */
     protected function connectDblib()
@@ -332,7 +330,6 @@ class SqlServerAdapter extends PdoAdapter
      * @inheritDoc
      *
      * SqlServer does not implement this functionality, and so will always throw an exception if used.
-     *
      * @throws \BadMethodCallException
      */
     protected function getChangeCommentInstructions(Table $table, $newComment)
@@ -345,7 +342,6 @@ class SqlServerAdapter extends PdoAdapter
      *
      * @param \Phinx\Db\Table\Column $column Column
      * @param string $tableName Table name
-     *
      * @return string
      */
     protected function getColumnCommentSqlDefinition(Column $column, $tableName)
@@ -353,7 +349,7 @@ class SqlServerAdapter extends PdoAdapter
         // passing 'null' is to remove column comment
         $currentComment = $this->getColumnComment($tableName, $column->getName());
 
-        $comment = (strcasecmp($column->getComment(), 'NULL') !== 0) ? $this->getConnection()->quote($column->getComment()) : '\'\'';
+        $comment = strcasecmp($column->getComment(), 'NULL') !== 0 ? $this->getConnection()->quote($column->getComment()) : '\'\'';
         $command = $currentComment === false ? 'sp_addextendedproperty' : 'sp_updateextendedproperty';
 
         return sprintf(
@@ -408,7 +404,6 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @param string $tableName Table name
      * @param string $columnName Column name
-     *
      * @return string|false
      */
     public function getColumnComment($tableName, $columnName)
@@ -479,7 +474,6 @@ class SqlServerAdapter extends PdoAdapter
 
     /**
      * @param string $default Default
-     *
      * @return int|string|null
      */
     protected function parseDefault($default)
@@ -569,7 +563,6 @@ SQL;
      *
      * @param string $tableName The table where the column is
      * @param \Phinx\Db\Table\Column $newColumn The column to alter
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     protected function getChangeDefault($tableName, Column $newColumn)
@@ -658,7 +651,6 @@ SQL;
     /**
      * @param string $tableName Table name
      * @param string|null $columnName Column name
-     *
      * @return \Phinx\Db\Util\AlterInstructions
      */
     protected function getDropDefaultConstraint($tableName, $columnName)
@@ -675,7 +667,6 @@ SQL;
     /**
      * @param string $tableName Table name
      * @param string $columnName Column name
-     *
      * @return string|false
      */
     protected function getDefaultConstraint($tableName, $columnName)
@@ -710,7 +701,6 @@ WHERE
     /**
      * @param int $tableId Table ID
      * @param int $indexId Index ID
-     *
      * @return array
      */
     protected function getIndexColums($tableId, $indexId)
@@ -734,7 +724,6 @@ ORDER BY IC.[key_ordinal];";
      * Get an array of indexes from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return array
      */
     public function getIndexes($tableName)
@@ -878,7 +867,7 @@ ORDER BY T.[name], I.[index_id];";
         }
 
         if ($constraint) {
-            return ($primaryKey['constraint'] === $constraint);
+            return $primaryKey['constraint'] === $constraint;
         }
 
         if (is_string($columns)) {
@@ -893,7 +882,6 @@ ORDER BY T.[name], I.[index_id];";
      * Get the primary key from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return array
      */
     public function getPrimaryKey($tableName)
@@ -953,7 +941,6 @@ ORDER BY T.[name], I.[index_id];";
      * Get an array of foreign keys from a particular table.
      *
      * @param string $tableName Table name
-     *
      * @return array
      */
     protected function getForeignKeys($tableName)
@@ -1101,11 +1088,8 @@ ORDER BY T.[name], I.[index_id];";
      * Returns Phinx type by SQL type
      *
      * @internal param string $sqlType SQL type
-     *
      * @param string $sqlType SQL Type definition
-     *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
-     *
      * @return string Phinx type
      */
     public function getPhinxType($sqlType)
@@ -1206,7 +1190,6 @@ SQL;
      *
      * @param \Phinx\Db\Table\Column $column Column
      * @param bool $create Create column flag
-     *
      * @return string
      */
     protected function getColumnSqlDefinition(Column $column, $create = true)
@@ -1262,7 +1245,6 @@ SQL;
      *
      * @param \Phinx\Db\Table\Index $index Index
      * @param string $tableName Table name
-     *
      * @return string
      */
     protected function getIndexSqlDefinition(Index $index, $tableName)
@@ -1288,7 +1270,6 @@ SQL;
      *
      * @param \Phinx\Db\Table\ForeignKey $foreignKey Foreign key
      * @param string $tableName Table name
-     *
      * @return string
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, $tableName)
@@ -1322,7 +1303,6 @@ SQL;
      * @param string $direction Direction
      * @param string $startTime Start Time
      * @param string $endTime End Time
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -69,7 +69,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function changePrimaryKey(Table $table, $newColumns)
@@ -90,7 +89,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function changeComment(Table $table, $newComment)
@@ -111,7 +109,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function renameTable($tableName, $newTableName)
@@ -130,7 +127,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropTable($tableName)
@@ -176,7 +172,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function addColumn(Table $table, Column $column)
@@ -194,7 +189,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function renameColumn($tableName, $columnName, $newColumnName)
@@ -211,7 +205,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function changeColumn($tableName, $columnName, Column $newColumn)
@@ -228,7 +221,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropColumn($tableName, $columnName)
@@ -265,7 +257,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function addIndex(Table $table, Index $index)
@@ -282,7 +273,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropIndex($tableName, $columns)
@@ -299,7 +289,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropIndexByName($tableName, $indexName)
@@ -336,7 +325,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function addForeignKey(Table $table, ForeignKey $foreignKey)
@@ -354,7 +342,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropForeignKey($tableName, $columns, $constraint = null)
@@ -411,7 +398,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * Applies the prefix and suffix to the table name.
      *
      * @param string $tableName Table name
-     *
      * @return string
      */
     public function getAdapterTableName($tableName)
@@ -423,7 +409,6 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     public function executeActions(Table $table, array $actions)
@@ -433,15 +418,15 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
 
         foreach ($actions as $k => $action) {
             switch (true) {
-                case ($action instanceof AddColumn):
+                case $action instanceof AddColumn:
                     $actions[$k] = new AddColumn($adapterTable, $action->getColumn());
                     break;
 
-                case ($action instanceof AddIndex):
+                case $action instanceof AddIndex:
                     $actions[$k] = new AddIndex($adapterTable, $action->getIndex());
                     break;
 
-                case ($action instanceof AddForeignKey):
+                case $action instanceof AddForeignKey:
                     $foreignKey = clone $action->getForeignKey();
                     $refTable = $foreignKey->getReferencedTable();
                     $refTableName = $this->getAdapterTableName($refTable->getName());
@@ -449,39 +434,39 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
                     $actions[$k] = new AddForeignKey($adapterTable, $foreignKey);
                     break;
 
-                case ($action instanceof ChangeColumn):
+                case $action instanceof ChangeColumn:
                     $actions[$k] = new ChangeColumn($adapterTable, $action->getColumnName(), $action->getColumn());
                     break;
 
-                case ($action instanceof DropForeignKey):
+                case $action instanceof DropForeignKey:
                     $actions[$k] = new DropForeignKey($adapterTable, $action->getForeignKey());
                     break;
 
-                case ($action instanceof DropIndex):
+                case $action instanceof DropIndex:
                     $actions[$k] = new DropIndex($adapterTable, $action->getIndex());
                     break;
 
-                case ($action instanceof DropTable):
+                case $action instanceof DropTable:
                     $actions[$k] = new DropTable($adapterTable);
                     break;
 
-                case ($action instanceof RemoveColumn):
+                case $action instanceof RemoveColumn:
                     $actions[$k] = new RemoveColumn($adapterTable, $action->getColumn());
                     break;
 
-                case ($action instanceof RenameColumn):
+                case $action instanceof RenameColumn:
                     $actions[$k] = new RenameColumn($adapterTable, $action->getColumn(), $action->getNewName());
                     break;
 
-                case ($action instanceof RenameTable):
+                case $action instanceof RenameTable:
                     $actions[$k] = new RenameTable($adapterTable, $action->getNewName());
                     break;
 
-                case ($action instanceof ChangePrimaryKey):
+                case $action instanceof ChangePrimaryKey:
                     $actions[$k] = new ChangePrimaryKey($adapterTable, $action->getNewColumns());
                     break;
 
-                case ($action instanceof ChangeComment):
+                case $action instanceof ChangeComment:
                     $actions[$k] = new ChangeComment($adapterTable, $action->getNewComment());
                     break;
 

--- a/src/Phinx/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Phinx/Db/Adapter/TimedOutputAdapter.php
@@ -49,7 +49,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      *
      * @param string $command Command Name
      * @param array $args Command Args
-     *
      * @return void
      */
     public function writeCommand($command, $args = [])
@@ -119,7 +118,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function changePrimaryKey(Table $table, $newColumns)
@@ -138,7 +136,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function changeComment(Table $table, $newComment)
@@ -157,7 +154,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function renameTable($tableName, $newTableName)
@@ -176,7 +172,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropTable($tableName)
@@ -206,7 +201,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function addColumn(Table $table, Column $column)
@@ -232,7 +226,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function renameColumn($tableName, $columnName, $newColumnName)
@@ -251,7 +244,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function changeColumn($tableName, $columnName, Column $newColumn)
@@ -270,7 +262,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropColumn($tableName, $columnName)
@@ -289,7 +280,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function addIndex(Table $table, Index $index)
@@ -308,7 +298,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropIndex($tableName, $columns)
@@ -327,7 +316,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropIndexByName($tableName, $indexName)
@@ -346,7 +334,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function addForeignKey(Table $table, ForeignKey $foreignKey)
@@ -365,7 +352,6 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * {@inheritDoc}
      *
      * @throws \BadMethodCallException
-     *
      * @return void
      */
     public function dropForeignKey($tableName, $columns, $constraint = null)

--- a/src/Phinx/Db/Adapter/WrapperInterface.php
+++ b/src/Phinx/Db/Adapter/WrapperInterface.php
@@ -25,7 +25,6 @@ interface WrapperInterface
      * Sets the database adapter to proxy commands to.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Adapter
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function setAdapter(AdapterInterface $adapter);
@@ -34,7 +33,6 @@ interface WrapperInterface
      * Gets the database adapter.
      *
      * @throws \RuntimeException if the adapter has not been set
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter();

--- a/src/Phinx/Db/Plan/AlterTable.php
+++ b/src/Phinx/Db/Plan/AlterTable.php
@@ -43,7 +43,6 @@ class AlterTable
      * Adds another action to the collection
      *
      * @param \Phinx\Db\Action\Action $action The action to add
-     *
      * @return void
      */
     public function addAction(Action $action)

--- a/src/Phinx/Db/Plan/Intent.php
+++ b/src/Phinx/Db/Plan/Intent.php
@@ -25,7 +25,6 @@ class Intent
      * Adds a new action to the collection
      *
      * @param \Phinx\Db\Action\Action $action The action to add
-     *
      * @return void
      */
     public function addAction(Action $action)
@@ -47,7 +46,6 @@ class Intent
      * Merges another Intent object with this one
      *
      * @param \Phinx\Db\Plan\Intent $another The other intent to merge in
-     *
      * @return void
      */
     public function merge(Intent $another)

--- a/src/Phinx/Db/Plan/NewTable.php
+++ b/src/Phinx/Db/Plan/NewTable.php
@@ -51,7 +51,6 @@ class NewTable
      * Adds a column to the collection
      *
      * @param \Phinx\Db\Table\Column $column The column description
-     *
      * @return void
      */
     public function addColumn(Column $column)
@@ -63,7 +62,6 @@ class NewTable
      * Adds an index to the collection
      *
      * @param \Phinx\Db\Table\Index $index The index description
-     *
      * @return void
      */
     public function addIndex(Index $index)

--- a/src/Phinx/Db/Plan/Plan.php
+++ b/src/Phinx/Db/Plan/Plan.php
@@ -90,7 +90,6 @@ class Plan
      * Parses the given Intent and creates the separate steps to execute
      *
      * @param \Phinx\Db\Action\Action[] $actions The actions to use for the plan
-     *
      * @return void
      */
     protected function createPlan($actions)
@@ -139,7 +138,6 @@ class Plan
      * Executes this plan using the given AdapterInterface
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $executor The executor object for the plan
-     *
      * @return void
      */
     public function execute(AdapterInterface $executor)
@@ -159,7 +157,6 @@ class Plan
      * Executes the inverse plan (rollback the actions) with the given AdapterInterface:w
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $executor The executor object for the plan
-     *
      * @return void
      */
     public function executeInverse(AdapterInterface $executor)
@@ -197,7 +194,7 @@ class Plan
         foreach ($this->columnRemoves as $columnRemove) {
             foreach ($columnRemove->getActions() as $action) {
                 if ($action instanceof RemoveColumn) {
-                    list($this->indexes) = $this->forgetDropIndex(
+                    [$this->indexes] = $this->forgetDropIndex(
                         $action->getTable(),
                         [$action->getColumn()->getName()],
                         $this->indexes
@@ -252,7 +249,6 @@ class Plan
      *
      * @param \Phinx\Db\Table\Table $table The table to find in the list of actions
      * @param \Phinx\Db\Plan\AlterTable[] $actions The actions to transform
-     *
      * @return \Phinx\Db\Plan\AlterTable[] The list of actions without actions for the given table
      */
     protected function forgetTable(Table $table, $actions)
@@ -274,7 +270,6 @@ class Plan
      * given AlterTable.
      *
      * @param \Phinx\Db\Plan\AlterTable $alter The collection of actions to inspect
-     *
      * @return \Phinx\Db\Plan\AlterTable The updated AlterTable object. This function
      * has the side effect of changing the `$this->indexes` property.
      */
@@ -285,7 +280,7 @@ class Plan
         foreach ($alter->getActions() as $action) {
             $newAlter->addAction($action);
             if ($action instanceof DropForeignKey) {
-                list($this->indexes, $dropIndexActions) = $this->forgetDropIndex(
+                [$this->indexes, $dropIndexActions] = $this->forgetDropIndex(
                     $action->getTable(),
                     $action->getForeignKey()->getColumns(),
                     $this->indexes
@@ -305,7 +300,6 @@ class Plan
      * @param \Phinx\Db\Table\Table $table The table to find in the list of actions
      * @param string[] $columns The column names to match
      * @param \Phinx\Db\Plan\AlterTable[] $actions The actions to transform
-     *
      * @return array A tuple containing the list of actions without actions for dropping the index
      * and a list of drop index actions that were removed.
      */
@@ -338,7 +332,6 @@ class Plan
      * @param \Phinx\Db\Table\Table $table The table to find in the list of actions
      * @param string[] $columns The column names to match
      * @param \Phinx\Db\Plan\AlterTable[] $actions The actions to transform
-     *
      * @return array A tuple containing the list of actions without actions for removing the column
      * and a list of remove column actions that were removed.
      */
@@ -369,7 +362,6 @@ class Plan
      * Collects all table creation actions from the given intent
      *
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
-     *
      * @return void
      */
     protected function gatherCreates($actions)
@@ -402,7 +394,6 @@ class Plan
      * Collects all alter table actions from the given intent
      *
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
-     *
      * @return void
      */
     protected function gatherUpdates($actions)
@@ -467,7 +458,6 @@ class Plan
      * Collects all index creation and drops from the given intent
      *
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
-     *
      * @return void
      */
     protected function gatherIndexes($actions)
@@ -494,7 +484,6 @@ class Plan
      * Collects all foreign key creation and drops from the given intent
      *
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
-     *
      * @return void
      */
     protected function gatherConstraints($actions)

--- a/src/Phinx/Db/Plan/Solver/ActionSplitter.php
+++ b/src/Phinx/Db/Plan/Solver/ActionSplitter.php
@@ -64,7 +64,6 @@ class ActionSplitter
      * based on the constructor parameters.
      *
      * @param \Phinx\Db\Plan\AlterTable $alter The collection of actions to inspect
-     *
      * @return \Phinx\Db\Plan\AlterTable[] A list of AlterTable that can be executed without
      * this type of conflict
      */

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -58,7 +58,7 @@ class Table
      * @param array $options Options
      * @param \Phinx\Db\Adapter\AdapterInterface|null $adapter Database Adapter
      */
-    public function __construct($name, $options = [], AdapterInterface $adapter = null)
+    public function __construct($name, $options = [], ?AdapterInterface $adapter = null)
     {
         $this->table = new TableValue($name, $options);
         $this->actions = new Intent();
@@ -102,7 +102,6 @@ class Table
      * Sets the database adapter.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
-     *
      * @return $this
      */
     public function setAdapter(AdapterInterface $adapter)
@@ -116,7 +115,6 @@ class Table
      * Gets the database adapter.
      *
      * @throws \RuntimeException
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface|null
      */
     public function getAdapter()
@@ -164,7 +162,6 @@ class Table
      * Renames the database table.
      *
      * @param string $newTableName New Table Name
-     *
      * @return $this
      */
     public function rename($newTableName)
@@ -178,7 +175,6 @@ class Table
      * Changes the primary key of the database table.
      *
      * @param string|string[]|null $columns Column name(s) to belong to the primary key, or null to drop the key
-     *
      * @return $this
      */
     public function changePrimaryKey($columns)
@@ -192,7 +188,6 @@ class Table
      * Changes the comment of the database table.
      *
      * @param string|null $comment New comment string, or null to drop the comment
-     *
      * @return $this
      */
     public function changeComment($comment)
@@ -216,7 +211,6 @@ class Table
      * Gets a table column if it exists.
      *
      * @param string $name Column name
-     *
      * @return \Phinx\Db\Table\Column|null
      */
     public function getColumn($name)
@@ -235,7 +229,6 @@ class Table
      * Sets an array of data to be inserted.
      *
      * @param array $data Data
-     *
      * @return $this
      */
     public function setData($data)
@@ -287,9 +280,7 @@ class Table
      * @param string|\Phinx\Db\Table\Column $columnName Column Name
      * @param string|\Phinx\Util\Literal|null $type Column Type
      * @param array $options Column Options
-     *
      * @throws \InvalidArgumentException
-     *
      * @return $this
      */
     public function addColumn($columnName, $type = null, $options = [])
@@ -318,7 +309,6 @@ class Table
      * Remove a table column.
      *
      * @param string $columnName Column Name
-     *
      * @return $this
      */
     public function removeColumn($columnName)
@@ -334,7 +324,6 @@ class Table
      *
      * @param string $oldName Old Column Name
      * @param string $newName New Column Name
-     *
      * @return $this
      */
     public function renameColumn($oldName, $newName)
@@ -351,7 +340,6 @@ class Table
      * @param string $columnName Column Name
      * @param string|\Phinx\Db\Table\Column|\Phinx\Util\Literal $newColumnType New Column Type
      * @param array $options Options
-     *
      * @return $this
      */
     public function changeColumn($columnName, $newColumnType, array $options = [])
@@ -370,7 +358,6 @@ class Table
      * Checks to see if a column exists.
      *
      * @param string $columnName Column Name
-     *
      * @return bool
      */
     public function hasColumn($columnName)
@@ -385,7 +372,6 @@ class Table
      *
      * @param string|array|\Phinx\Db\Table\Index $columns Table Column(s)
      * @param array $options Index Options
-     *
      * @return $this
      */
     public function addIndex($columns, array $options = [])
@@ -400,7 +386,6 @@ class Table
      * Removes the given index from a table.
      *
      * @param string|string[] $columns Columns
-     *
      * @return $this
      */
     public function removeIndex($columns)
@@ -415,7 +400,6 @@ class Table
      * Removes the given index identified by its name from a table.
      *
      * @param string $name Index name
-     *
      * @return $this
      */
     public function removeIndexByName($name)
@@ -430,7 +414,6 @@ class Table
      * Checks to see if an index exists.
      *
      * @param string|string[] $columns Columns
-     *
      * @return bool
      */
     public function hasIndex($columns)
@@ -442,7 +425,6 @@ class Table
      * Checks to see if an index specified by name exists.
      *
      * @param string $indexName Index name
-     *
      * @return bool
      */
     public function hasIndexByName($indexName)
@@ -460,7 +442,6 @@ class Table
      * @param string|\Phinx\Db\Table $referencedTable Referenced Table
      * @param string|string[] $referencedColumns Referenced Columns
      * @param array $options Options
-     *
      * @return $this
      */
     public function addForeignKey($columns, $referencedTable, $referencedColumns = ['id'], $options = [])
@@ -482,7 +463,6 @@ class Table
      * @param string|\Phinx\Db\Table $referencedTable Referenced Table
      * @param string|string[] $referencedColumns Referenced Columns
      * @param array $options Options
-     *
      * @return $this
      */
     public function addForeignKeyWithName($name, $columns, $referencedTable, $referencedColumns = ['id'], $options = [])
@@ -505,7 +485,6 @@ class Table
      *
      * @param string|string[] $columns Column(s)
      * @param string|null $constraint Constraint names
-     *
      * @return $this
      */
     public function dropForeignKey($columns, $constraint = null)
@@ -521,7 +500,6 @@ class Table
      *
      * @param string|string[] $columns Column(s)
      * @param string|null $constraint Constraint names
-     *
      * @return bool
      */
     public function hasForeignKey($columns, $constraint = null)
@@ -535,13 +513,12 @@ class Table
      * @param string|null $createdAt Alternate name for the created_at column
      * @param string|null $updatedAt Alternate name for the updated_at column
      * @param bool $withTimezone Whether to set the timezone option on the added columns
-     *
      * @return $this
      */
     public function addTimestamps($createdAt = 'created_at', $updatedAt = 'updated_at', $withTimezone = false)
     {
-        $createdAt = $createdAt === null ? 'created_at' : $createdAt;
-        $updatedAt = $updatedAt === null ? 'updated_at' : $updatedAt;
+        $createdAt = $createdAt ?? 'created_at';
+        $updatedAt = $updatedAt ?? 'updated_at';
 
         $this->addColumn($createdAt, 'timestamp', [
                    'default' => 'CURRENT_TIMESTAMP',
@@ -562,10 +539,8 @@ class Table
      * Alias that always sets $withTimezone to true
      *
      * @see addTimestamps
-     *
      * @param string|null $createdAt Alternate name for the created_at column
      * @param string|null $updatedAt Alternate name for the updated_at column
-     *
      * @return $this
      */
     public function addTimestampsWithTimezone($createdAt = null, $updatedAt = null)
@@ -584,7 +559,6 @@ class Table
      *                  array("col2" => "value2", "col2" => "anotherValue2"),
      *              )
      *              or array("col1" => "value1", "col2" => "anotherValue1")
-     *
      * @return $this
      */
     public function insert($data)
@@ -695,7 +669,6 @@ class Table
      * Executes all the pending actions for this table
      *
      * @param bool $exists Whether or not the table existed prior to executing this method
-     *
      * @return void
      */
     protected function executeActions($exists)

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -153,7 +153,6 @@ class Column
      * Sets the column name.
      *
      * @param string $name Name
-     *
      * @return $this
      */
     public function setName($name)
@@ -177,7 +176,6 @@ class Column
      * Sets the column type.
      *
      * @param string|\Phinx\Util\Literal $type Column type
-     *
      * @return $this
      */
     public function setType($type)
@@ -201,7 +199,6 @@ class Column
      * Sets the column limit.
      *
      * @param int $limit Limit
-     *
      * @return $this
      */
     public function setLimit($limit)
@@ -225,7 +222,6 @@ class Column
      * Sets whether the column allows nulls.
      *
      * @param bool $null Null
-     *
      * @return $this
      */
     public function setNull($null)
@@ -259,7 +255,6 @@ class Column
      * Sets the default column value.
      *
      * @param mixed $default Default
-     *
      * @return $this
      */
     public function setDefault($default)
@@ -283,7 +278,6 @@ class Column
      * Sets whether or not the column is an identity column.
      *
      * @param bool $identity Identity
-     *
      * @return $this
      */
     public function setIdentity($identity)
@@ -317,7 +311,6 @@ class Column
      * Sets the name of the column to add this column after.
      *
      * @param string $after After
-     *
      * @return $this
      */
     public function setAfter($after)
@@ -341,7 +334,6 @@ class Column
      * Sets the 'ON UPDATE' mysql column function.
      *
      * @param string $update On Update function
-     *
      * @return $this
      */
     public function setUpdate($update)
@@ -368,7 +360,6 @@ class Column
      * and the column could store value from -999.99 to 999.99.
      *
      * @param int $precision Number precision
-     *
      * @return $this
      */
     public function setPrecision($precision)
@@ -415,7 +406,6 @@ class Column
      * Sets the column identity seed.
      *
      * @param int $seed Number seed
-     *
      * @return $this
      */
     public function setSeed($seed)
@@ -429,7 +419,6 @@ class Column
      * Sets the column identity increment.
      *
      * @param int $increment Number increment
-     *
      * @return $this
      */
     public function setIncrement($increment)
@@ -446,7 +435,6 @@ class Column
      * and the column could store value from -999.99 to 999.99.
      *
      * @param int $scale Number scale
-     *
      * @return $this
      */
     public function setScale($scale)
@@ -477,7 +465,6 @@ class Column
      *
      * @param int $precision Number precision
      * @param int $scale Number scale
-     *
      * @return $this
      */
     public function setPrecisionAndScale($precision, $scale)
@@ -492,7 +479,6 @@ class Column
      * Sets the column comment.
      *
      * @param string $comment Comment
-     *
      * @return $this
      */
     public function setComment($comment)
@@ -516,7 +502,6 @@ class Column
      * Sets whether field should be signed.
      *
      * @param bool $signed Signed
-     *
      * @return $this
      */
     public function setSigned($signed)
@@ -551,7 +536,6 @@ class Column
      * Used for date/time columns only!
      *
      * @param bool $timezone Timezone
-     *
      * @return $this
      */
     public function setTimezone($timezone)
@@ -585,7 +569,6 @@ class Column
      * Sets field properties.
      *
      * @param array $properties Properties
-     *
      * @return $this
      */
     public function setProperties($properties)
@@ -609,7 +592,6 @@ class Column
      * Sets field values.
      *
      * @param string[]|string $values Value(s)
-     *
      * @return $this
      */
     public function setValues($values)
@@ -636,9 +618,7 @@ class Column
      * Sets the column collation.
      *
      * @param string $collation Collation
-     *
      * @throws \UnexpectedValueException If collation not allowed for type
-     *
      * @return $this
      */
     public function setCollation($collation)
@@ -671,9 +651,7 @@ class Column
      * Sets the column character set.
      *
      * @param string $encoding Encoding
-     *
      * @throws \UnexpectedValueException If character set not allowed for type
-     *
      * @return $this
      */
     public function setEncoding($encoding)
@@ -770,9 +748,7 @@ class Column
      * Utility method that maps an array of column options to this objects methods.
      *
      * @param array $options Options
-     *
      * @throws \RuntimeException
-     *
      * @return $this
      */
     public function setOptions($options)

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -51,7 +51,6 @@ class ForeignKey
      * Sets the foreign key columns.
      *
      * @param string[]|string $columns Columns
-     *
      * @return $this
      */
     public function setColumns($columns)
@@ -75,7 +74,6 @@ class ForeignKey
      * Sets the foreign key referenced table.
      *
      * @param \Phinx\Db\Table\Table $table The table this KEY is pointing to
-     *
      * @return $this
      */
     public function setReferencedTable(Table $table)
@@ -99,7 +97,6 @@ class ForeignKey
      * Sets the foreign key referenced columns.
      *
      * @param string[] $referencedColumns Referenced columns
-     *
      * @return $this
      */
     public function setReferencedColumns(array $referencedColumns)
@@ -123,7 +120,6 @@ class ForeignKey
      * Sets ON DELETE action for the foreign key.
      *
      * @param string $onDelete On Delete
-     *
      * @return $this
      */
     public function setOnDelete($onDelete)
@@ -157,7 +153,6 @@ class ForeignKey
      * Sets ON UPDATE action for the foreign key.
      *
      * @param string $onUpdate On Update
-     *
      * @return $this
      */
     public function setOnUpdate($onUpdate)
@@ -171,7 +166,6 @@ class ForeignKey
      * Sets constraint for the foreign key.
      *
      * @param string $constraint Constraint
-     *
      * @return $this
      */
     public function setConstraint($constraint)
@@ -195,9 +189,7 @@ class ForeignKey
      * Utility method that maps an array of index options to this objects methods.
      *
      * @param array $options Options
-     *
      * @throws \RuntimeException
-     *
      * @return $this
      */
     public function setOptions($options)
@@ -227,9 +219,7 @@ class ForeignKey
      * From passed value checks if it's correct and fixes if needed
      *
      * @param string $action Action
-     *
      * @throws \InvalidArgumentException
-     *
      * @return string
      */
     protected function normalizeAction($action)

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -50,7 +50,6 @@ class Index
      * Sets the index columns.
      *
      * @param string[] $columns Columns
-     *
      * @return $this
      */
     public function setColumns($columns)
@@ -74,7 +73,6 @@ class Index
      * Sets the index type.
      *
      * @param string $type Type
-     *
      * @return $this
      */
     public function setType($type)
@@ -98,7 +96,6 @@ class Index
      * Sets the index name.
      *
      * @param string $name Name
-     *
      * @return $this
      */
     public function setName($name)
@@ -122,7 +119,6 @@ class Index
      * Sets the index limit.
      *
      * @param int|array $limit limit value or array of limit value
-     *
      * @return $this
      */
     public function setLimit($limit)
@@ -146,9 +142,7 @@ class Index
      * Utility method that maps an array of index options to this objects methods.
      *
      * @param array $options Options
-     *
      * @throws \RuntimeException
-     *
      * @return $this
      */
     public function setOptions($options)

--- a/src/Phinx/Db/Table/Table.php
+++ b/src/Phinx/Db/Table/Table.php
@@ -24,7 +24,6 @@ class Table
     /**
      * @param string $name The table name
      * @param array $options The creation options for this table
-     *
      * @throws \InvalidArgumentException
      */
     public function __construct($name, array $options = [])
@@ -41,7 +40,6 @@ class Table
      * Sets the table name.
      *
      * @param string $name The name of the table
-     *
      * @return $this
      */
     public function setName($name)
@@ -75,7 +73,6 @@ class Table
      * Sets the table options
      *
      * @param array $options The options for the table creation
-     *
      * @return void
      */
     public function setOptions(array $options)

--- a/src/Phinx/Db/Util/AlterInstructions.php
+++ b/src/Phinx/Db/Util/AlterInstructions.php
@@ -39,7 +39,6 @@ class AlterInstructions
      * Adds another part to the single ALTER instruction
      *
      * @param string $part The SQL snipped to add as part of the ALTER instruction
-     *
      * @return void
      */
     public function addAlter($part)
@@ -56,7 +55,6 @@ class AlterInstructions
      * This allows to keep a single state across callbacks.
      *
      * @param string|callable $sql The SQL to run after, or a callable to execute
-     *
      * @return void
      */
     public function addPostStep($sql)
@@ -88,7 +86,6 @@ class AlterInstructions
      * Merges another AlterInstructions object to this one
      *
      * @param \Phinx\Db\Util\AlterInstructions $other The other collection of instructions to merge in
-     *
      * @return void
      */
     public function merge(AlterInstructions $other)
@@ -102,7 +99,6 @@ class AlterInstructions
      *
      * @param string $alterTemplate The template for the alter instruction
      * @param callable $executor The function to be used to execute all instructions
-     *
      * @return void
      */
     public function execute($alterTemplate, callable $executor)

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -70,7 +70,7 @@ abstract class AbstractMigration implements MigrationInterface
      * @param \Symfony\Component\Console\Input\InputInterface|null $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output
      */
-    final public function __construct($environment, $version, InputInterface $input = null, OutputInterface $output = null)
+    final public function __construct($environment, $version, ?InputInterface $input = null, ?OutputInterface $output = null)
     {
         $this->environment = $environment;
         $this->version = $version;
@@ -282,9 +282,7 @@ abstract class AbstractMigration implements MigrationInterface
      * A short-hand method to drop the given database table.
      *
      * @deprecated since 0.10.0. Use $this->table($tableName)->drop()->save() instead.
-     *
      * @param string $tableName Table name
-     *
      * @return void
      */
     public function dropTable($tableName)
@@ -301,7 +299,6 @@ abstract class AbstractMigration implements MigrationInterface
      * an `up()` or a `down()` method.
      *
      * @param string|null $direction Direction
-     *
      * @return void
      */
     public function preFlightCheck($direction = null)
@@ -324,9 +321,7 @@ abstract class AbstractMigration implements MigrationInterface
      * Right now, the only check is whether all changes were committed
      *
      * @param string|null $direction direction of migration
-     *
      * @throws \RuntimeException
-     *
      * @return void
      */
     public function postFlightCheck($direction = null)

--- a/src/Phinx/Migration/AbstractTemplateCreation.php
+++ b/src/Phinx/Migration/AbstractTemplateCreation.php
@@ -26,7 +26,7 @@ abstract class AbstractTemplateCreation implements CreationInterface
      * @param \Symfony\Component\Console\Input\InputInterface|null $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output
      */
-    public function __construct(InputInterface $input = null, OutputInterface $output = null)
+    public function __construct(?InputInterface $input = null, ?OutputInterface $output = null)
     {
         if ($input !== null) {
             $this->setInput($input);

--- a/src/Phinx/Migration/CreationInterface.php
+++ b/src/Phinx/Migration/CreationInterface.php
@@ -21,18 +21,16 @@ interface CreationInterface
      * @param \Symfony\Component\Console\Input\InputInterface|null $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output
      */
-    public function __construct(InputInterface $input = null, OutputInterface $output = null);
+    public function __construct(?InputInterface $input = null, ?OutputInterface $output = null);
 
     /**
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     *
      * @return \Phinx\Migration\CreationInterface
      */
     public function setInput(InputInterface $input);
 
     /**
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return \Phinx\Migration\CreationInterface
      */
     public function setOutput(OutputInterface $output);
@@ -65,7 +63,6 @@ interface CreationInterface
      * @param string $migrationFilename The name of the newly created migration.
      * @param string $className The class name.
      * @param string $baseClassName The name of the base class.
-     *
      * @return void
      */
     public function postMigrationCreation($migrationFilename, $className, $baseClassName);

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -80,9 +80,7 @@ class Manager
      *
      * @param string $environment environment to print status of
      * @param string|null $format format to print status in (either text, json, or null)
-     *
      * @throws \RuntimeException
-     *
      * @return array array indicating if there are any missing or down migrations
      */
     public function printStatus($environment, $format = null)
@@ -106,10 +104,10 @@ class Manager
 
             switch ($this->getConfig()->getVersionOrder()) {
                 case Config::VERSION_ORDER_CREATION_TIME:
-                    $migrationIdAndStartedHeader = "<info>[Migration ID]</info>  Started            ";
+                    $migrationIdAndStartedHeader = '<info>[Migration ID]</info>  Started            ';
                     break;
                 case Config::VERSION_ORDER_EXECUTION_TIME:
-                    $migrationIdAndStartedHeader = "Migration ID    <info>[Started          ]</info>";
+                    $migrationIdAndStartedHeader = 'Migration ID    <info>[Started          ]</info>';
                     break;
                 default:
                     throw new RuntimeException('Invalid version_order configuration option');
@@ -252,7 +250,6 @@ class Manager
      *
      * @param array $version The missing version to print (in the format returned by Environment.getVersionLog).
      * @param int $maxNameLength The maximum migration name length.
-     *
      * @return void
      */
     protected function printMissingVersion($version, $maxNameLength)
@@ -277,7 +274,6 @@ class Manager
      * @param \DateTime $dateTime Date to migrate to
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the
      *                               migration
-     *
      * @return void
      */
     public function migrateToDateTime($environment, DateTime $dateTime, $fake = false)
@@ -302,7 +298,6 @@ class Manager
      * @param string $environment Environment
      * @param int|null $version version to migrate to
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
-     *
      * @return void
      */
     public function migrate($environment, $version = null, $fake = false)
@@ -365,7 +360,6 @@ class Manager
      * @param \Phinx\Migration\MigrationInterface $migration Migration
      * @param string $direction Direction
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
-     *
      * @return void
      */
     public function executeMigration($name, MigrationInterface $migration, $direction = MigrationInterface::UP, $fake = false)
@@ -395,7 +389,6 @@ class Manager
      *
      * @param string $name Environment Name
      * @param \Phinx\Seed\SeedInterface $seed Seed
-     *
      * @return void
      */
     public function executeSeed($name, SeedInterface $seed)
@@ -428,7 +421,6 @@ class Manager
      * @param bool $force Force
      * @param bool $targetMustMatchVersion Target must match version
      * @param bool $fake Flag that if true, we just record running the migration, but not actually do the migration
-     *
      * @return void
      */
     public function rollback($environment, $target = null, $force = false, $targetMustMatchVersion = true, $fake = false)
@@ -539,9 +531,7 @@ class Manager
      *
      * @param string $environment Environment
      * @param string|null $seed Seeder
-     *
      * @throws \InvalidArgumentException
-     *
      * @return void
      */
     public function seed($environment, $seed = null)
@@ -569,7 +559,6 @@ class Manager
      * Sets the environments.
      *
      * @param \Phinx\Migration\Manager\Environment[] $environments Environments
-     *
      * @return $this
      */
     public function setEnvironments($environments = [])
@@ -583,9 +572,7 @@ class Manager
      * Gets the manager class for the given environment.
      *
      * @param string $name Environment Name
-     *
      * @throws \InvalidArgumentException
-     *
      * @return \Phinx\Migration\Manager\Environment
      */
     public function getEnvironment($name)
@@ -629,7 +616,6 @@ class Manager
      * Sets the console input.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     *
      * @return $this
      */
     public function setInput(InputInterface $input)
@@ -653,7 +639,6 @@ class Manager
      * Sets the console output.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return $this
      */
     public function setOutput(OutputInterface $output)
@@ -677,7 +662,6 @@ class Manager
      * Sets the database migrations.
      *
      * @param \Phinx\Migration\AbstractMigration[] $migrations Migrations
-     *
      * @return $this
      */
     public function setMigrations(array $migrations)
@@ -692,9 +676,7 @@ class Manager
      * order
      *
      * @param string $environment Environment
-     *
      * @throws \InvalidArgumentException
-     *
      * @return \Phinx\Migration\AbstractMigration[]
      */
     public function getMigrations($environment)
@@ -809,7 +791,6 @@ class Manager
      * Sets the database seeders.
      *
      * @param \Phinx\Seed\AbstractSeed[] $seeds Seeders
-     *
      * @return $this
      */
     public function setSeeds(array $seeds)
@@ -823,7 +804,6 @@ class Manager
      * Get seed dependencies instances from seed dependency array
      *
      * @param \Phinx\Seed\AbstractSeed $seed Seed
-     *
      * @return \Phinx\Seed\AbstractSeed[]
      */
     protected function getSeedDependenciesInstances(AbstractSeed $seed)
@@ -847,7 +827,6 @@ class Manager
      * Order seeds by dependencies
      *
      * @param \Phinx\Seed\AbstractSeed[] $seeds Seeds
-     *
      * @return \Phinx\Seed\AbstractSeed[]
      */
     protected function orderSeedsByDependencies(array $seeds)
@@ -871,7 +850,6 @@ class Manager
      * Gets an array of database seeders.
      *
      * @throws \InvalidArgumentException
-     *
      * @return \Phinx\Seed\AbstractSeed[]
      */
     public function getSeeds()
@@ -955,7 +933,6 @@ class Manager
      * Sets the config.
      *
      * @param \Phinx\Config\ConfigInterface $config Configuration Object
-     *
      * @return $this
      */
     public function setConfig(ConfigInterface $config)
@@ -980,7 +957,6 @@ class Manager
      *
      * @param string $environment Environment name
      * @param int|null $version Version
-     *
      * @return void
      */
     public function toggleBreakpoint($environment, $version)
@@ -994,7 +970,6 @@ class Manager
      * @param string $environment The required environment
      * @param int|null $version The version of the target migration
      * @param int $mark The state of the breakpoint as defined by self::BREAKPOINT_xxxx constants.
-     *
      * @return void
      */
     protected function markBreakpoint($environment, $version, $mark)
@@ -1051,7 +1026,6 @@ class Manager
      * Remove all breakpoints
      *
      * @param string $environment The required environment
-     *
      * @return void
      */
     public function removeBreakpoints($environment)
@@ -1067,7 +1041,6 @@ class Manager
      *
      * @param string $environment The required environment
      * @param int|null $version The version of the target migration
-     *
      * @return void
      */
     public function setBreakpoint($environment, $version)
@@ -1080,7 +1053,6 @@ class Manager
      *
      * @param string $environment The required environment
      * @param int|null $version The version of the target migration
-     *
      * @return void
      */
     public function unsetBreakpoint($environment, $version)

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -69,12 +69,11 @@ class Environment
      * @param \Phinx\Migration\MigrationInterface $migration Migration
      * @param string $direction Direction
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
-     *
      * @return void
      */
     public function executeMigration(MigrationInterface $migration, $direction = MigrationInterface::UP, $fake = false)
     {
-        $direction = ($direction === MigrationInterface::UP) ? MigrationInterface::UP : MigrationInterface::DOWN;
+        $direction = $direction === MigrationInterface::UP ? MigrationInterface::UP : MigrationInterface::DOWN;
         $migration->setMigratingUp($direction === MigrationInterface::UP);
 
         $startTime = time();
@@ -128,7 +127,6 @@ class Environment
      * Executes the specified seeder on this environment.
      *
      * @param \Phinx\Seed\SeedInterface $seed Seed
-     *
      * @return void
      */
     public function executeSeed(SeedInterface $seed)
@@ -158,7 +156,6 @@ class Environment
      * Sets the environment's name.
      *
      * @param string $name Environment Name
-     *
      * @return $this
      */
     public function setName($name)
@@ -182,7 +179,6 @@ class Environment
      * Sets the environment's options.
      *
      * @param array $options Environment Options
-     *
      * @return $this
      */
     public function setOptions($options)
@@ -206,7 +202,6 @@ class Environment
      * Sets the console input.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     *
      * @return $this
      */
     public function setInput(InputInterface $input)
@@ -230,7 +225,6 @@ class Environment
      * Sets the console output.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return $this
      */
     public function setOutput(OutputInterface $output)
@@ -275,7 +269,6 @@ class Environment
      * Sets the current version of the environment.
      *
      * @param int $version Environment Version
-     *
      * @return $this
      */
     public function setCurrentVersion($version)
@@ -311,7 +304,6 @@ class Environment
      * Sets the database adapter.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
-     *
      * @return $this
      */
     public function setAdapter(AdapterInterface $adapter)
@@ -325,7 +317,6 @@ class Environment
      * Gets the database adapter.
      *
      * @throws \RuntimeException
-     *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
     public function getAdapter()
@@ -386,7 +377,6 @@ class Environment
      * Sets the schema table name.
      *
      * @param string $schemaTableName Schema Table Name
-     *
      * @return $this
      */
     public function setSchemaTableName($schemaTableName)

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -42,7 +42,6 @@ interface MigrationInterface
      * Sets the database adapter.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
-     *
      * @return \Phinx\Migration\MigrationInterface
      */
     public function setAdapter(AdapterInterface $adapter);
@@ -58,7 +57,6 @@ interface MigrationInterface
      * Sets the input object to be used in migration object
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     *
      * @return \Phinx\Migration\MigrationInterface
      */
     public function setInput(InputInterface $input);
@@ -74,7 +72,6 @@ interface MigrationInterface
      * Sets the output object to be used in migration object
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return \Phinx\Migration\MigrationInterface
      */
     public function setOutput(OutputInterface $output);
@@ -104,7 +101,6 @@ interface MigrationInterface
      * Sets the migration version number.
      *
      * @param int $version Version
-     *
      * @return \Phinx\Migration\MigrationInterface
      */
     public function setVersion($version);
@@ -120,7 +116,6 @@ interface MigrationInterface
      * Sets whether this migration is being applied or reverted
      *
      * @param bool $isMigratingUp True if the migration is being applied
-     *
      * @return \Phinx\Migration\MigrationInterface
      */
     public function setMigratingUp($isMigratingUp);
@@ -137,7 +132,6 @@ interface MigrationInterface
      * Executes a SQL statement and returns the number of affected rows.
      *
      * @param string $sql SQL
-     *
      * @return int
      */
     public function execute($sql);
@@ -151,7 +145,6 @@ interface MigrationInterface
      * you can set the return type by the adapter in your current use.
      *
      * @param string $sql SQL
-     *
      * @return mixed
      */
     public function query($sql);
@@ -164,7 +157,6 @@ interface MigrationInterface
      * the dry-run settings.
      *
      * @see https://api.cakephp.org/3.6/class-Cake.Database.Query.html
-     *
      * @return \Cake\Database\Query
      */
     public function getQueryBuilder();
@@ -173,7 +165,6 @@ interface MigrationInterface
      * Executes a query and returns only one row as an array.
      *
      * @param string $sql SQL
-     *
      * @return array
      */
     public function fetchRow($sql);
@@ -182,7 +173,6 @@ interface MigrationInterface
      * Executes a query and returns an array of rows.
      *
      * @param string $sql SQL
-     *
      * @return array
      */
     public function fetchAll($sql);
@@ -191,10 +181,8 @@ interface MigrationInterface
      * Insert data into a table.
      *
      * @deprecated since 0.10.0. Use $this->table($tableName)->insert($data)->save() instead.
-     *
      * @param string $tableName Table name
      * @param array $data Data
-     *
      * @return void
      */
     public function insert($tableName, $data);
@@ -204,7 +192,6 @@ interface MigrationInterface
      *
      * @param string $name Database Name
      * @param array $options Options
-     *
      * @return void
      */
     public function createDatabase($name, $options);
@@ -213,7 +200,6 @@ interface MigrationInterface
      * Drop a database.
      *
      * @param string $name Database Name
-     *
      * @return void
      */
     public function dropDatabase($name);
@@ -222,7 +208,6 @@ interface MigrationInterface
      * Checks to see if a table exists.
      *
      * @param string $tableName Table name
-     *
      * @return bool
      */
     public function hasTable($tableName);
@@ -234,7 +219,6 @@ interface MigrationInterface
      *
      * @param string $tableName Table name
      * @param array $options Options
-     *
      * @return \Phinx\Db\Table
      */
     public function table($tableName, $options);
@@ -244,7 +228,6 @@ interface MigrationInterface
      * if there are potential problems.
      *
      * @param string|null $direction Direction
-     *
      * @return void
      */
     public function preFlightCheck($direction = null);
@@ -255,7 +238,6 @@ interface MigrationInterface
      * Right now, the only check is whether all changes were committed
      *
      * @param string|null $direction direction of migration
-     *
      * @return void
      */
     public function postFlightCheck($direction = null);

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -39,7 +39,6 @@ interface SeedInterface
      * Sets the database adapter.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
-     *
      * @return \Phinx\Seed\SeedInterface
      */
     public function setAdapter(AdapterInterface $adapter);
@@ -55,7 +54,6 @@ interface SeedInterface
      * Sets the input object to be used in migration object
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     *
      * @return \Phinx\Seed\SeedInterface
      */
     public function setInput(InputInterface $input);
@@ -71,7 +69,6 @@ interface SeedInterface
      * Sets the output object to be used in migration object
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     *
      * @return \Phinx\Seed\SeedInterface
      */
     public function setOutput(OutputInterface $output);
@@ -94,7 +91,6 @@ interface SeedInterface
      * Executes a SQL statement and returns the number of affected rows.
      *
      * @param string $sql SQL
-     *
      * @return int
      */
     public function execute($sql);
@@ -108,7 +104,6 @@ interface SeedInterface
      * you can set the return type by the adapter in your current use.
      *
      * @param string $sql SQL
-     *
      * @return mixed
      */
     public function query($sql);
@@ -117,7 +112,6 @@ interface SeedInterface
      * Executes a query and returns only one row as an array.
      *
      * @param string $sql SQL
-     *
      * @return array
      */
     public function fetchRow($sql);
@@ -126,7 +120,6 @@ interface SeedInterface
      * Executes a query and returns an array of rows.
      *
      * @param string $sql SQL
-     *
      * @return array
      */
     public function fetchAll($sql);
@@ -136,7 +129,6 @@ interface SeedInterface
      *
      * @param string $tableName Table name
      * @param array $data Data
-     *
      * @return void
      */
     public function insert($tableName, $data);
@@ -145,7 +137,6 @@ interface SeedInterface
      * Checks to see if a table exists.
      *
      * @param string $tableName Table name
-     *
      * @return bool
      */
     public function hasTable($tableName);
@@ -157,7 +148,6 @@ interface SeedInterface
      *
      * @param string $tableName Table name
      * @param array $options Options
-     *
      * @return \Phinx\Db\Table
      */
     public function table($tableName, $options);

--- a/src/Phinx/Util/Expression.php
+++ b/src/Phinx/Util/Expression.php
@@ -32,7 +32,6 @@ class Expression
 
     /**
      * @param string $value The expression
-     *
      * @return self
      */
     public static function from($value)

--- a/src/Phinx/Util/Literal.php
+++ b/src/Phinx/Util/Literal.php
@@ -32,7 +32,6 @@ class Literal
 
     /**
      * @param string $value The literal's value
-     *
      * @return self
      */
     public static function from($value)

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -54,7 +54,6 @@ class Util
      * Gets an array of all the existing migration class names.
      *
      * @param string $path Path
-     *
      * @return string[]
      */
     public static function getExistingMigrationClassNames($path)
@@ -82,7 +81,6 @@ class Util
      * Get the version from the beginning of a file name.
      *
      * @param string $fileName File Name
-     *
      * @return string
      */
     public static function getVersionFromFileName($fileName)
@@ -99,7 +97,6 @@ class Util
      * '12345678901234_limit_resource_names_to_30_chars.php'.
      *
      * @param string $className Class Name
-     *
      * @return string
      */
     public static function mapClassNameToFileName($className)
@@ -118,7 +115,6 @@ class Util
      * names like 'CreateUserTable'.
      *
      * @param string $fileName File Name
-     *
      * @return string
      */
     public static function mapFileNameToClassName(string $fileName): string
@@ -127,7 +123,7 @@ class Util
         if (preg_match(static::MIGRATION_FILE_NAME_PATTERN, $fileName, $matches)) {
             $fileName = $matches[1];
         } elseif (preg_match(static::MIGRATION_FILE_NAME_NO_NAME_PATTERN, $fileName)) {
-            return "V" . substr($fileName, 0, strlen($fileName) - 4);
+            return 'V' . substr($fileName, 0, strlen($fileName) - 4);
         }
 
         $className = str_replace('_', '', ucwords($fileName, '_'));
@@ -147,7 +143,6 @@ class Util
      *
      * @param string $className Class Name
      * @param string $path Path
-     *
      * @return bool
      */
     public static function isUniqueMigrationClassName($className, $path)
@@ -166,7 +161,6 @@ class Util
      * Single words are not allowed on their own.
      *
      * @param string $className Class Name
-     *
      * @return bool
      */
     public static function isValidPhinxClassName($className)
@@ -178,22 +172,18 @@ class Util
      * Check if a migration file name is valid.
      *
      * @param string $fileName File Name
-     *
      * @return bool
      */
     public static function isValidMigrationFileName(string $fileName): bool
     {
-        return (
-            (bool)preg_match(static::MIGRATION_FILE_NAME_PATTERN, $fileName)
-            || (bool)preg_match(static::MIGRATION_FILE_NAME_NO_NAME_PATTERN, $fileName)
-        );
+        return (bool)preg_match(static::MIGRATION_FILE_NAME_PATTERN, $fileName)
+            || (bool)preg_match(static::MIGRATION_FILE_NAME_NO_NAME_PATTERN, $fileName);
     }
 
     /**
      * Check if a seed file name is valid.
      *
      * @param string $fileName File Name
-     *
      * @return bool
      */
     public static function isValidSeedFileName($fileName)
@@ -205,7 +195,6 @@ class Util
      * Expands a set of paths with curly braces (if supported by the OS).
      *
      * @param string[] $paths Paths
-     *
      * @return string[]
      */
     public static function globAll(array $paths)
@@ -223,7 +212,6 @@ class Util
      * Expands a path with curly braces (if supported by the OS).
      *
      * @param string $path Path
-     *
      * @return string[]
      */
     public static function glob($path)
@@ -235,9 +223,7 @@ class Util
      * Takes the path to a php file and attempts to include it if readable
      *
      * @param string $filename Filename
-     *
      * @throws \Exception
-     *
      * @return string
      */
     public static function loadPhpFile($filename)
@@ -267,13 +253,12 @@ class Util
      * Given an array of paths, return all unique PHP files that are in them
      *
      * @param string|string[] $paths Path or array of paths to get .php files.
-     *
      * @return string[]
      */
     public static function getFiles($paths)
     {
         $files = static::globAll(array_map(function ($path) {
-            return $path . DIRECTORY_SEPARATOR . "*.php";
+            return $path . DIRECTORY_SEPARATOR . '*.php';
         }, (array)$paths));
         // glob() can return the same file multiple times
         // This will cause the migration to fail with a

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -68,7 +68,6 @@ class TextWrapper
      * Returns the output from running the "status" command.
      *
      * @param string|null $env environment name (optional)
-     *
      * @return string
      */
     public function getStatus($env = null)
@@ -95,7 +94,6 @@ class TextWrapper
      *
      * @param string|null $env environment name (optional)
      * @param string|null $target target version (optional)
-     *
      * @return string
      */
     public function getMigrate($env = null, $target = null)
@@ -123,7 +121,6 @@ class TextWrapper
      * @param string|null $env Environment name
      * @param string|null $target Target version
      * @param string[]|string|null $seed Array of seed names or seed name
-     *
      * @return string
      */
     public function getSeed($env = null, $target = null, $seed = null)
@@ -154,7 +151,6 @@ class TextWrapper
      *
      * @param string|null $env Environment name (optional)
      * @param mixed $target Target version, or 0 (zero) fully revert (optional)
-     *
      * @return string
      */
     public function getRollback($env = null, $target = null)
@@ -182,7 +178,6 @@ class TextWrapper
      * Check option from options array
      *
      * @param string $key Key
-     *
      * @return bool
      */
     protected function hasOption($key)
@@ -194,7 +189,6 @@ class TextWrapper
      * Get option from options array
      *
      * @param string $key Key
-     *
      * @return string|null
      */
     protected function getOption($key)
@@ -211,7 +205,6 @@ class TextWrapper
      *
      * @param string $key Key
      * @param string $value Value
-     *
      * @return $this
      */
     public function setOption($key, $value)
@@ -225,7 +218,6 @@ class TextWrapper
      * Execute a command, capturing output and storing the exit code.
      *
      * @param array $command Command
-     *
      * @return string
      */
     protected function executeRun(array $command)

--- a/tests/Phinx/Config/AbstractConfigTest.php
+++ b/tests/Phinx/Config/AbstractConfigTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class AbstractConfigTest
+ *
  * @package Test\Phinx\Config
  * @group config
  * @coversNothing
@@ -73,7 +74,7 @@ abstract class AbstractConfigTest extends TestCase
      */
     protected function getMigrationPaths()
     {
-        if (null === $this->migrationPath) {
+        if ($this->migrationPath === null) {
             $this->migrationPath = uniqid('phinx', true);
         }
 
@@ -87,7 +88,7 @@ abstract class AbstractConfigTest extends TestCase
      */
     protected function getSeedPaths()
     {
-        if (null === $this->seedPath) {
+        if ($this->seedPath === null) {
             $this->seedPath = uniqid('phinx', true);
         }
 

--- a/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
+++ b/tests/Phinx/Config/ConfigDefaultEnvironmentTest.php
@@ -7,6 +7,7 @@ use RuntimeException;
 
 /**
  * Class ConfigDefaultEnvironmentTest
+ *
  * @package Test\Phinx\Config
  * @group config
  * @covers \Phinx\Config\Config::getDefaultEnvironment

--- a/tests/Phinx/Config/ConfigDsnTest.php
+++ b/tests/Phinx/Config/ConfigDsnTest.php
@@ -6,6 +6,7 @@ use Phinx\Config\Config;
 
 /**
  * Class ConfigDsnTest
+ *
  * @package Test\Phinx\Config
  * @group config
  * @covers \Phinx\Config\Config::getEnvironment

--- a/tests/Phinx/Config/ConfigFileTest.php
+++ b/tests/Phinx/Config/ConfigFileTest.php
@@ -3,11 +3,9 @@
 namespace Test\Phinx\Config;
 
 use InvalidArgumentException;
-use Phinx\Console\Command\AbstractCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
 class ConfigFileTest extends TestCase
@@ -31,7 +29,6 @@ class ConfigFileTest extends TestCase
      * Test workingContext
      *
      * @dataProvider workingProvider
-     *
      * @param $input
      * @param $dir
      * @param $expectedFile
@@ -48,7 +45,6 @@ class ConfigFileTest extends TestCase
      * Test workingContext
      *
      * @dataProvider notWorkingProvider
-     *
      * @param $input
      * @param $dir
      */
@@ -80,7 +76,6 @@ class ConfigFileTest extends TestCase
 
     /**
      * Working cases
-     *
      *
      * @return array
      */
@@ -117,18 +112,5 @@ class ConfigFileTest extends TestCase
             ['phinx.json', 'OnlyYaml'],
             ['phinx.php', 'OnlyYaml'],
         ];
-    }
-}
-
-/**
- * Class VoidCommand : used to expose locateConfigFile To testing
- *
- * @package Test\Phinx\Config
- */
-class VoidCommand extends AbstractCommand
-{
-    public function locateConfigFile(InputInterface $input)
-    {
-        return parent::locateConfigFile($input);
     }
 }

--- a/tests/Phinx/Config/ConfigJsonTest.php
+++ b/tests/Phinx/Config/ConfigJsonTest.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 /**
  * Class ConfigJsonTest
+ *
  * @package Test\Phinx\Config
  * @group config
  */

--- a/tests/Phinx/Config/ConfigMigrationPathsTest.php
+++ b/tests/Phinx/Config/ConfigMigrationPathsTest.php
@@ -7,6 +7,7 @@ use UnexpectedValueException;
 
 /**
  * Class ConfigMigrationPathsTest
+ *
  * @package Test\Phinx\Config
  * @group config
  * @covers \Phinx\Config\Config::getMigrationPaths

--- a/tests/Phinx/Config/ConfigPhpTest.php
+++ b/tests/Phinx/Config/ConfigPhpTest.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 /**
  * Class ConfigPhpTest
+ *
  * @package Test\Phinx\Config
  * @group config
  */

--- a/tests/Phinx/Config/ConfigReplaceTokensTest.php
+++ b/tests/Phinx/Config/ConfigReplaceTokensTest.php
@@ -6,6 +6,7 @@ use Phinx\Config\Config;
 
 /**
  * Class ConfigReplaceTokensTest
+ *
  * @package Test\Phinx\Config
  * @group config
  */

--- a/tests/Phinx/Config/ConfigSeedPathsTest.php
+++ b/tests/Phinx/Config/ConfigSeedPathsTest.php
@@ -7,6 +7,7 @@ use UnexpectedValueException;
 
 /**
  * Class ConfigSeedPathsTest
+ *
  * @package Test\Phinx\Config
  * @group config
  * @covers \Phinx\Config\Config::getSeedPaths

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -8,6 +8,7 @@ use UnexpectedValueException;
 
 /**
  * Class ConfigTest
+ *
  * @package Test\Phinx\Config
  * @group config
  */
@@ -363,12 +364,12 @@ class ConfigTest extends AbstractConfigTest
             'environments' => [
                 'production' => [
                     'adapter' => 'sqlite',
-                    'memory' => "yes",
+                    'memory' => 'yes',
                 ],
             ],
         ]);
         $this->assertSame(
-            ['adapter' => 'sqlite', 'memory' => "yes", 'name' => ':memory:'],
+            ['adapter' => 'sqlite', 'memory' => 'yes', 'name' => ':memory:'],
             $config->getEnvironment('production')
         );
     }

--- a/tests/Phinx/Config/ConfigYamlTest.php
+++ b/tests/Phinx/Config/ConfigYamlTest.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 /**
  * Class ConfigYamlTest
+ *
  * @package Test\Phinx\Config
  * @group config
  */

--- a/tests/Phinx/Config/VoidCommand.php
+++ b/tests/Phinx/Config/VoidCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Test\Phinx\Config;
+
+use Phinx\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Class VoidCommand : used to expose locateConfigFile To testing
+ *
+ * @package Test\Phinx\Config
+ */
+class VoidCommand extends AbstractCommand
+{
+    public function locateConfigFile(InputInterface $input)
+    {
+        return parent::locateConfigFile($input);
+    }
+}

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -4,15 +4,11 @@ namespace Test\Phinx\Console\Command;
 
 use InvalidArgumentException;
 use Phinx\Config\Config;
-use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Breakpoint;
 use Phinx\Console\PhinxApplication;
-use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -79,7 +75,6 @@ class BreakpointTest extends TestCase
      * @param array $commandLine
      * @param int|null $version
      * @param bool $noVersionParameter
-     *
      * @dataProvider provideBreakpointTests
      */
     public function testExecute($testMethod, $commandLine, $version = null, $noVersionParameter = false)
@@ -194,7 +189,6 @@ class BreakpointTest extends TestCase
 
     /**
      * @param array $commandLine
-     *
      * @dataProvider provideCombinedParametersToCauseException
      */
     public function testRemoveAllSetUnsetCombinedThrowsException($commandLine)
@@ -300,7 +294,7 @@ class BreakpointTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
-        $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
+        $this->assertStringEndsWith('The environment "fakeenv" does not exist', trim($commandTester->getDisplay()));
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 }

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -5,20 +5,17 @@ namespace Test\Phinx\Console\Command;
 use Exception;
 use InvalidArgumentException;
 use Phinx\Config\Config;
-use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\Create;
 use Phinx\Console\PhinxApplication;
-use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\Phinx\TestUtils;
 
 /**
  * Class CreateTest
+ *
  * @package Test\Phinx\Console\Command
  * @group create
  */
@@ -95,7 +92,7 @@ class CreateTest extends TestCase
         $files = array_diff(scandir($this->config->getMigrationPaths()[0]), ['.', '..']);
         $this->assertCount(1, $files);
         $fileName = current($files);
-        $this->assertRegExp("/^[0-9]{14}.php/", $fileName);
+        $this->assertRegExp('/^[0-9]{14}.php/', $fileName);
         $date = substr($fileName, 0, 14);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
         $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
@@ -124,7 +121,7 @@ class CreateTest extends TestCase
         $files = array_diff(scandir($this->config->getMigrationPaths()[0]), ['.', '..']);
         $this->assertCount(1, $files);
         $fileName = current($files);
-        $this->assertRegExp("/^[0-9]{14}_my_migration.php/", $fileName);
+        $this->assertRegExp('/^[0-9]{14}_my_migration.php/', $fileName);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
         $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class MyMigration extends AbstractMigration\n";
         $this->assertStringStartsWith($prefix, file_get_contents($this->config->getMigrationPaths()[0] . DIRECTORY_SEPARATOR . $fileName));

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -25,7 +25,7 @@ class InitTest extends TestCase
     {
         $application = new PhinxApplication();
         $application->add(new Init());
-        $command = $application->find("init");
+        $command = $application->find('init');
         $commandTester = new CommandTester($command);
         $fullPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $configName;
 
@@ -64,7 +64,6 @@ class InitTest extends TestCase
 
     /**
      * @dataProvider formatDataProvider
-     *
      * @param string $format format to use for file
      */
     public function testConfigIsWritten($format)
@@ -74,7 +73,6 @@ class InitTest extends TestCase
 
     /**
      * @dataProvider formatDataProvider
-     *
      * @param string $format format to use for file
      */
     public function testCustomNameConfigIsWritten($format)

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -23,7 +23,6 @@ class ListAliasesTest extends TestCase
     /**
      * @param string $file
      * @param bool $hasAliases
-     *
      * @dataProvider provideConfigurations
      */
     public function testListingAliases($file, $hasAliases)

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -3,15 +3,11 @@
 namespace Test\Phinx\Console\Command;
 
 use Phinx\Config\Config;
-use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Migrate;
 use Phinx\Console\PhinxApplication;
-use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -174,7 +170,7 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
-        $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
+        $this->assertStringEndsWith('The environment "fakeenv" does not exist', trim($commandTester->getDisplay()));
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
@@ -297,10 +293,10 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
         $this->assertStringContainsString(implode(PHP_EOL, [
-            "using environment development",
-            "using adapter sqlite",
-            "using database :memory:",
-            "ordering by creation time",
+            'using environment development',
+            'using adapter sqlite',
+            'using database :memory:',
+            'ordering by creation time',
         ]) . PHP_EOL, $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -4,15 +4,11 @@ namespace Test\Phinx\Console\Command;
 
 use InvalidArgumentException;
 use Phinx\Config\Config;
-use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Rollback;
 use Phinx\Console\PhinxApplication;
-use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -146,7 +142,7 @@ class RollbackTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
-        $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
+        $this->assertStringEndsWith('The environment "fakeenv" does not exist', trim($commandTester->getDisplay()));
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
@@ -377,10 +373,10 @@ class RollbackTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
         $this->assertStringContainsString(implode(PHP_EOL, [
-            "using environment development",
-            "using adapter sqlite",
-            "using database :memory:",
-            "ordering by creation time",
+            'using environment development',
+            'using adapter sqlite',
+            'using database :memory:',
+            'ordering by creation time',
         ]) . PHP_EOL, $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -4,14 +4,10 @@ namespace Test\Phinx\Console\Command;
 
 use InvalidArgumentException;
 use Phinx\Config\Config;
-use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\SeedCreate;
 use Phinx\Console\PhinxApplication;
-use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -3,15 +3,11 @@
 namespace Test\Phinx\Console\Command;
 
 use Phinx\Config\Config;
-use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\SeedRun;
 use Phinx\Console\PhinxApplication;
-use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -170,7 +166,7 @@ class SeedRunTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
-        $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
+        $this->assertStringEndsWith('The environment "fakeenv" does not exist', trim($commandTester->getDisplay()));
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
@@ -278,9 +274,9 @@ class SeedRunTest extends TestCase
         );
 
         $this->assertStringContainsString(implode(PHP_EOL, [
-            "using environment development",
-            "using adapter sqlite",
-            "using database :memory:",
+            'using environment development',
+            'using adapter sqlite',
+            'using database :memory:',
         ]) . PHP_EOL, $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -3,15 +3,11 @@
 namespace Test\Phinx\Console\Command;
 
 use Phinx\Config\Config;
-use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Status;
 use Phinx\Console\PhinxApplication;
-use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -189,7 +185,7 @@ class StatusTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
-        $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
+        $this->assertStringEndsWith('The environment "fakeenv" does not exist', trim($commandTester->getDisplay()));
         $this->assertEquals(AbstractCommand::CODE_ERROR, $exitCode);
     }
 

--- a/tests/Phinx/Console/Command/TemplateGenerators/DoesNotImplementRequiredInterface.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/DoesNotImplementRequiredInterface.php
@@ -3,5 +3,4 @@ namespace Test\Phinx\Console\Command\TemplateGenerators;
 
 class DoesNotImplementRequiredInterface
 {
-
 }

--- a/tests/Phinx/Console/PhinxApplicationTest.php
+++ b/tests/Phinx/Console/PhinxApplicationTest.php
@@ -2,7 +2,6 @@
 
 namespace Test\Phinx\Console;
 
-use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\PhinxApplication;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\ApplicationTester;
@@ -11,7 +10,6 @@ class PhinxApplicationTest extends TestCase
 {
     /**
      * @dataProvider provider
-     *
      * @param AbstractCommand $command
      * @param $result
      */

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -43,7 +43,7 @@ class AdapterFactoryTest extends TestCase
 
     public function testRegisterAdapterFailure()
     {
-        $adapter = get_class($this);
+        $adapter = static::class;
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Adapter class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must implement Phinx\Db\Adapter\AdapterInterface');
@@ -81,7 +81,7 @@ class AdapterFactoryTest extends TestCase
 
     public function testRegisterWrapperFailure()
     {
-        $wrapper = get_class($this);
+        $wrapper = static::class;
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Wrapper class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must be implement Phinx\Db\Adapter\WrapperInterface');

--- a/tests/Phinx/Db/Adapter/DataDomainTest.php
+++ b/tests/Phinx/Db/Adapter/DataDomainTest.php
@@ -11,8 +11,8 @@ class DataDomainTest extends TestCase
     public function testThrowsIfNoTypeSpecified()
     {
         $data_domain = [
-            "phone_number" => [
-                "length" => 19,
+            'phone_number' => [
+                'length' => 19,
             ],
         ];
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 
-use Cake\Collection\Collection;
 use PDOException;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\MysqlAdapter;
@@ -613,7 +612,7 @@ class MysqlAdapterTest extends TestCase
         $table->addColumn('default_zero', 'string', ['default' => 'test'])
               ->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
-        $this->assertEquals("test", $rows[1]['Default']);
+        $this->assertEquals('test', $rows[1]['Default']);
     }
 
     public function testAddColumnWithDefaultZero()
@@ -624,7 +623,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
         $this->assertNotNull($rows[1]['Default']);
-        $this->assertEquals("0", $rows[1]['Default']);
+        $this->assertEquals('0', $rows[1]['Default']);
     }
 
     public function testAddColumnWithDefaultEmptyString()
@@ -832,7 +831,7 @@ class MysqlAdapterTest extends TestCase
         $table->changeColumn('column1', $newColumn1)->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
         $this->assertNotNull($rows[1]['Default']);
-        $this->assertEquals("test1", $rows[1]['Default']);
+        $this->assertEquals('test1', $rows[1]['Default']);
     }
 
     public function testChangeColumnDefaultToZero()
@@ -846,7 +845,7 @@ class MysqlAdapterTest extends TestCase
         $table->changeColumn('column1', $newColumn1)->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
         $this->assertNotNull($rows[1]['Default']);
-        $this->assertEquals("0", $rows[1]['Default']);
+        $this->assertEquals('0', $rows[1]['Default']);
     }
 
     public function testChangeColumnDefaultToNull()
@@ -1146,14 +1145,13 @@ class MysqlAdapterTest extends TestCase
             ['column21', 'set', ['values' => ['one', 'two']]],
             ['column22', 'enum', ['values' => ['three', 'four']]],
             ['enum_quotes', 'enum', ['values' => [
-                "'", '\'\n', '\\', ',', '', "\\\n", "\\n", "\n", "\r", "\r\n", '/', ',,', "\t",
+                "'", '\'\n', '\\', ',', '', "\\\n", '\\n', "\n", "\r", "\r\n", '/', ',,', "\t",
             ]]],
             ['column23', 'bit', []],
         ];
     }
 
     /**
-     *
      * @dataProvider columnsProvider
      */
     public function testGetColumns($colName, $type, $options)
@@ -1951,7 +1949,6 @@ INPUT;
 
     /**
      * @dataProvider geometryTypeProvider
-     *
      * @param string $type
      * @param string $geom
      */
@@ -1976,7 +1973,6 @@ INPUT;
 
     /**
      * @dataProvider geometryTypeProvider
-     *
      * @param string $type
      * @param string $geom
      */

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -6,34 +6,6 @@ use PDOException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class PdoAdapterTestPDOMock extends \PDO
-{
-    public function __construct()
-    {
-    }
-}
-
-/**
- * A mock PDO that stores its last exec()'d SQL that can be retrieved for queries.
- *
- * This exists as $this->getMockForAbstractClass('\PDO') fails under PHP5.4 and
- * an older PHPUnit; a PDO instance cannot be serialised.
- */
-class PdoAdapterTestPDOMockWithExecChecks extends PdoAdapterTestPDOMock
-{
-    private $sql;
-
-    public function exec($sql)
-    {
-        $this->sql = $sql;
-    }
-
-    public function getExecutedSqlForTest()
-    {
-        return $this->sql;
-    }
-}
-
 class PdoAdapterTest extends TestCase
 {
     private $adapter;

--- a/tests/Phinx/Db/Adapter/PdoAdapterTestPDOMock.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTestPDOMock.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 

--- a/tests/Phinx/Db/Adapter/PdoAdapterTestPDOMock.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTestPDOMock.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Test\Phinx\Db\Adapter;
+
+class PdoAdapterTestPDOMock extends \PDO
+{
+    public function __construct()
+    {
+    }
+}

--- a/tests/Phinx/Db/Adapter/PdoAdapterTestPDOMockWithExecChecks.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTestPDOMockWithExecChecks.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 

--- a/tests/Phinx/Db/Adapter/PdoAdapterTestPDOMockWithExecChecks.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTestPDOMockWithExecChecks.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Test\Phinx\Db\Adapter;
+
+/**
+ * A mock PDO that stores its last exec()'d SQL that can be retrieved for queries.
+ *
+ * This exists as $this->getMockForAbstractClass('\PDO') fails under PHP5.4 and
+ * an older PHPUnit; a PDO instance cannot be serialised.
+ */
+class PdoAdapterTestPDOMockWithExecChecks extends PdoAdapterTestPDOMock
+{
+    private $sql;
+
+    public function exec($sql)
+    {
+        $this->sql = $sql;
+    }
+
+    public function getExecutedSqlForTest()
+    {
+        return $this->sql;
+    }
+}

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -5,7 +5,6 @@ namespace Test\Phinx\Db\Adapter;
 use Phinx\Db\Adapter\AbstractAdapter;
 use Phinx\Db\Adapter\PostgresAdapter;
 use Phinx\Db\Adapter\UnsupportedColumnTypeException;
-use Phinx\Db\Table\Column;
 use Phinx\Util\Literal;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -518,7 +517,7 @@ class PostgresAdapterTest extends TestCase
         $columns = $this->adapter->getColumns('table1');
         foreach ($columns as $column) {
             if ($column->getName() === 'default_zero') {
-                $this->assertEquals("test", $column->getDefault());
+                $this->assertEquals('test', $column->getDefault());
             }
         }
     }
@@ -651,7 +650,7 @@ class PostgresAdapterTest extends TestCase
 
         $this->assertTrue($this->adapter->hasColumn('citable', 'insensitive'));
 
-        /** @var $columns Column[] */
+        /** @var Column[] $columns */
         $columns = $this->adapter->getColumns('citable');
         foreach ($columns as $column) {
             if ($column->getName() === 'insensitive') {
@@ -705,13 +704,13 @@ class PostgresAdapterTest extends TestCase
         $columns = $this->adapter->getColumns('table1');
         foreach ($columns as $column) {
             if ($column->getName() === 'number') {
-                $this->assertEquals("10", $column->getPrecision());
-                $this->assertEquals("2", $column->getScale());
+                $this->assertEquals('10', $column->getPrecision());
+                $this->assertEquals('2', $column->getScale());
             }
 
             if ($column->getName() === 'number2') {
-                $this->assertEquals("12", $column->getPrecision());
-                $this->assertEquals("0", $column->getScale());
+                $this->assertEquals('12', $column->getPrecision());
+                $this->assertEquals('0', $column->getScale());
             }
         }
     }
@@ -727,15 +726,15 @@ class PostgresAdapterTest extends TestCase
         $columns = $this->adapter->getColumns('table1');
         foreach ($columns as $column) {
             if ($column->getName() === 'timestamp1') {
-                $this->assertEquals("0", $column->getPrecision());
+                $this->assertEquals('0', $column->getPrecision());
             }
 
             if ($column->getName() === 'timestamp2') {
-                $this->assertEquals("4", $column->getPrecision());
+                $this->assertEquals('4', $column->getPrecision());
             }
 
             if ($column->getName() === 'timestamp3') {
-                $this->assertEquals("6", $column->getPrecision());
+                $this->assertEquals('6', $column->getPrecision());
             }
         }
     }
@@ -1349,7 +1348,7 @@ class PostgresAdapterTest extends TestCase
 
         $rows = $this->adapter->fetchAll(
             sprintf(
-                "SELECT description FROM pg_description JOIN pg_class ON pg_description.objoid = " .
+                'SELECT description FROM pg_description JOIN pg_class ON pg_description.objoid = ' .
                 "pg_class.oid WHERE relname = '%s'",
                 'ntable'
             )
@@ -2053,7 +2052,6 @@ OUTPUT;
 
     /**
      * Tests interaction with the query builder
-     *
      */
     public function testQueryBuilder()
     {

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -66,7 +66,7 @@ class SQLiteAdapterTest extends TestCase
 
         $this->assertTrue(
             $this->adapter->getConnection()->inTransaction(),
-            "Underlying PDO instance did not detect new transaction"
+            'Underlying PDO instance did not detect new transaction'
         );
     }
 
@@ -79,7 +79,7 @@ class SQLiteAdapterTest extends TestCase
 
         $this->assertFalse(
             $this->adapter->getConnection()->inTransaction(),
-            "Underlying PDO instance did not detect rolled back transaction"
+            'Underlying PDO instance did not detect rolled back transaction'
         );
     }
 
@@ -448,7 +448,7 @@ class SQLiteAdapterTest extends TestCase
             ->save();
         $rows = $this->adapter->fetchAll(sprintf('pragma table_info(%s)', 'table1'));
         $this->assertNotNull($rows[1]['dflt_value']);
-        $this->assertEquals("0", $rows[1]['dflt_value']);
+        $this->assertEquals('0', $rows[1]['dflt_value']);
     }
 
     public function testAddColumnWithDefaultEmptyString()
@@ -556,7 +556,7 @@ class SQLiteAdapterTest extends TestCase
             ->setType('integer');
         $table->changeColumn('column1', $newColumn1)->save();
         $rows = $this->adapter->fetchAll('pragma table_info(t)');
-        $this->assertEquals("0", $rows[1]['dflt_value']);
+        $this->assertEquals('0', $rows[1]['dflt_value']);
     }
 
     public function testChangeColumnDefaultToNull()
@@ -947,14 +947,14 @@ class SQLiteAdapterTest extends TestCase
 
         // construct table with default/null combinations
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
-        $table->addColumn("aa", "string", ["null" => true]) // no default value
-        ->addColumn("bb", "string", ["null" => false]) // no default value
-        ->addColumn("cc", "string", ["null" => true, "default" => "some1"])
-            ->addColumn("dd", "string", ["null" => false, "default" => "some2"])
+        $table->addColumn('aa', 'string', ['null' => true]) // no default value
+        ->addColumn('bb', 'string', ['null' => false]) // no default value
+        ->addColumn('cc', 'string', ['null' => true, 'default' => 'some1'])
+            ->addColumn('dd', 'string', ['null' => false, 'default' => 'some2'])
             ->save();
 
         // load table info
-        $columns = $this->adapter->getColumns("table1");
+        $columns = $this->adapter->getColumns('table1');
 
         $this->assertCount(5, $columns);
 
@@ -963,21 +963,21 @@ class SQLiteAdapterTest extends TestCase
         $cc = $columns[3];
         $dd = $columns[4];
 
-        $this->assertEquals("aa", $aa->getName());
+        $this->assertEquals('aa', $aa->getName());
         $this->assertTrue($aa->isNull());
         $this->assertNull($aa->getDefault());
 
-        $this->assertEquals("bb", $bb->getName());
+        $this->assertEquals('bb', $bb->getName());
         $this->assertFalse($bb->isNull());
         $this->assertNull($bb->getDefault());
 
-        $this->assertEquals("cc", $cc->getName());
+        $this->assertEquals('cc', $cc->getName());
         $this->assertTrue($cc->isNull());
-        $this->assertEquals("some1", $cc->getDefault());
+        $this->assertEquals('some1', $cc->getDefault());
 
-        $this->assertEquals("dd", $dd->getName());
+        $this->assertEquals('dd', $dd->getName());
         $this->assertFalse($dd->isNull());
-        $this->assertEquals("some2", $dd->getDefault());
+        $this->assertEquals('some2', $dd->getDefault());
     }
 
     public function testDumpCreateTable()
@@ -1120,7 +1120,6 @@ OUTPUT;
 
     /**
      * Tests interaction with the query builder
-     *
      */
     public function testQueryBuilder()
     {
@@ -1845,13 +1844,13 @@ INPUT;
     public function provideDatabaseVersionStrings()
     {
         return [
-            ["2", true],
-            ["3", true],
-            ["4", false],
-            ["3.0", true],
-            ["3.0.0.0.0.0", true],
-            ["3.0.0.0.0.99999", true],
-            ["3.9999", false],
+            ['2', true],
+            ['3', true],
+            ['4', false],
+            ['3.0', true],
+            ['3.0.0.0.0.0', true],
+            ['3.0.0.0.0.99999', true],
+            ['3.9999', false],
         ];
     }
 
@@ -1972,19 +1971,19 @@ INPUT;
             'Explicit null UC' => ['create table t(a integer default NULL)', null],
             'Explicit null MC' => ['create table t(a integer default nuLL)', null],
             'Extra parentheses' => ['create table t(a integer default ( ( null ) ))', null],
-            'Comment 1' => ["create table t(a integer default ( /* this is perfectly fine */ null ))", null],
+            'Comment 1' => ['create table t(a integer default ( /* this is perfectly fine */ null ))', null],
             'Comment 2' => ["create table t(a integer default ( /* this\nis\nperfectly\nfine */ null ))", null],
             'Line comment 1' => ["create table t(a integer default ( -- this is perfectly fine, too\n null ))", null],
             'Line comment 2' => ["create table t(a integer default ( -- this is perfectly fine, too\r\n null ))", null],
-            'Current date LC' => ['create table t(a date default current_date)', "CURRENT_DATE"],
-            'Current date UC' => ['create table t(a date default CURRENT_DATE)', "CURRENT_DATE"],
-            'Current date MC' => ['create table t(a date default CURRENT_date)', "CURRENT_DATE"],
-            'Current time LC' => ['create table t(a time default current_time)', "CURRENT_TIME"],
-            'Current time UC' => ['create table t(a time default CURRENT_TIME)', "CURRENT_TIME"],
-            'Current time MC' => ['create table t(a time default CURRENT_time)', "CURRENT_TIME"],
-            'Current timestamp LC' => ['create table t(a datetime default current_timestamp)', "CURRENT_TIMESTAMP"],
-            'Current timestamp UC' => ['create table t(a datetime default CURRENT_TIMESTAMP)', "CURRENT_TIMESTAMP"],
-            'Current timestamp MC' => ['create table t(a datetime default CURRENT_timestamp)', "CURRENT_TIMESTAMP"],
+            'Current date LC' => ['create table t(a date default current_date)', 'CURRENT_DATE'],
+            'Current date UC' => ['create table t(a date default CURRENT_DATE)', 'CURRENT_DATE'],
+            'Current date MC' => ['create table t(a date default CURRENT_date)', 'CURRENT_DATE'],
+            'Current time LC' => ['create table t(a time default current_time)', 'CURRENT_TIME'],
+            'Current time UC' => ['create table t(a time default CURRENT_TIME)', 'CURRENT_TIME'],
+            'Current time MC' => ['create table t(a time default CURRENT_time)', 'CURRENT_TIME'],
+            'Current timestamp LC' => ['create table t(a datetime default current_timestamp)', 'CURRENT_TIMESTAMP'],
+            'Current timestamp UC' => ['create table t(a datetime default CURRENT_TIMESTAMP)', 'CURRENT_TIMESTAMP'],
+            'Current timestamp MC' => ['create table t(a datetime default CURRENT_timestamp)', 'CURRENT_TIMESTAMP'],
             'String 1' => ['create table t(a text default \'\')', Literal::from('')],
             'String 2' => ['create table t(a text default \'value!\')', Literal::from('value!')],
             'String 3' => ['create table t(a text default \'O\'\'Brien\')', Literal::from('O\'Brien')],

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -384,7 +384,7 @@ WHERE t.name='ntable'");
         $columns = $this->adapter->getColumns('table1');
         foreach ($columns as $column) {
             if ($column->getName() === 'default_zero') {
-                $this->assertEquals("test", $column->getDefault());
+                $this->assertEquals('test', $column->getDefault());
             }
         }
     }
@@ -998,7 +998,6 @@ OUTPUT;
 
     /**
      * Tests interaction with the query builder
-     *
      */
     public function testQueryBuilder()
     {

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -9,7 +9,6 @@ use RuntimeException;
 
 class ForeignKeyTest extends TestCase
 {
-
     /**
      * @var ForeignKey
      */

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -102,13 +102,12 @@ class TableTest extends TestCase
 
     /**
      * @dataProvider provideTimestampColumnNames
-     *
      * @param AdapterInterface $adapter
      * @param string|null      $createdAtColumnName
      * @param string|null      $updatedAtColumnName
      * @param string           $expectedCreatedAtColumnName
      * @param string           $expectedUpdatedAtColumnName
-     * @param boolean          $withTimezone
+     * @param bool $withTimezone
      */
     public function testAddTimestamps(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
     {
@@ -138,13 +137,12 @@ class TableTest extends TestCase
 
     /**
      * @dataProvider provideTimestampColumnNames
-     *
      * @param AdapterInterface $adapter
      * @param string|null      $createdAtColumnName
      * @param string|null      $updatedAtColumnName
      * @param string           $expectedCreatedAtColumnName
      * @param string           $expectedUpdatedAtColumnName
-     * @param boolean          $withTimezone
+     * @param bool $withTimezone
      */
     public function testAddTimestampsWithTimezone(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
     {
@@ -294,8 +292,8 @@ class TableTest extends TestCase
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
-        $columns = ["column1"];
-        $data = [["value1"]];
+        $columns = ['column1'];
+        $data = [['value1']];
         $table->insert($columns, $data)->save();
         $this->assertEquals([], $table->getData());
     }
@@ -306,8 +304,8 @@ class TableTest extends TestCase
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
-        $columns = ["column1"];
-        $data = [["value1"]];
+        $columns = ['column1'];
+        $data = [['value1']];
         $table->insert($columns, $data);
         $this->assertTrue($table->hasPendingActions());
     }
@@ -321,7 +319,7 @@ class TableTest extends TestCase
             ->method('isValidColumnType')
             ->willReturn(true);
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
-        $table->addColumn("column1", "integer", ['null' => true]);
+        $table->addColumn('column1', 'integer', ['null' => true]);
         $this->assertTrue($table->hasPendingActions());
     }
 
@@ -347,7 +345,6 @@ class TableTest extends TestCase
 
     /**
      * @dataProvider removeIndexDataprovider
-     *
      * @param string $indexIdentifier
      * @param Index $index
      */

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -285,7 +285,7 @@ class AbstractMigrationTest extends TestCase
         $migrationStub->setAdapter($adapterStub);
 
         $table = $migrationStub->table('test_table');
-        $table->addColumn("column1", "integer", ['null' => true]);
+        $table->addColumn('column1', 'integer', ['null' => true]);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Migration has pending actions after execution!');
@@ -308,7 +308,7 @@ class AbstractMigrationTest extends TestCase
         $migrationStub->setAdapter($adapterStub);
 
         $table = $migrationStub->table('test_table');
-        $table->addColumn("column1", "integer", ['null' => true])->create();
+        $table->addColumn('column1', 'integer', ['null' => true])->create();
 
         $migrationStub->postFlightCheck();
 

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -8,41 +8,6 @@ use Phinx\Migration\MigrationInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class PDOMock extends \PDO
-{
-    /**
-     * @var array
-     */
-    protected $attributes = [];
-
-    public function __construct()
-    {
-    }
-
-    /**
-     * @param int $attribute Attribute
-     *
-     * @return string
-     */
-    public function getAttribute($attribute)
-    {
-        return isset($this->attributes[$attribute]) ? $this->attributes[$attribute] : 'pdomock';
-    }
-
-    /**
-     * @param int $attribute Attribute
-     * @param mixed $value Value
-     *
-     * @return bool
-     */
-    public function setAttribute($attribute, $value)
-    {
-        $this->attributes[$attribute] = $value;
-
-        return true;
-    }
-}
-
 class EnvironmentTest extends TestCase
 {
     /**

--- a/tests/Phinx/Migration/Manager/PDOMock.php
+++ b/tests/Phinx/Migration/Manager/PDOMock.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Test\Phinx\Migration\Manager;
+
+class PDOMock extends \PDO
+{
+    /**
+     * @var array
+     */
+    protected $attributes = [];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @param int $attribute Attribute
+     * @return string
+     */
+    public function getAttribute($attribute)
+    {
+        return $this->attributes[$attribute] ?? 'pdomock';
+    }
+
+    /**
+     * @param int $attribute Attribute
+     * @param mixed $value Value
+     * @return bool
+     */
+    public function setAttribute($attribute, $value)
+    {
+        $this->attributes[$attribute] = $value;
+
+        return true;
+    }
+}

--- a/tests/Phinx/Migration/Manager/PDOMock.php
+++ b/tests/Phinx/Migration/Manager/PDOMock.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Migration\Manager;
 

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -9,13 +9,13 @@ use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
 class ManagerTest extends TestCase
 {
-    /** @var Config */
+    /**
+     * @var Config
+     */
     protected $config;
 
     /**
@@ -127,9 +127,6 @@ class ManagerTest extends TestCase
         );
     }
 
-    /**
-     *
-     */
     public function testEnvironmentInheritsDataDomainOptions()
     {
         foreach ($this->config->getEnvironments() as $name => $opts) {
@@ -1042,7 +1039,6 @@ class ManagerTest extends TestCase
      * Test that ensures the status header is correctly printed with regards to the version order
      *
      * @dataProvider statusVersionOrderProvider
-     *
      * @param Config $config Config to use for the test
      * @param string $expectedStatusHeader expected header string
      */
@@ -1234,7 +1230,6 @@ class ManagerTest extends TestCase
      * migration to point to.
      *
      * @dataProvider migrateDateDataProvider
-     *
      * @param string[] $availableMigrations
      * @param string $dateString
      * @param string $expectedMigration
@@ -1286,7 +1281,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1320,7 +1315,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1354,7 +1349,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1387,7 +1382,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1421,7 +1416,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1455,7 +1450,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1536,7 +1531,7 @@ class ManagerTest extends TestCase
 
         $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironments(['mockenv' => $envStub]);
-        $this->manager->rollback('mockenv', isset($availableRollbacks[$version]['migration_name']) ? $availableRollbacks[$version]['migration_name'] : $version);
+        $this->manager->rollback('mockenv', $availableRollbacks[$version]['migration_name'] ?? $version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
@@ -1626,7 +1621,7 @@ class ManagerTest extends TestCase
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1668,7 +1663,7 @@ class ManagerTest extends TestCase
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1838,7 +1833,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1877,7 +1872,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -1916,7 +1911,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback" . PHP_EOL, $output);
+            $this->assertEquals('No migrations to rollback' . PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -6065,18 +6060,6 @@ class ManagerTest extends TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertEquals("warning 20120133235330 is not a valid version", trim($outputStr));
-    }
-}
-
-/**
- * RawBufferedOutput is a specialized BufferedOutput that outputs raw "writeln" calls (ie. it doesn't replace the
- * tags like <info>message</info>.
- */
-class RawBufferedOutput extends \Symfony\Component\Console\Output\BufferedOutput
-{
-    public function writeln($messages, $options = self::OUTPUT_RAW)
-    {
-        $this->write($messages, true, $options);
+        $this->assertEquals('warning 20120133235330 is not a valid version', trim($outputStr));
     }
 }

--- a/tests/Phinx/Migration/RawBufferedOutput.php
+++ b/tests/Phinx/Migration/RawBufferedOutput.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Migration;
 

--- a/tests/Phinx/Migration/RawBufferedOutput.php
+++ b/tests/Phinx/Migration/RawBufferedOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Test\Phinx\Migration;
+
+/**
+ * RawBufferedOutput is a specialized BufferedOutput that outputs raw "writeln" calls (ie. it doesn't replace the
+ * tags like <info>message</info>.
+ */
+class RawBufferedOutput extends \Symfony\Component\Console\Output\BufferedOutput
+{
+    public function writeln($messages, $options = self::OUTPUT_RAW)
+    {
+        $this->write($messages, true, $options);
+    }
+}

--- a/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205056_first_fk_index_migration.php
+++ b/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205056_first_fk_index_migration.php
@@ -94,7 +94,7 @@ class FirstFkIndexMigration extends AbstractMigration
             'row_format' => 'DYNAMIC',
         ])
         ->removeColumn('table2_id')
-        ->removeIndexByName("table1_table2_id")
+        ->removeIndexByName('table1_table2_id')
         ->dropForeignKey('table2_id', 'table1_table2_id')
         ->update();
     }

--- a/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205060_second_fk_index_migration.php
+++ b/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205060_second_fk_index_migration.php
@@ -16,7 +16,7 @@ class SecondFkIndexMigration extends AbstractMigration
             'row_format' => 'DYNAMIC',
         ])
         ->removeColumn('table3_id')
-        ->removeIndexByName("table1_table3_id")
+        ->removeIndexByName('table1_table3_id')
         ->dropForeignKey('table3_id', 'table1_table3_id')
         ->update();
     }

--- a/tests/Phinx/Migration/_files/postgres/20180516025208_test_not_empty_snapshot_pgsql.php
+++ b/tests/Phinx/Migration/_files/postgres/20180516025208_test_not_empty_snapshot_pgsql.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Phinx\Migration\AbstractMigration;
 

--- a/tests/Phinx/Migration/_files/postgres/20180516025208_test_not_empty_snapshot_pgsql.php
+++ b/tests/Phinx/Migration/_files/postgres/20180516025208_test_not_empty_snapshot_pgsql.php
@@ -1,4 +1,5 @@
 <?php
+
 use Phinx\Migration\AbstractMigration;
 
 class TestNotEmptySnapshotPgsql extends AbstractMigration


### PR DESCRIPTION
This disables the strict types declaration in case it affects end-users somehow.

We'll see if stickler can handle this.