### PR TITLE
make default PKs for mysql unsigned by default

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -479,11 +479,11 @@ comment    set a text comment on the table
 row_format set the table row format
 engine     define table engine *(defaults to ``InnoDB``)*
 collation  define table collation *(defaults to ``utf8mb4_unicode_ci``)*
-signed     whether the primary key is ``signed``  *(defaults to ``true``)*
+signed     whether the primary key is ``signed``  *(defaults to ``false``)*
 ========== ===========
 
-By default the primary key is ``signed``.
-To simply set it to unsigned just pass ``signed`` option with a ``false`` value:
+By default, the primary key is ``unsigned``.
+To simply set it to be signed just pass ``signed`` option with a ``true`` value:
 
 .. code-block:: php
 

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -263,7 +263,7 @@ class MysqlAdapter extends PdoAdapter
             $column->setName($options['id'])
                    ->setType('integer')
                    ->setOptions([
-                       'signed' => $options['signed'] ?? true,
+                       'signed' => $options['signed'] ?? false,
                        'identity' => true,
                    ]);
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -187,7 +187,7 @@ class MysqlAdapterTest extends TestCase
 
         $table = new \Phinx\Db\Table('ntable', [], $this->adapter);
         $table->addColumn('realname', 'string')
-              ->addColumn('tag_id', 'integer')
+              ->addColumn('tag_id', 'integer', ['signed' => false])
               ->addForeignKey('tag_id', 'ntable_tag', 'id', ['delete' => 'NO_ACTION', 'update' => 'NO_ACTION'])
               ->save();
 
@@ -1412,21 +1412,21 @@ class MysqlAdapterTest extends TestCase
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
-    public function testAddForeignKeyForTableWithUnsignedPK()
+    public function testAddForeignKeyForTableWithSignedPK()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', ['signed' => false], $this->adapter);
+        $refTable = new \Phinx\Db\Table('ref_table', ['signed' => true], $this->adapter);
         $refTable->addColumn('field1', 'string')->save();
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addColumn('ref_table_id', 'integer')
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
@@ -1440,7 +1440,7 @@ class MysqlAdapterTest extends TestCase
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
@@ -1448,14 +1448,14 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
-    public function testDropForeignKeyForTableWithUnsignedPK()
+    public function testDropForeignKeyForTableWithSignedPK()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', ['signed' => false], $this->adapter);
+        $refTable = new \Phinx\Db\Table('ref_table', ['signed' => true], $this->adapter);
         $refTable->addColumn('field1', 'string')->save();
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addColumn('ref_table_id', 'integer')
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
@@ -1470,7 +1470,7 @@ class MysqlAdapterTest extends TestCase
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
@@ -1485,7 +1485,7 @@ class MysqlAdapterTest extends TestCase
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
@@ -1500,7 +1500,7 @@ class MysqlAdapterTest extends TestCase
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
@@ -1508,14 +1508,14 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id'], 'my_constraint2'));
     }
 
-    public function testHasForeignKeyWithConstraintForTableWithUnsignedPK()
+    public function testHasForeignKeyWithConstraintForTableWithSignedPK()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', ['signed' => false], $this->adapter);
+        $refTable = new \Phinx\Db\Table('ref_table', ['signed' => true], $this->adapter);
         $refTable->addColumn('field1', 'string')->save();
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addColumn('ref_table_id', 'integer')
             ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
@@ -1530,7 +1530,7 @@ class MysqlAdapterTest extends TestCase
 
         $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
-            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
@@ -1733,7 +1733,7 @@ class MysqlAdapterTest extends TestCase
             ->save();
 
         $expectedOutput = <<<'OUTPUT'
-CREATE TABLE `table1` (`id` INT(11) NOT NULL AUTO_INCREMENT, `column1` VARCHAR(255) NOT NULL, `column2` INT(11) NULL, `column3` VARCHAR(255) NOT NULL DEFAULT 'test', PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE TABLE `table1` (`id` INT(11) unsigned NOT NULL AUTO_INCREMENT, `column1` VARCHAR(255) NOT NULL, `column2` INT(11) NULL, `column3` VARCHAR(255) NOT NULL DEFAULT 'test', PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 OUTPUT;
         $actualOutput = $consoleOutput->fetch();
         $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');

--- a/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205056_first_fk_index_migration.php
+++ b/tests/Phinx/Migration/_files/drop_column_fk_index_regression/20190928205056_first_fk_index_migration.php
@@ -18,7 +18,7 @@ class FirstFkIndexMigration extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'null' => false,
                 'limit' => 20,
-                'identity' => 'enable',
+                'identity' => true,
             ])
             ->create();
 
@@ -34,7 +34,7 @@ class FirstFkIndexMigration extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'null' => false,
                 'limit' => 20,
-                'identity' => 'enable',
+                'identity' => true,
             ])
             ->create();
 
@@ -50,7 +50,7 @@ class FirstFkIndexMigration extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'null' => false,
                 'limit' => 20,
-                'identity' => 'enable',
+                'identity' => true,
             ])
             ->addColumn('table2_id', 'integer', [
                 'null' => true,

--- a/tests/Phinx/Migration/_files/drop_index_regression/20121213232502_create_drop_fk_initial_schema.php
+++ b/tests/Phinx/Migration/_files/drop_index_regression/20121213232502_create_drop_fk_initial_schema.php
@@ -11,7 +11,7 @@ class CreateDropFkInitialSchema extends AbstractMigration
     {
         $this->table('my_table')
             ->addColumn('name', 'string')
-            ->addColumn('entity_id', 'integer')
+            ->addColumn('entity_id', 'integer', ['signed' => false])
             ->create();
 
         $this->table('my_other_table')

--- a/tests/Phinx/Migration/_files/drop_table_with_fk_regression/20190928205060_second_drop_fk_migration.php
+++ b/tests/Phinx/Migration/_files/drop_table_with_fk_regression/20190928205060_second_drop_fk_migration.php
@@ -11,7 +11,7 @@ class SecondDropFkMigration extends AbstractMigration
             ->create();
 
         $this->table('orders')
-            ->addColumn('customer_id', 'integer')
+            ->addColumn('customer_id', 'integer', ['signed' => false])
             ->addForeignKey('customer_id', 'customers', 'id')
             ->update();
     }

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20121224200852_create_user_logins_table.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20121224200852_create_user_logins_table.php
@@ -12,12 +12,12 @@ class CreateUserLoginsTable extends AbstractMigration
     {
         // user logins table
         $table = $this->table('user_logins');
-        $table->addColumn('user_id', Column::INTEGER)
+        $table->addColumn('user_id', Column::INTEGER, ['signed' => false])
               ->addColumn('created', Column::DATETIME)
               ->create();
 
         // add a foreign key back to the users table
-        $table->addForeignKey('user_id', 'users', ['id'])
+        $table->addForeignKey('user_id', 'users')
               ->update();
     }
 

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20190928220334_add_column_index_fk.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20190928220334_add_column_index_fk.php
@@ -37,6 +37,7 @@ class AddColumnIndexFk extends AbstractMigration
             ->addColumn('user_id', Column::INTEGER, [
                 'null' => true,
                 'limit' => 20,
+                'signed' => false,
             ])
             ->addIndex(['user_id'], [
                     'name' => 'statuses_users_id',

--- a/tests/Phinx/Migration/_files_baz/reversiblemigrations/20151224200852_create_user_logins_table.php
+++ b/tests/Phinx/Migration/_files_baz/reversiblemigrations/20151224200852_create_user_logins_table.php
@@ -14,7 +14,7 @@ class CreateUserLoginsTable extends AbstractMigration
     {
         // user logins table
         $table = $this->table('user_logins_baz');
-        $table->addColumn('user_id', Column::INTEGER)
+        $table->addColumn('user_id', Column::INTEGER, ['signed' => false])
               ->addColumn('created', Column::DATETIME)
               ->create();
 

--- a/tests/Phinx/Migration/_files_foo_bar/reversiblemigrations/20161224200852_create_user_logins_table.php
+++ b/tests/Phinx/Migration/_files_foo_bar/reversiblemigrations/20161224200852_create_user_logins_table.php
@@ -13,7 +13,7 @@ class CreateUserLoginsTable extends AbstractMigration
     {
         // user logins table
         $table = $this->table('user_logins_foo_bar');
-        $table->addColumn('user_id', 'integer')
+        $table->addColumn('user_id', 'integer', ['signed' => false])
               ->addColumn('created', 'datetime')
               ->create();
 


### PR DESCRIPTION
closes #1780

This changes it so that the default PK for a table (either by not specifying one at all, or just setting the `id` option for the table) is unsigned by default, instead of signed. This gives users extra space to store IDs in their databases, and is generally considered the "right" definition to have for an auto incrementing column for mysql, with some amount of other ORM / DB stuff out there doing this as well.

The principle downside is that foreign key columns will have to be specified with `"signed" => false` now, but I think is balanced out by the upsides of doing this.