### PR TITLE
add parentheses to nested ternary statement

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -294,7 +294,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     {
         $className = !isset($this->values['migration_base_class']) ? 'Phinx\Migration\AbstractMigration' : $this->values['migration_base_class'];
 
-        return $dropNamespace ? substr(strrchr($className, '\\'), 1) ?: $className : $className;
+        return $dropNamespace ? (substr(strrchr($className, '\\'), 1) ?: $className) : $className;
     }
 
     /**


### PR DESCRIPTION
My IDE complained about how this statement was deprecated in PHP 7.4, and adding the parentheses fixed that, while also making the whole thing a bit more readable and less likely to have weird right/left parse differences.