### PR TITLE
Fix :: Postgres :: Change column type from text to integer | fixed #1940

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -547,7 +547,7 @@ class PostgresAdapter extends PdoAdapter
             $this->getColumnSqlDefinition($newColumn)
         );
 
-        if (in_array($newColumn->getType(), ['smallinteger', 'integer', 'biginteger'])) {
+        if (in_array($newColumn->getType(), ['smallinteger', 'integer', 'biginteger'], true)) {
             $sql .= sprintf(
                 ' USING (%s::bigint)',
                 $this->quoteColumnName($columnName)

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -551,7 +551,7 @@ class PostgresAdapter extends PdoAdapter
             $sql .= sprintf(
                 ' USING (%s::bigint)',
                 $this->quoteColumnName($columnName)
-            );;
+            );
         }
 
         //NULL and DEFAULT cannot be set while changing column type

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -546,6 +546,14 @@ class PostgresAdapter extends PdoAdapter
             $this->quoteColumnName($columnName),
             $this->getColumnSqlDefinition($newColumn)
         );
+
+        if (in_array($newColumn->getType(), ['smallinteger', 'integer', 'biginteger'])) {
+            $sql .= sprintf(
+                ' USING (%s::bigint)',
+                $this->quoteColumnName($columnName)
+            );;
+        }
+
         //NULL and DEFAULT cannot be set while changing column type
         $sql = preg_replace('/ NOT NULL/', '', $sql);
         $sql = preg_replace('/ NULL/', '', $sql);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -833,49 +833,31 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
     }
 
-    public function testChangeColumnFromTextToSmallInteger()
+    public function integersProvider()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
-        $table->addColumn('column1', 'text')
-            ->insert(['column1' => '32767'])
-            ->save();
-
-        $table->changeColumn('column1', 'smallinteger')->save();
-        $columnType = $table->getColumn('column1')->getType();
-        $this->assertTrue($columnType === 'smallinteger');
-
-        $row = $this->adapter->fetchRow('SELECT * FROM t');
-        $this->assertEquals(32767, $row['column1']);
+        return [
+            ['smallinteger', 32767],
+            ['integer', 2147483647],
+            ['biginteger', 9223372036854775807],
+        ];
     }
 
-    public function testChangeColumnFromTextToInteger()
+    /**
+     * @dataProvider integersProvider
+     */
+    public function testChangeColumnFromTextToInteger($type, $value)
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
         $table->addColumn('column1', 'text')
-            ->insert(['column1' => '2147483647'])
+            ->insert(['column1' => (string)$value])
             ->save();
 
-        $table->changeColumn('column1', 'integer')->save();
+        $table->changeColumn('column1', $type)->save();
         $columnType = $table->getColumn('column1')->getType();
-        $this->assertTrue($columnType === 'integer');
+        $this->assertSame($columnType, $type);
 
         $row = $this->adapter->fetchRow('SELECT * FROM t');
-        $this->assertEquals(2147483647, $row['column1']);
-    }
-
-    public function testChangeColumnFromTextToBigInteger()
-    {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
-        $table->addColumn('column1', 'text')
-            ->insert(['column1' => '9223372036854775807'])
-            ->save();
-
-        $table->changeColumn('column1', 'biginteger')->save();
-        $columnType = $table->getColumn('column1')->getType();
-        $this->assertTrue($columnType === 'biginteger');
-
-        $row = $this->adapter->fetchRow('SELECT * FROM t');
-        $this->assertEquals(9223372036854775807, $row['column1']);
+        $this->assertSame($value, $row['column1']);
     }
 
     public function testChangeColumnWithDefault()

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -833,6 +833,51 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
     }
 
+    public function testChangeColumnFromTextToSmallInteger()
+    {
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'text')
+            ->insert(['column1' => '123'])
+            ->save();
+
+        $table->changeColumn('column1', 'smallinteger')->save();
+        $columnType = $table->getColumn('column1')->getType();
+        $this->assertTrue($columnType === 'smallinteger');
+
+        $row = $this->adapter->fetchRow('SELECT * FROM t');
+        $this->assertEquals(123, $row['column1']);
+    }
+
+    public function testChangeColumnFromTextToInteger()
+    {
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'text')
+            ->insert(['column1' => '123'])
+            ->save();
+
+        $table->changeColumn('column1', 'integer')->save();
+        $columnType = $table->getColumn('column1')->getType();
+        $this->assertTrue($columnType === 'integer');
+
+        $row = $this->adapter->fetchRow('SELECT * FROM t');
+        $this->assertEquals(123, $row['column1']);
+    }
+
+    public function testChangeColumnFromTextToBigInteger()
+    {
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'text')
+            ->insert(['column1' => '123'])
+            ->save();
+
+        $table->changeColumn('column1', 'biginteger')->save();
+        $columnType = $table->getColumn('column1')->getType();
+        $this->assertTrue($columnType === 'biginteger');
+
+        $row = $this->adapter->fetchRow('SELECT * FROM t');
+        $this->assertEquals(123, $row['column1']);
+    }
+
     public function testChangeColumnWithDefault()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -837,7 +837,7 @@ class PostgresAdapterTest extends TestCase
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
         $table->addColumn('column1', 'text')
-            ->insert(['column1' => '123'])
+            ->insert(['column1' => '32767'])
             ->save();
 
         $table->changeColumn('column1', 'smallinteger')->save();
@@ -845,14 +845,14 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($columnType === 'smallinteger');
 
         $row = $this->adapter->fetchRow('SELECT * FROM t');
-        $this->assertEquals(123, $row['column1']);
+        $this->assertEquals(32767, $row['column1']);
     }
 
     public function testChangeColumnFromTextToInteger()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
         $table->addColumn('column1', 'text')
-            ->insert(['column1' => '123'])
+            ->insert(['column1' => '2147483647'])
             ->save();
 
         $table->changeColumn('column1', 'integer')->save();
@@ -860,14 +860,14 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($columnType === 'integer');
 
         $row = $this->adapter->fetchRow('SELECT * FROM t');
-        $this->assertEquals(123, $row['column1']);
+        $this->assertEquals(2147483647, $row['column1']);
     }
 
     public function testChangeColumnFromTextToBigInteger()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
         $table->addColumn('column1', 'text')
-            ->insert(['column1' => '123'])
+            ->insert(['column1' => '9223372036854775807'])
             ->save();
 
         $table->changeColumn('column1', 'biginteger')->save();
@@ -875,7 +875,7 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($columnType === 'biginteger');
 
         $row = $this->adapter->fetchRow('SELECT * FROM t');
-        $this->assertEquals(123, $row['column1']);
+        $this->assertEquals(9223372036854775807, $row['column1']);
     }
 
     public function testChangeColumnWithDefault()


### PR DESCRIPTION
Since bigint has the largest range of numbers I used it to convert a value to a number and no need to worry about smaller numbers. I also added 3 different tests for different types of integers. I'm not sure if this is the right thing to do now, but there may be some changes with the types in the future.