### PR TITLE
Replace coveralls badge with codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/cakephp/phinx/workflows/Phinx%20CI/badge.svg?branch=master&event=push)](https://github.com/cakephp/phinx/actions?query=workflow%3A%22Phinx+CI%22+branch%3Amaster+event%3Apush)
 [![Build Status](https://img.shields.io/travis/com/cakephp/phinx?style=flat-square)](https://travis-ci.com/cakephp/phinx)
 [![Build status](https://ci.appveyor.com/api/projects/status/9vag4892hfq6effr)](https://ci.appveyor.com/project/robmorgan/phinx)
-[![Code Coverage](https://img.shields.io/coveralls/cakephp/phinx/master.svg?style=flat-square)](https://coveralls.io/r/cakephp/phinx?branch=master)
+[![Code Coverage](https://codecov.io/gh/cakephp/phinx/branch/master/graph/badge.svg)](https://codecov.io/gh/cakephp/phinx)
 [![Latest Stable Version](https://poser.pugx.org/robmorgan/phinx/version.png)](https://packagist.org/packages/robmorgan/phinx)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.2-8892BF.svg)](https://php.net/)
 [![Total Downloads](https://poser.pugx.org/robmorgan/phinx/d/total.png)](https://packagist.org/packages/robmorgan/phinx)


### PR DESCRIPTION
#1928 replaced coveralls with codecov, but did not update the badge in the README for the service.