### PR TITLE
add ability to set generic PDO attributes

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -334,7 +334,7 @@ For example, to set the above example options:
 
     $config = [
         "environments" => [
-            "developement" => [
+            "development" => [
                 "adapter" => "mysql",
                 # other adapter settings
                 "attr_case" => \PDO::ATTR_CASE,

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -321,6 +321,31 @@ Phinx currently supports the following database adapters natively:
 * `SQLite <http://www.sqlite.org/>`_: specify the ``sqlite`` adapter.
 * `SQL Server <http://www.microsoft.com/sqlserver>`_: specify the ``sqlsrv`` adapter.
 
+For each adapter, you may configure the behavior of the underlying PDO object by setting in your
+config object the lowercase version of the constant name. This works for both PDO options
+(e.g. ``\PDO::ATTR_CASE`` would be ``attr_case``) and adapter specific options (e.g. for MySQL
+you may set ``\PDO::MYSQL_ATTR_IGNORE_SPACE`` as ``mysql_attr_ignore_space``). Please consult
+the `PDO documentation <https://www.php.net/manual/en/book.pdo.php>`_ for the allowed attributes
+and their values.
+
+For example, to set the above example options:
+
+.. code-block:: php
+
+    $config = [
+        "environments" => [
+            "developement" => [
+                "adapter" => "mysql",
+                # other adapter settings
+                "attr_case" => \PDO::ATTR_CASE,
+                "mysql_attr_ignore_space" => 1,
+            ],
+        ],
+    ];
+
+By default, the only attribute that Phinx sets is ``\PDO::ATTR_ERRMODE`` to ``PDO::ERRMODE_EXCEPTION``. It is
+not recommended to override this.
+
 SQLite
 `````````````````
 

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -127,7 +127,11 @@ class MysqlAdapter extends PdoAdapter
             // http://php.net/manual/en/ref.pdo-mysql.php#pdo-mysql.constants
             foreach ($options as $key => $option) {
                 if (strpos($key, 'mysql_attr_') === 0) {
-                    $driverOptions[constant('\PDO::' . strtoupper($key))] = $option;
+                    $pdoConstant = '\PDO::' . strtoupper($key);
+                    if (!defined($pdoConstant)) {
+                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . '(' . $pdoConstant . ')');
+                    }
+                    $driverOptions[constant($pdoConstant)] = $option;
                 }
             }
 

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -129,7 +129,7 @@ class MysqlAdapter extends PdoAdapter
                 if (strpos($key, 'mysql_attr_') === 0) {
                     $pdoConstant = '\PDO::' . strtoupper($key);
                     if (!defined($pdoConstant)) {
-                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . '(' . $pdoConstant . ')');
+                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
                     }
                     $driverOptions[constant($pdoConstant)] = $option;
                 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -87,7 +87,11 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
 
             foreach ($adapterOptions as $key => $option) {
                 if (strpos($key, 'attr_') === 0) {
-                    $db->setAttribute(constant('\PDO::' . strtoupper($key)), $option);
+                    $pdoConstant = '\PDO::' . strtoupper($key);
+                    if (!defined($pdoConstant)) {
+                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . '(' . $pdoConstant . ')');
+                    }
+                    $db->setAttribute(constant($pdoConstant), $option);
                 }
             }
         } catch (PDOException $e) {

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -76,9 +76,20 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     protected function createPdoConnection($dsn, $username = null, $password = null, array $options = [])
     {
+        $adapterOptions = $this->getOptions();
+
+        if (!isset($adapterOptions['attr_errmode'])) {
+            $adapterOptions['attr_errmode'] = PDO::ERRMODE_EXCEPTION;
+        }
+
         try {
             $db = new PDO($dsn, $username, $password, $options);
-            $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+            foreach ($adapterOptions as $key => $option) {
+                if (strpos($key, 'attr_') === 0) {
+                    $db->setAttribute(constant('\PDO::' . strtoupper($key)), $option);
+                }
+            }
         } catch (PDOException $e) {
             throw new InvalidArgumentException(sprintf(
                 'There was a problem connecting to the database: %s',

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -89,7 +89,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                 if (strpos($key, 'attr_') === 0) {
                     $pdoConstant = '\PDO::' . strtoupper($key);
                     if (!defined($pdoConstant)) {
-                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . '(' . $pdoConstant . ')');
+                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
                     }
                     $db->setAttribute(constant($pdoConstant), $option);
                 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -76,11 +76,9 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     protected function createPdoConnection($dsn, $username = null, $password = null, array $options = [])
     {
-        $adapterOptions = $this->getOptions();
-
-        if (!isset($adapterOptions['attr_errmode'])) {
-            $adapterOptions['attr_errmode'] = PDO::ERRMODE_EXCEPTION;
-        }
+        $adapterOptions = $this->getOptions() + [
+            'attr_errmode' => PDO::ERRMODE_EXCEPTION,
+        ];
 
         try {
             $db = new PDO($dsn, $username, $password, $options);

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -94,7 +94,11 @@ class SqlServerAdapter extends PdoAdapter
             // http://php.net/manual/en/ref.pdo-sqlsrv.php#pdo-sqlsrv.constants
             foreach ($options as $key => $option) {
                 if (strpos($key, 'sqlsrv_attr_') === 0) {
-                    $driverOptions[constant('\PDO::' . strtoupper($key))] = $option;
+                    $pdoConstant = '\PDO::' . strtoupper($key);
+                    if (!defined($pdoConstant)) {
+                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . '(' . $pdoConstant . ')');
+                    }
+                    $driverOptions[constant($pdoConstant)] = $option;
                 }
             }
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -96,7 +96,7 @@ class SqlServerAdapter extends PdoAdapter
                 if (strpos($key, 'sqlsrv_attr_') === 0) {
                     $pdoConstant = '\PDO::' . strtoupper($key);
                     if (!defined($pdoConstant)) {
-                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . '(' . $pdoConstant . ')');
+                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
                     }
                     $driverOptions[constant($pdoConstant)] = $option;
                 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2047,12 +2047,9 @@ INPUT;
      */
     public function testInvalidPdoAttribute($attribute)
     {
-        $adapter = new MysqlAdapter([
-            'host' => 'localhost',
-            'name' => 'phinx',
-            $attribute => true,
-        ]);
+        $adapter = new MysqlAdapter(MYSQL_DB_CONFIG + [$attribute => true]);
         $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (\PDO::' . strtoupper($attribute) . ')');
         $adapter->connect();
     }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2033,4 +2033,26 @@ INPUT;
         $colDef = $rows[0];
         $this->assertEquals('CURRENT_TIMESTAMP(3)', $colDef['COLUMN_DEFAULT']);
     }
+
+    public function pdoAttributeProvider()
+    {
+        return [
+            ['mysql_attr_invalid'],
+            ['attr_invalid'],
+        ];
+    }
+
+    /**
+     * @dataProvider pdoAttributeProvider
+     */
+    public function testInvalidPdoAttribute($attribute)
+    {
+        $adapter = new MysqlAdapter([
+            'host' => 'localhost',
+            'name' => 'phinx',
+            $attribute => true,
+        ]);
+        $this->expectException(\UnexpectedValueException::class);
+        $adapter->connect();
+    }
 }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Db\Adapter;
 
 use PDOException;
+use Phinx\Db\Adapter\PdoAdapter;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2115,4 +2115,15 @@ OUTPUT;
         $this->assertTrue($this->adapter->hasColumn('OrganizationSettings', 'SettingTypeId'));
         $this->assertFalse($this->adapter->hasColumn('OrganizationSettings', 'SettingType'));
     }
+
+    public function testInvalidPdoAttribute()
+    {
+        $adapter = new PostgresAdapter([
+            'host' => 'localhost',
+            'name' => 'phinx',
+            'attr_invalid' => true,
+        ]);
+        $this->expectException(\UnexpectedValueException::class);
+        $adapter->connect();
+    }
 }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2118,12 +2118,9 @@ OUTPUT;
 
     public function testInvalidPdoAttribute()
     {
-        $adapter = new PostgresAdapter([
-            'host' => 'localhost',
-            'name' => 'phinx',
-            'attr_invalid' => true,
-        ]);
+        $adapter = new PostgresAdapter(PGSQL_DB_CONFIG + ['attr_invalid' => true]);
         $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid PDO attribute: attr_invalid (\PDO::ATTR_INVALID)');
         $adapter->connect();
     }
 }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2237,4 +2237,15 @@ INPUT;
         }
         $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
     }
+
+    public function testInvalidPdoAttribute()
+    {
+        $adapter = new SQLiteAdapter([
+            'host' => 'localhost',
+            'name' => 'phinx',
+            'attr_invalid' => true,
+        ]);
+        $this->expectException(\UnexpectedValueException::class);
+        $adapter->connect();
+    }
 }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2240,12 +2240,9 @@ INPUT;
 
     public function testInvalidPdoAttribute()
     {
-        $adapter = new SQLiteAdapter([
-            'host' => 'localhost',
-            'name' => 'phinx',
-            'attr_invalid' => true,
-        ]);
+        $adapter = new SQLiteAdapter(SQLITE_DB_CONFIG + ['attr_invalid' => true]);
         $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid PDO attribute: attr_invalid (\PDO::ATTR_INVALID)');
         $adapter->connect();
     }
 }

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -1052,4 +1052,26 @@ INPUT;
         $this->assertCount(1, $columns);
         $this->assertEquals(Literal::from('smallmoney'), array_pop($columns)->getType());
     }
+
+    public function pdoAttributeProvider()
+    {
+        return [
+            ['sqlsrv_attr_invalid'],
+            ['attr_invalid'],
+        ];
+    }
+
+    /**
+     * @dataProvider pdoAttributeProvider
+     */
+    public function testInvalidPdoAttribute($attribute)
+    {
+        $adapter = new SqlServerAdapter([
+            'host' => 'localhost',
+            'name' => 'phinx',
+            $attribute => true,
+        ]);
+        $this->expectException(\UnexpectedValueException::class);
+        $adapter->connect();
+    }
 }

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -1066,12 +1066,9 @@ INPUT;
      */
     public function testInvalidPdoAttribute($attribute)
     {
-        $adapter = new SqlServerAdapter([
-            'host' => 'localhost',
-            'name' => 'phinx',
-            $attribute => true,
-        ]);
+        $adapter = new SqlServerAdapter(SQLSRV_DB_CONFIG + [$attribute => true]);
         $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (\PDO::' . strtoupper($attribute) . ')');
         $adapter->connect();
     }
 }


### PR DESCRIPTION
Closes #1844

This allows specifying a list of PDO options that are then set against the connection using the `setAttribute` method. This follows a similar design of the adapter specific options of checking against a specific prefix. This is BC breaking in that it reserves `attr_` for options, but there is no option with that value so it should not affect anyone's code unless they were adding extraneous things to their config.

I've also added documentation on setting these options, both the generic ones and the adapter specific ones with a simple example, as I could not find a mention of it before in the docs.