### PR TITLE
Replace getEnvironment existence check with hasEnvironment

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -221,7 +221,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
         // if the user has configured a default environment then use it,
         // providing it actually exists!
         if (isset($this->values['environments']['default_environment'])) {
-            if ($this->getEnvironment($this->values['environments']['default_environment'])) {
+            if ($this->hasEnvironment($this->values['environments']['default_environment'])) {
                 return $this->values['environments']['default_environment'];
             }
 


### PR DESCRIPTION
Both have the same conceptual idea and work the same in this instance, but probably better to use the function built for the purpose of answering "does this environment exist" than the "get this environment" function.