### PR TITLE
add support for smallserial alias for postgres

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -838,7 +838,7 @@ Option    Description
 values    Can be a comma separated list or an array of values
 ========= ===========
 
-For ``integer`` and ``biginteger`` columns:
+For ``smallinteger``, ``integer`` and ``biginteger`` columns:
 
 ======== ===========
 Option   Description
@@ -846,6 +846,9 @@ Option   Description
 identity enable or disable automatic incrementing
 signed   enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ======== ===========
+
+For Postgres, when using ``identity``, it will utilize the ``serial`` type appropriate for the integer size, so that
+``smallinteger`` will give you ``smallserial``, ``integer`` gives ``serial``, and ``biginteger`` gives ``bigserial``.
 
 For ``timestamp`` columns:
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1144,7 +1144,13 @@ class PostgresAdapter extends PdoAdapter
     {
         $buffer = [];
         if ($column->isIdentity()) {
-            $buffer[] = $column->getType() === 'biginteger' ? 'BIGSERIAL' : 'SERIAL';
+            if ($column->getType() === 'smallinteger') {
+                $buffer[] = 'SMALLSERIAL';
+            } elseif ($column->getType() === 'biginteger') {
+                $buffer[] = 'BIGSERIAL';
+            } else {
+                $buffer[] = 'SERIAL';
+            }
         } elseif ($column->getType() instanceof Literal) {
             $buffer[] = (string)$column->getType();
         } else {

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2115,4 +2115,28 @@ OUTPUT;
         $this->assertTrue($this->adapter->hasColumn('OrganizationSettings', 'SettingTypeId'));
         $this->assertFalse($this->adapter->hasColumn('OrganizationSettings', 'SettingType'));
     }
+
+    public function serialProvider(): array
+    {
+        return [
+            [\Phinx\Db\Adapter\AdapterInterface::PHINX_TYPE_SMALL_INTEGER],
+            [\Phinx\Db\Adapter\AdapterInterface::PHINX_TYPE_INTEGER],
+            [\Phinx\Db\Adapter\AdapterInterface::PHINX_TYPE_BIG_INTEGER],
+        ];
+    }
+
+    /**
+     * @dataProvider serialProvider
+     */
+    public function testSerialAliases(string $columnType): void
+    {
+        $table = new \Phinx\Db\Table('test', ['id' => false], $this->adapter);
+        $table->addColumn('id', $columnType, ['identity' => true])->create();
+
+        $columns = $table->getColumns();
+        $this->assertCount(1, $columns);
+        $column = $columns[0];
+        $this->assertSame($columnType, $column->getType());
+        $this->assertSame("nextval('test_id_seq'::regclass)", (string)$column->getDefault());
+    }
 }


### PR DESCRIPTION
Debated on whether to make this against master or 0.next, and decided for 0.next as this is a breaking chang, albeit a small one.

Closes (properly) #1693

Using the column type `smallinteger` with `identity = true` will produce `SMALLSERIAL` data type. This mirrors the usage of `biginteger` producing `BIGSERIAL`.