### PR TITLE
Allow a way to insert demo data only for empty table.

### DIFF
--- a/docs/en/seeding.rst
+++ b/docs/en/seeding.rst
@@ -138,7 +138,7 @@ within your seed class and then use the `insert()` method to insert data:
                     ],[
                         'body'    => 'bar',
                         'created' => date('Y-m-d H:i:s'),
-                    ]
+                    ],
                 ];
 
                 $posts = $this->table('posts');
@@ -192,6 +192,21 @@ Then use it in your seed classes:
                 $this->table('users')->insert($data)->saveData();
             }
         }
+
+Executing seeds only once
+-------------------------
+
+If you want to make sure your seed data doesn't get added multiple times, a
+basic check on if the table is empty or contains already some data can help.
+
+.. code-block:: php
+    public function run()
+    {
+        if ($this->hasData('posts')) {
+            return;
+        }
+        ...
+    }
 
 Truncating Tables
 -----------------

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -174,7 +174,7 @@ abstract class AbstractSeed implements SeedInterface
     public function hasData(string $tableName): bool
     {
         $table = $this->getAdapter()->quoteTableName($tableName);
-        $countQuery = $this->getAdapter()->query('SELECT COUNT(*) FROM ' . $table);
+        $countQuery = $this->getAdapter()->query('SELECT COUNT(*) as count FROM ' . $table);
         $res = $countQuery->fetchAll();
 
         return $res[0]['count'] > 0;

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -162,11 +162,21 @@ abstract class AbstractSeed implements SeedInterface
      */
     public function insert($table, $data)
     {
-        // convert to table object
-        if (is_string($table)) {
-            $table = new Table($table, [], $this->getAdapter());
-        }
-        $table->insert($data)->save();
+        $tableInstance = new Table($table, [], $this->getAdapter());
+        $tableInstance->insert($data)->save();
+    }
+
+    /**
+     * @param string $tableName
+     *
+     * @return bool
+     */
+    public function hasData(string $tableName): bool
+    {
+        $countQuery = $this->getAdapter()->query('SELECT COUNT(*) FROM ' . $tableName);
+        $res = $countQuery->fetchAll();
+
+        return $res[0]['count'] > 0;
     }
 
     /**

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -173,7 +173,8 @@ abstract class AbstractSeed implements SeedInterface
      */
     public function hasData(string $tableName): bool
     {
-        $countQuery = $this->getAdapter()->query('SELECT COUNT(*) FROM ' . $tableName);
+        $table = $this->getAdapter()->quoteTableName($tableName);
+        $countQuery = $this->getAdapter()->query('SELECT COUNT(*) FROM ' . $table);
         $res = $countQuery->fetchAll();
 
         return $res[0]['count'] > 0;

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -167,7 +167,7 @@ abstract class AbstractSeed implements SeedInterface
     }
 
     /**
-     * @param string $tableName
+     * @param string $tableName Table name.
      *
      * @return bool
      */

--- a/tests/Phinx/Seed/SeedTest.php
+++ b/tests/Phinx/Seed/SeedTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Test\Phinx\Seed;
+
+use PDOStatement;
+use Phinx\Db\Adapter\PdoAdapter;
+use Phinx\Seed\AbstractSeed;
+use PHPUnit\Framework\TestCase;
+
+class SeedTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testHasData(): void
+    {
+        $queryStub = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
+        $queryStub->expects($this->once())
+            ->method('fetchAll')
+            ->will($this->returnValue([0 => ['count' => 0]]));
+
+        $adapterStub = $this->getMockBuilder(PdoAdapter::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+            ->method('query')
+            ->will($this->returnValue($queryStub));
+
+        $stub = $this->getMockForAbstractClass(AbstractSeed::class);
+        $stub->setAdapter($adapterStub);
+        $result = $stub->hasData('foo');
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasDataTrue(): void
+    {
+        $queryStub = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
+        $queryStub->expects($this->once())
+            ->method('fetchAll')
+            ->will($this->returnValue([0 => ['count' => 1]]));
+
+        $adapterStub = $this->getMockBuilder(PdoAdapter::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+            ->method('query')
+            ->will($this->returnValue($queryStub));
+
+        $stub = $this->getMockForAbstractClass(AbstractSeed::class);
+        $stub->setAdapter($adapterStub);
+        $result = $stub->hasData('foo');
+
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
This would solve https://github.com/cakephp/phinx/issues/1922 , or somehow at least would allow to easily check for non empty table and skip the demo data input (on 2nd + run).

What do you think?
@MasterOdin 

Trying to go the interface way or some other more clean way might not be so trivial, but we could also always try to add that on top.
On problem also is that seeds can have dependencies to other seeds, so it becomes less and less easy without also storing migration data for seeds. And at that point we are back to just saying: Use migrations for both data and structure then.