### PR TITLE
Add new shouldExecute method to prevent a migration or seeder from being executed

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -158,6 +158,14 @@ The ``init()`` method is run by Phinx before the migration methods if it exists.
 This can be used for setting common class properties that are then used within
 the migration methods.
 
+The Should Execute Method
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``shouldExecute()`` method is run by Phinx before executing the migration.
+This can be used to prevent the migration from being executed at this time. It always
+returns true by default. You can override it in your custom ``AbstractMigration``
+implementation.
+
 Executing Queries
 -----------------
 

--- a/docs/en/seeding.rst
+++ b/docs/en/seeding.rst
@@ -75,6 +75,14 @@ The Init Method
 The ``init()`` method is run by Phinx before the run method if it exists. This
 can be used to initialize properties of the Seed class before using run.
 
+The Should Execute Method
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``shouldExecute()`` method is run by Phinx before executing the seed.
+This can be used to prevent the seed from being executed at this time. It always
+returns true by default. You can override it in your custom ``AbstractSeed``
+implementation.
+
 Foreign Key Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -336,4 +336,18 @@ abstract class AbstractMigration implements MigrationInterface
             }
         }
     }
+
+    /**
+     * Checks to see if the migration should be executed.
+     *
+     * Returns true by default.
+     *
+     * You can use this to prevent a migration from executing.
+     *
+     * @return bool
+     */
+    public function shouldExecute()
+    {
+        return true;
+    }
 }

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -265,4 +265,15 @@ interface MigrationInterface
      * @return void
      */
     public function postFlightCheck();
+
+    /**
+     * Checks to see if the migration should be executed.
+     *
+     * Returns true by default.
+     *
+     * You can use this to prevent a migration from executing.
+     *
+     * @return bool
+     */
+    public function shouldExecute();
 }

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -184,4 +184,18 @@ abstract class AbstractSeed implements SeedInterface
     {
         return new Table($tableName, $options, $this->getAdapter());
     }
+
+    /**
+     * Checks to see if the seed should be executed.
+     *
+     * Returns true by default.
+     *
+     * You can use this to prevent a seed from executing.
+     *
+     * @return bool
+     */
+    public function shouldExecute()
+    {
+        return true;
+    }
 }

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -161,4 +161,15 @@ interface SeedInterface
      * @return \Phinx\Db\Table
      */
     public function table($tableName, $options);
+
+    /**
+     * Checks to see if the seed should be executed.
+     *
+     * Returns true by default.
+     *
+     * You can use this to prevent a seed from executing.
+     *
+     * @return bool
+     */
+    public function shouldExecute();
 }

--- a/tests/Phinx/Migration/_files/seeds/UserSeederNotExecuted.php
+++ b/tests/Phinx/Migration/_files/seeds/UserSeederNotExecuted.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Phinx\Seed\AbstractSeed;
 

--- a/tests/Phinx/Migration/_files/seeds/UserSeederNotExecuted.php
+++ b/tests/Phinx/Migration/_files/seeds/UserSeederNotExecuted.php
@@ -1,0 +1,29 @@
+<?php
+
+use Phinx\Seed\AbstractSeed;
+
+class UserSeederNotExecuted extends AbstractSeed
+{
+    public function run()
+    {
+        $data = [
+            [
+                'name' => 'foo',
+                'created' => date('Y-m-d H:i:s'),
+            ],
+            [
+                'name' => 'bar',
+                'created' => date('Y-m-d H:i:s'),
+            ],
+        ];
+
+        $users = $this->table('users');
+        $users->insert($data)
+              ->save();
+    }
+
+    public function shouldExecute()
+    {
+        return false;
+    }
+}

--- a/tests/Phinx/Migration/_files/should_execute/20201207205056_should_not_execute_migration.php
+++ b/tests/Phinx/Migration/_files/should_execute/20201207205056_should_not_execute_migration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Phinx\Migration\AbstractMigration;
 

--- a/tests/Phinx/Migration/_files/should_execute/20201207205056_should_not_execute_migration.php
+++ b/tests/Phinx/Migration/_files/should_execute/20201207205056_should_not_execute_migration.php
@@ -1,0 +1,17 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ShouldNotExecuteMigration extends AbstractMigration
+{
+    public function change()
+    {
+        // info table
+        $this->table('info')->create();
+    }
+
+    public function shouldExecute()
+    {
+        return false;
+    }
+}

--- a/tests/Phinx/Migration/_files/should_execute/20201207205057_should_execute_migration.php
+++ b/tests/Phinx/Migration/_files/should_execute/20201207205057_should_execute_migration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Phinx\Migration\AbstractMigration;
 

--- a/tests/Phinx/Migration/_files/should_execute/20201207205057_should_execute_migration.php
+++ b/tests/Phinx/Migration/_files/should_execute/20201207205057_should_execute_migration.php
@@ -1,0 +1,17 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ShouldExecuteMigration extends AbstractMigration
+{
+    public function change()
+    {
+        // info table
+        $this->table('info')->create();
+    }
+
+    public function shouldExecute()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
The company I work for uses Phinx and we are pleased with it. However what's currently stopping us from using it in production is not being able to run migrations in two steps, before and after deployment.

This is an issue that's been raised several times already, in #529, #1044, #1619 and #1824 

I started using my own implementation of AbstractMigration and creating a custom template, but I realized that there was a key feature that I was missing if I did not want to wrap all my code in big `if` conditions in all my migrations: a way to stop the migrations from being executed at the Manager level, before it inserts data in phinxlog. This was rightly suggested here: https://github.com/cakephp/phinx/issues/1619#issuecomment-578732670

Even with `if` conditions as mentioned in #1619, the migration would still be recorded in the database and not tried again. What I needed was a way to make sure it would only be executed when the `shouldExecute` method returns true.

As I implemented it, a custom `AbstractMigration` implementation can override `shouldExecute` and perform any logic it wants to determine if the migration should run.

If not, it displays "skipped" in the console and stops there.

I was toying with the idea of changing how `preFlightCheck` works, and making it return a boolean and execute the migrations or not based on that, but it would break its existing behaviour, and I was not sure what to do with `postFlightCheck`, resulting in an inconsistency between the two methods.

While I was at it, I also refactored the console status message display to use a common method to display all the similar migration/seed status messages.

I believe this method would provide a simple, implementation agnostic solution for pre/post deployments and possibly other uses such as determining if a migration should run based on migration attributes, time, tags, environment, etc.

Please let me know if you have any comments! Thank you :)