### PR TITLE
Add test case for sqlite for new table adding column using update

### DIFF
--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2245,7 +2245,7 @@ INPUT;
         $this->expectExceptionMessage('Invalid PDO attribute: attr_invalid (\PDO::ATTR_INVALID)');
         $adapter->connect();
     }
-    
+
     public function testPdoExceptionUpdateNonExistingTable()
     {
         $this->expectException(\PDOException::class);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2245,4 +2245,11 @@ INPUT;
         $this->expectExceptionMessage('Invalid PDO attribute: attr_invalid (\PDO::ATTR_INVALID)');
         $adapter->connect();
     }
+    
+    public function testPdoExceptionUpdateNonExistingTable()
+    {
+        $this->expectException(\PDOException::class);
+        $table = new \Phinx\Db\Table('non_existing_table', [], $this->adapter);
+        $table->addColumn('column', 'string')->update();
+    }
 }


### PR DESCRIPTION
This adds a test case for the change made in #1927 so that I do not potentially re-introduce the regression that it fixed which I caused in #1845. I did not add the error message here as it's somewhat irrelevant and to make the test less brittle as the important thing is the data provider is throwing the error here, not the code itself.

For reference, the error message thrown is a SQL error on invalid `)` which happens as we hit query `INSERT INTO temp_non_existing_table () SELECT * FROM non_existing_table` (or something of that nature).