### PR TITLE
remove check on column type for setting collation / encoding

### DIFF
--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -637,21 +637,10 @@ class Column
      *
      * @param string $collation Collation
      *
-     * @throws \UnexpectedValueException If collation not allowed for type
-     *
      * @return $this
      */
     public function setCollation($collation)
     {
-        $allowedTypes = [
-            AdapterInterface::PHINX_TYPE_CHAR,
-            AdapterInterface::PHINX_TYPE_STRING,
-            AdapterInterface::PHINX_TYPE_TEXT,
-        ];
-        if (!in_array($this->getType(), $allowedTypes, true)) {
-            throw new UnexpectedValueException('Collation may be set only for types: ' . implode(', ', $allowedTypes));
-        }
-
         $this->collation = $collation;
 
         return $this;
@@ -672,21 +661,10 @@ class Column
      *
      * @param string $encoding Encoding
      *
-     * @throws \UnexpectedValueException If character set not allowed for type
-     *
      * @return $this
      */
     public function setEncoding($encoding)
     {
-        $allowedTypes = [
-            AdapterInterface::PHINX_TYPE_CHAR,
-            AdapterInterface::PHINX_TYPE_STRING,
-            AdapterInterface::PHINX_TYPE_TEXT,
-        ];
-        if (!in_array($this->getType(), $allowedTypes, true)) {
-            throw new UnexpectedValueException('Character set may be set only for types: ' . implode(', ', $allowedTypes));
-        }
-
         $this->encoding = $encoding;
 
         return $this;


### PR DESCRIPTION
Closes #1876

I mistakenly created the PR to fix this bug (#1881) against the `0.next` branch. This backports it to master for the next `0.12` release as it is not BC breaking.