### PR TITLE
Run codecov for sqlserver test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,9 @@ jobs:
     - name: Run PHPUnit
       env:
         SQLSRV_DSN: 'sqlserver://(localdb)\MSSQLLocalDB/phinx'
+        CODECOVERAGE: 1
       run: |
-          vendor/bin/phpunit --verbose
+          vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
           
     - name: Submit code coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         php-version: ${{ env.PHP_VERSION }}
         extensions: ${{ env.EXTENSIONS }}
         ini-values: apc.enable_cli = 1, extension = php_fileinfo.dll
-        coverage: none
+        coverage: pcov
 
     - name: Setup SQLServer
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
         SQLSRV_DSN: 'sqlserver://(localdb)\MSSQLLocalDB/phinx'
       run: |
           vendor/bin/phpunit --verbose
+          
+    - name: Submit code coverage
+      uses: codecov/codecov-action@v1
 
   cs-stan:
     name: Coding Standard & Static Analysis


### PR DESCRIPTION
Given the consolidation onto GH actions for the full test suite, see no reason to not also run codecov for windows/sqlserver now, in addition to the other DB adapters. This should improve the experience for submitting sqlserver patches as well as now codecov will not be an instant failure on adding lines because sqlserver has never been considered on the coverage count.

On completion with these changes, codecov reports:
> 88.39% (+8.58%) compared to 30faad2