### PR TITLE
Allow setting limit option for big int for mysql

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1014,7 +1014,7 @@ class MysqlAdapter extends PdoAdapter
 
                 return ['name' => 'int', 'limit' => $limit];
             case static::PHINX_TYPE_BIG_INTEGER:
-                return ['name' => 'bigint', 'limit' => 20];
+                return ['name' => 'bigint', 'limit' => $limit ?: 20];
             case static::PHINX_TYPE_BOOLEAN:
                 return ['name' => 'tinyint', 'limit' => 1];
             case static::PHINX_TYPE_UUID:

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -666,10 +666,13 @@ class MysqlAdapterTest extends TestCase
         return [
             ['integer', [], 'int', '11', ''],
             ['integer', ['signed' => false], 'int', '11', ' unsigned'],
+            ['integer', ['limit' => 8], 'int', '8', ''],
             ['smallinteger', [], 'smallint', '6', ''],
             ['smallinteger', ['signed' => false], 'smallint', '6', ' unsigned'],
+            ['smallinteger', ['limit' => 3], 'smallint', '3', ''],
             ['biginteger', [], 'bigint', '20', ''],
             ['biginteger', ['signed' => false], 'bigint', '20', ' unsigned'],
+            ['biginteger', ['limit' => 12], 'bigint', '12', ''],
         ];
     }
 


### PR DESCRIPTION
This makes `biginteger` work as the other integer types for mysql where it has a default, but you can override it.

Opening this PR here just so I don't forget about this as I noticed this while working on a project that used phinx. Will add a test shortly.