### PR TITLE
replace assertRegExp with assertStringContains where possible

### DIFF
--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -299,7 +299,7 @@ class BreakpointTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment fakeenv', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -79,8 +79,8 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $output = $commandTester->getDisplay();
-        $this->assertRegExp('/no environment specified/', $output);
-        $this->assertRegExp('/ordering by creation time/', $output);
+        $this->assertStringContainsString('no environment specified', $output);
+        $this->assertStringContainsString('ordering by creation time', $output);
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -120,8 +120,8 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $output = $commandTester->getDisplay();
-        $this->assertRegExp('/no environment specified/', $output);
-        $this->assertRegExp('/ordering by creation time/', $output);
+        $this->assertStringContainsString('no environment specified', $output);
+        $this->assertStringContainsString('ordering by creation time', $output);
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -147,7 +147,7 @@ class MigrateTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment development', $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -173,7 +173,7 @@ class MigrateTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment fakeenv', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
@@ -200,7 +200,7 @@ class MigrateTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
-        $this->assertRegExp('/using database development/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using database development', $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -226,7 +226,7 @@ class MigrateTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--fake' => true], ['decorated' => false]);
 
-        $this->assertRegExp('/warning performing fake migrations/', $commandTester->getDisplay());
+        $this->assertStringContainsString('warning performing fake migrations', $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -255,8 +255,8 @@ class MigrateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $output = $commandTester->getDisplay();
-        $this->assertRegExp('/no environment specified/', $output);
-        $this->assertRegExp('/ordering by execution time/', $output);
+        $this->assertStringContainsString('no environment specified', $output);
+        $this->assertStringContainsString('ordering by execution time', $output);
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -90,10 +90,10 @@ class RollbackTest extends TestCase
 
         $display = $commandTester->getDisplay();
 
-        $this->assertRegExp('/no environment specified/', $display);
+        $this->assertStringContainsString('no environment specified', $display);
 
         // note that the default order is by creation time
-        $this->assertRegExp('/ordering by creation time/', $display);
+        $this->assertStringContainsString('ordering by creation time', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -119,7 +119,7 @@ class RollbackTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment development', $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -145,7 +145,7 @@ class RollbackTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment fakeenv', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
@@ -172,7 +172,7 @@ class RollbackTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
-        $this->assertRegExp('/using database development/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using database development', $commandTester->getDisplay());
     }
 
     public function testStartTimeVersionOrder()
@@ -199,7 +199,7 @@ class RollbackTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
-        $this->assertRegExp('/ordering by execution time/', $commandTester->getDisplay());
+        $this->assertStringContainsString('ordering by execution time', $commandTester->getDisplay());
     }
 
     public function testWithDate()
@@ -308,7 +308,7 @@ class RollbackTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName(), '-d' => $targetDate], ['decorated' => false]);
-        $this->assertRegExp('/ordering by execution time/', $commandTester->getDisplay());
+        $this->assertStringContainsString('ordering by execution time', $commandTester->getDisplay());
     }
 
     public function testFakeRollback()
@@ -336,7 +336,7 @@ class RollbackTest extends TestCase
 
         $display = $commandTester->getDisplay();
 
-        $this->assertRegExp('/warning performing fake rollback/', $display);
+        $this->assertStringContainsString('warning performing fake rollback', $display);
     }
 
     public function testRollbackMemorySqlite()

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -79,7 +79,7 @@ class SeedRunTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
-        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+        $this->assertStringContainsString('no environment specified', $commandTester->getDisplay());
     }
 
     public function testExecuteWithDsn()
@@ -118,7 +118,7 @@ class SeedRunTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
-        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+        $this->assertStringContainsString('no environment specified', $commandTester->getDisplay());
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -143,7 +143,7 @@ class SeedRunTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
-        $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment development', $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -169,7 +169,7 @@ class SeedRunTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment fakeenv', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
@@ -195,7 +195,7 @@ class SeedRunTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
-        $this->assertRegExp('/using database development/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using database development', $commandTester->getDisplay());
     }
 
     public function testExecuteMultipleSeeders()
@@ -230,7 +230,7 @@ class SeedRunTest extends TestCase
             ['decorated' => false]
         );
 
-        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+        $this->assertStringContainsString('no environment specified', $commandTester->getDisplay());
     }
 
     public function testSeedRunMemorySqlite()

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -91,10 +91,10 @@ class StatusTest extends TestCase
         $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $display = $commandTester->getDisplay();
-        $this->assertRegExp('/no environment specified/', $display);
+        $this->assertStringContainsString('no environment specified', $display);
 
         // note that the default order is by creation time
-        $this->assertRegExp('/ordering by creation time/', $display);
+        $this->assertStringContainsString('ordering by creation time', $display);
     }
 
     public function testExecuteWithDsn()
@@ -134,7 +134,7 @@ class StatusTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment development', $commandTester->getDisplay());
         $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -162,7 +162,7 @@ class StatusTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'development'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment development/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment development', $commandTester->getDisplay());
         $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
@@ -188,7 +188,7 @@ class StatusTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--environment' => 'fakeenv'], ['decorated' => false]);
 
-        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using environment fakeenv', $commandTester->getDisplay());
         $this->assertStringEndsWith("The environment \"fakeenv\" does not exist", trim($commandTester->getDisplay()));
         $this->assertEquals(AbstractCommand::CODE_ERROR, $exitCode);
     }
@@ -217,7 +217,7 @@ class StatusTest extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--format' => AbstractCommand::FORMAT_JSON], ['decorated' => false]);
         $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
-        $this->assertRegExp('/using format json/', $commandTester->getDisplay());
+        $this->assertStringContainsString('using format json', $commandTester->getDisplay());
     }
 
     public function testExecuteVersionOrderByExecutionTime()
@@ -249,8 +249,8 @@ class StatusTest extends TestCase
         $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $display = $commandTester->getDisplay();
-        $this->assertRegExp('/no environment specified/', $display);
-        $this->assertRegExp('/ordering by execution time/', $display);
+        $this->assertStringContainsString('no environment specified', $display);
+        $this->assertStringContainsString('ordering by execution time', $display);
     }
 
     public function testExitCodeMissingMigrations()

--- a/tests/Phinx/Console/PhinxApplicationTest.php
+++ b/tests/Phinx/Console/PhinxApplicationTest.php
@@ -26,13 +26,13 @@ class PhinxApplicationTest extends TestCase
         $stream = $appTester->getOutput()->getStream();
         rewind($stream);
 
-        $this->assertRegExp($result, stream_get_contents($stream));
+        $this->assertStringContainsString($result, stream_get_contents($stream));
     }
 
     public function provider()
     {
         return [
-            ['help', '/help \[options\] \[--\] \[<command_name>\]/'],
+            ['help', 'help [options] [--] [<command_name>]'],
         ];
     }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -85,7 +85,7 @@ class MysqlAdapterTest extends TestCase
                 $e,
                 'Expected exception of type InvalidArgumentException, got ' . get_class($e)
             );
-            $this->assertRegExp('/There was a problem connecting to the database/', $e->getMessage());
+            $this->assertStringContainsString('There was a problem connecting to the database', $e->getMessage());
         }
     }
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -106,7 +106,7 @@ class PostgresAdapterTest extends TestCase
                 $e,
                 'Expected exception of type InvalidArgumentException, got ' . get_class($e)
             );
-            $this->assertRegExp('/There was a problem connecting to the database/', $e->getMessage());
+            $this->assertStringContainsString('There was a problem connecting to the database', $e->getMessage());
         }
     }
 
@@ -851,7 +851,7 @@ class PostgresAdapterTest extends TestCase
         foreach ($columns as $column) {
             if ($column->getName() === 'column1') {
                 $this->assertTrue($column->isNull());
-                $this->assertRegExp('/Test/', $column->getDefault());
+                $this->assertStringContainsString('Test', $column->getDefault());
             }
         }
     }
@@ -865,7 +865,7 @@ class PostgresAdapterTest extends TestCase
         $columns = $this->adapter->getColumns('t');
         foreach ($columns as $column) {
             if ($column->getName() === 'column1') {
-                $this->assertRegExp('/Test/', $column->getDefault());
+                $this->assertStringContainsString('Test', $column->getDefault());
             }
         }
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -309,8 +309,8 @@ class SQLiteAdapterTest extends TestCase
         $row = $this->adapter->fetchRow(
             "SELECT * FROM sqlite_master WHERE `type` = 'table' AND `tbl_name` = 'tbl_child'"
         );
-        $this->assertRegExp(
-            '/CONSTRAINT `fk_master_id` FOREIGN KEY \(`master_id`\) REFERENCES `tbl_master` \(`id`\) ON DELETE NO ACTION ON UPDATE NO ACTION/',
+        $this->assertStringContainsString(
+            'CONSTRAINT `fk_master_id` FOREIGN KEY (`master_id`) REFERENCES `tbl_master` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION',
             $row['sql']
         );
     }
@@ -2122,7 +2122,7 @@ INPUT;
                 $sql = $row['sql'];
             }
         }
-        $this->assertRegExp("/REFERENCES `{$refTable->getName()}` \(`id`\)/", $sql);
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
     }
 
     public function testForeignKeyReferenceCorrectAfterChangeColumn()
@@ -2149,7 +2149,7 @@ INPUT;
                 $sql = $row['sql'];
             }
         }
-        $this->assertRegExp("/REFERENCES `{$refTable->getName()}` \(`id`\)/", $sql);
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
     }
 
     public function testForeignKeyReferenceCorrectAfterRemoveColumn()
@@ -2176,7 +2176,7 @@ INPUT;
                 $sql = $row['sql'];
             }
         }
-        $this->assertRegExp("/REFERENCES `{$refTable->getName()}` \(`id`\)/", $sql);
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
     }
 
     public function testForeignKeyReferenceCorrectAfterChangePrimaryKey()
@@ -2203,7 +2203,7 @@ INPUT;
                 $sql = $row['sql'];
             }
         }
-        $this->assertRegExp("/REFERENCES `{$refTable->getName()}` \(`id`\)/", $sql);
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
     }
 
     public function testForeignKeyReferenceCorrectAfterDropForeignKey()
@@ -2235,6 +2235,6 @@ INPUT;
                 $sql = $row['sql'];
             }
         }
-        $this->assertRegExp("/REFERENCES `{$refTable->getName()}` \(`id`\)/", $sql);
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
     }
 }

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -82,7 +82,7 @@ class SqlServerAdapterTest extends TestCase
                 $e,
                 'Expected exception of type InvalidArgumentException, got ' . get_class($e)
             );
-            $this->assertRegExp('/There was a problem connecting to the database/', $e->getMessage());
+            $this->assertStringContainsString('There was a problem connecting to the database', $e->getMessage());
         } finally {
             if (!empty($adapter)) {
                 $adapter->disconnect();

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -47,7 +47,7 @@ class TableTest extends TestCase
                 $e,
                 'Expected exception of type InvalidArgumentException, got ' . get_class($e)
             );
-            $this->assertRegExp('/^An invalid column type /', $e->getMessage());
+            $this->assertStringStartsWith('An invalid column type ', $e->getMessage());
         }
     }
 

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -174,8 +174,8 @@ class ManagerTest extends TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/up  20120111235330  2012-01-11 23:53:36  2012-01-11 23:53:37  TestMigration/', $outputStr);
-        $this->assertRegExp('/up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2/', $outputStr);
+        $this->assertStringContainsString('up  20120111235330  2012-01-11 23:53:36  2012-01-11 23:53:37  TestMigration', $outputStr);
+        $this->assertStringContainsString('up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2', $outputStr);
     }
 
     public function testPrintStatusMethodJsonFormat()
@@ -252,8 +252,8 @@ class ManagerTest extends TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/up  20160111235330  2016-01-11 23:53:36  2016-01-11 23:53:37  Foo\\\\Bar\\\\TestMigration/', $outputStr);
-        $this->assertRegExp('/up  20160116183504  2016-01-16 18:35:40  2016-01-16 18:35:41  Foo\\\\Bar\\\\TestMigration2/', $outputStr);
+        $this->assertStringContainsString('up  20160111235330  2016-01-11 23:53:36  2016-01-11 23:53:37  Foo\\Bar\\TestMigration', $outputStr);
+        $this->assertStringContainsString('up  20160116183504  2016-01-16 18:35:40  2016-01-16 18:35:41  Foo\\Bar\\TestMigration2', $outputStr);
     }
 
     public function testPrintStatusMethodWithMixedNamespace()
@@ -325,12 +325,12 @@ class ManagerTest extends TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/up  20120111235330  2012-01-11 23:53:36  2012-01-11 23:53:37  TestMigration/', $outputStr);
-        $this->assertRegExp('/up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2/', $outputStr);
-        $this->assertRegExp('/up  20150111235330  2015-01-11 23:53:36  2015-01-11 23:53:37  Baz\\\\TestMigration/', $outputStr);
-        $this->assertRegExp('/up  20150116183504  2015-01-16 18:35:40  2015-01-16 18:35:41  Baz\\\\TestMigration2/', $outputStr);
-        $this->assertRegExp('/up  20160111235330  2016-01-11 23:53:36  2016-01-11 23:53:37  Foo\\\\Bar\\\\TestMigration/', $outputStr);
-        $this->assertRegExp('/up  20160116183504  2016-01-16 18:35:40  2016-01-16 18:35:41  Foo\\\\Bar\\\\TestMigration2/', $outputStr);
+        $this->assertStringContainsString('up  20120111235330  2012-01-11 23:53:36  2012-01-11 23:53:37  TestMigration', $outputStr);
+        $this->assertStringContainsString('up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2', $outputStr);
+        $this->assertStringContainsString('up  20150111235330  2015-01-11 23:53:36  2015-01-11 23:53:37  Baz\\TestMigration', $outputStr);
+        $this->assertStringContainsString('up  20150116183504  2015-01-16 18:35:40  2015-01-16 18:35:41  Baz\\TestMigration2', $outputStr);
+        $this->assertStringContainsString('up  20160111235330  2016-01-11 23:53:36  2016-01-11 23:53:37  Foo\\Bar\\TestMigration', $outputStr);
+        $this->assertStringContainsString('up  20160116183504  2016-01-16 18:35:40  2016-01-16 18:35:41  Foo\\Bar\\TestMigration2', $outputStr);
     }
 
     public function testPrintStatusMethodWithBreakpointSet()
@@ -369,7 +369,7 @@ class ManagerTest extends TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/BREAKPOINT SET/', $outputStr);
+        $this->assertStringContainsString('BREAKPOINT SET', $outputStr);
     }
 
     public function testPrintStatusMethodWithNoMigrations()
@@ -392,7 +392,7 @@ class ManagerTest extends TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/There are no available migrations. Try creating one using the create command./', $outputStr);
+        $this->assertStringContainsString('There are no available migrations. Try creating one using the create command.', $outputStr);
     }
 
     public function testPrintStatusMethodWithMissingMigrations()
@@ -764,7 +764,7 @@ class ManagerTest extends TestCase
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertRegExp('/up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING \*\*/', $outputStr);
-        $this->assertRegExp('/BREAKPOINT SET/', $outputStr);
+        $this->assertStringContainsString('BREAKPOINT SET', $outputStr);
         $this->assertRegExp('/up  20120815145812  2012-01-16 18:35:40  2012-01-16 18:35:41  Example   *\*\* MISSING \*\*/', $outputStr);
     }
 
@@ -792,8 +792,8 @@ class ManagerTest extends TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/up  20120111235330  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration/', $outputStr);
-        $this->assertRegExp('/down  20120116183504                                            TestMigration2/', $outputStr);
+        $this->assertStringContainsString('up  20120111235330  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration', $outputStr);
+        $this->assertStringContainsString('down  20120116183504                                            TestMigration2', $outputStr);
     }
 
     public function testPrintStatusMethodWithDownMigrationsWithNamespace()
@@ -821,8 +821,8 @@ class ManagerTest extends TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/up  20160111235330  2016-01-16 18:35:40  2016-01-16 18:35:41  Foo\\\\Bar\\\\TestMigration/', $outputStr);
-        $this->assertRegExp('/down  20160116183504                                            Foo\\\\Bar\\\\TestMigration2/', $outputStr);
+        $this->assertStringContainsString('up  20160111235330  2016-01-16 18:35:40  2016-01-16 18:35:41  Foo\\Bar\\TestMigration', $outputStr);
+        $this->assertStringContainsString('down  20160116183504                                            Foo\\Bar\\TestMigration2', $outputStr);
     }
 
     public function testPrintStatusMethodWithDownMigrationsWithMixedNamespace()


### PR DESCRIPTION
`assertRegExp` was deprecated in PHPUnit 9 (and to be removed in PHPUnit 10) and instead you are supposed to use `assertMatchesRegularExpression`. While we cannot remove all usages of `assertRegExp` as phinx still requires PHPUnit 8 when testing against PHP 7.2, there were a number of places where `assertRegExp` could be replaced with `assertStringContainsString` and accomplish the same test result, while also getting rid of a bunch of warnings about how that function was deprecated.