### PR TITLE
Fixed type hint in doc-block.

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -457,7 +457,7 @@ class Table
      * on_update, constraint = constraint name.
      *
      * @param string|string[] $columns Columns
-     * @param string|\Phinx\Db\Table $referencedTable Referenced Table
+     * @param string|\Phinx\Db\Table\Table $referencedTable Referenced Table
      * @param string|string[] $referencedColumns Referenced Columns
      * @param array $options Options
      *
@@ -479,7 +479,7 @@ class Table
      *
      * @param string $name The constraint name
      * @param string|string[] $columns Columns
-     * @param string|\Phinx\Db\Table $referencedTable Referenced Table
+     * @param string|\Phinx\Db\Table\Table $referencedTable Referenced Table
      * @param string|string[] $referencedColumns Referenced Columns
      * @param array $options Options
      *


### PR DESCRIPTION
Doc blocks for `Table::addForeighKey()` and `Table::addForeignKeyWithName()` both referenced `\Phinx\Db\Table` for the parameter `$referencedTable`. In practice this parameter was simply passed to `AddForeignKey::build()` which takes a `\Phinx\Db\Table\Table`. 

Updated the doc block to the correct type. I did not add an automated conversion from `\Phinx\Db\Table` to `\Phinx\Db\Table\Table` as that would break existing code calling the methods.