### PR TITLE
Add MySQL FIRST support.

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -816,7 +816,7 @@ limit   set maximum length for strings, also hints column types in adapters (see
 length  alias for ``limit``
 default set default value or action
 null    allow ``NULL`` values, defaults to false (should not be used with primary keys!) (see note below)
-after   specify the column that a new column should be placed after *(only applies to MySQL)*
+after   specify the column that a new column should be placed after, or use ``\Phinx\Db\Adapter\MysqlAdapter::FIRST`` to place the column at the start of the table *(only applies to MySQL)*
 comment set a text comment on the column
 ======= ===========
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -661,6 +661,16 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($rows[1]['Default'] === 'CURRENT_TIMESTAMP' || $rows[1]['Default'] === 'current_timestamp()');
     }
 
+    public function testAddColumnFirst()
+    {
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table->save();
+        $table->addColumn('new_id', 'integer', ['after' => MysqlAdapter::FIRST])
+              ->save();
+        $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
+        $this->assertSame('new_id', $rows[0]['Field']);
+    }
+
     public function integerDataProvider()
     {
         return [


### PR DESCRIPTION
Closes #655. (Only 5 years later.)

This is a MySQL-only syntax (as is the `AFTER` syntax to begin with) so no other adapters are relevant.

Since the Phinx repo isn't labeled with `hacktoberfest`, could I kindly request adding the `hacktoberfest-accepted` to this PR upon approval please?