### PR TITLE
Avoid error

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -693,6 +693,9 @@ PCRE_PATTERN;
             // as the alternative is unwinding all possible table constraints which
             // gets messy quickly with CHECK constraints.
             $columns = $this->getColumns($tableName);
+            if (!$columns) {
+                return $state;
+            }
             $finalColumnName = end($columns)->getName();
             $sql = preg_replace(
                 sprintf(


### PR DESCRIPTION
> 1) Migrations\Test\TestCase\MigrationsTest::testMigrateErrors
Failed asserting that exception of type "Error" matches expected exception "Exception". Message was: "Call to a member function getName() on bool" at
/.../vendor/robmorgan/phinx/src/Phinx/Db/Adapter/SQLiteAdapter.php:696
