### PR TITLE
Add false to PHPDoc for FetchRow return

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -312,7 +312,7 @@ interface AdapterInterface
      *
      * @param string $sql SQL
      *
-     * @return array
+     * @return array|false
      */
     public function fetchRow($sql);
 

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -174,7 +174,7 @@ interface MigrationInterface
      *
      * @param string $sql SQL
      *
-     * @return array
+     * @return array|false
      */
     public function fetchRow($sql);
 

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -118,7 +118,7 @@ interface SeedInterface
      *
      * @param string $sql SQL
      *
-     * @return array
+     * @return array|false
      */
     public function fetchRow($sql);
 


### PR DESCRIPTION
The PHPDoc for FetchRow omits [false as a possible return](https://www.php.net/manual/en/pdostatement.fetch.php), which impedes proper error handling when using the method, or can all-but prevent error handling if using in conjunction with static analysis tools which emit logic exceptions on statements that contradict the declared return types in PHPDoc.

This PR resolves that by making the return of fetch row falseable. 

This will have the unfortunate consequence of highlighting in static analysis tools any areas where false is ignored as a possible return type, which could cause issues in existing usages.