### PR TITLE
Added alternative template option to seed create command

### DIFF
--- a/docs/en/commands.rst
+++ b/docs/en/commands.rst
@@ -218,6 +218,13 @@ Open the new seed file in your text editor to add your database seed commands.
 Phinx creates seed files using the path specified in your configuration file.
 Please see the :doc:`Configuration <configuration>` chapter for more information.
 
+You are able to override the template file used by Phinx by supplying an
+alternative template filename.
+
+.. code-block:: bash
+
+        $ phinx seed:create MyNewSeeder --template="<file>"
+
 The Seed Run Command
 --------------------
 

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -175,7 +175,7 @@ class SeedCreate extends AbstractCommand
         // Verify the alternative template file's existence.
         if ($altTemplate && !is_file($altTemplate)) {
             throw new InvalidArgumentException(sprintf(
-                'The alternative template file "%s" does not exist',
+                'The template file "%s" does not exist',
                 $altTemplate
             ));
         }

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -43,6 +43,9 @@ class SeedCreate extends AbstractCommand
                 PHP_EOL,
                 PHP_EOL
             ));
+
+        // An alternative template.
+        $this->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Use an alternative template');
     }
 
     /**
@@ -166,8 +169,20 @@ class SeedCreate extends AbstractCommand
             ));
         }
 
-        // inject the class names appropriate to this seeder
-        $contents = file_get_contents($this->getSeedTemplateFilename());
+        // Get the alternative template option from the command line.
+        $altTemplate = $input->getOption('template');
+
+        // Verify the alternative template file's existence.
+        if ($altTemplate && !is_file($altTemplate)) {
+            throw new InvalidArgumentException(sprintf(
+                'The alternative template file "%s" does not exist',
+                $altTemplate
+            ));
+        }
+
+        // Determine the appropriate mechanism to get the template
+        // Load the alternative template if it is defined.
+        $contents = file_get_contents($altTemplate ?: $this->getSeedTemplateFilename());
 
         $config = $this->getConfig();
         $namespace = $config instanceof NamespaceAwareInterface ? $config->getSeedNamespaceByPath($path) : null;

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -140,7 +140,7 @@ class SeedCreateTest extends TestCase
         $this->assertFileExists($match['SeedFilename'], 'Failed to create seed file from template generator');
 
         // Does the migration match our expectation?
-        $expectedMigration = "useClassName Phinx\\Seed\\AbstractSeed / className {$commandLine['name']} / version {$match['Version']} / baseClassName AbstractSeed";
+        $expectedMigration = "useClassName Phinx\\Seed\\AbstractSeed / className {$commandLine['name']} / baseClassName AbstractSeed";
         $this->assertStringEqualsFile($match['SeedFilename'], $expectedMigration, 'Failed to create seed file from template generator correctly.');
     }
 }

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -162,13 +162,12 @@ class SeedCreateTest extends TestCase
 
         $commandTester = new CommandTester($command);
 
-        $commandLine = ['command' => $command->getName(), 'name' => 'AltTemplateDoesntExist', '--template' => __DIR__ . '/Templates/ThisDoesntExist.template.php.dist'];
+        $template = __DIR__ . '/Templates/ThisDoesntExist.template.php.dist';
+        $commandLine = ['command' => $command->getName(), 'name' => 'AltTemplateDoesntExist', '--template' => $template];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The alternative template file "' . $template . '" does not exist');
+
         $commandTester->execute($commandLine, ['decorated' => false]);
-
-        // Get output.
-        preg_match('`The alternative template file "(?P<AltTemplate>.*?)" does not exist\s`', $commandTester->getDisplay(), $match);
-
-        // Check reported file name
-        $this->assertEquals($match['AltTemplate'], $commandLine['--template']);
     }
 }

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -36,7 +36,7 @@ class SeedCreateTest extends TestCase
     protected function setUp(): void
     {
         TestUtils::recursiveRmdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'seeds');
-        @mkdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'seeds', 0777, true);
+        mkdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'seeds', 0777, true);
         $this->config = new Config([
             'paths' => [
                 'migrations' => sys_get_temp_dir(),

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
+use Test\Phinx\TestUtils;
 
 class SeedCreateTest extends TestCase
 {
@@ -34,10 +35,12 @@ class SeedCreateTest extends TestCase
 
     protected function setUp(): void
     {
+        TestUtils::recursiveRmdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'seeds');
+        @mkdir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'seeds', 0777, true);
         $this->config = new Config([
             'paths' => [
                 'migrations' => sys_get_temp_dir(),
-                'seeds' => sys_get_temp_dir(),
+                'seeds' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'seeds',
             ],
             'environments' => [
                 'default_migration_table' => 'phinxlog',
@@ -71,7 +74,7 @@ class SeedCreateTest extends TestCase
 
         // mock the manager class
         /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -97,7 +100,7 @@ class SeedCreateTest extends TestCase
 
         // mock the manager class
         /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -121,7 +124,7 @@ class SeedCreateTest extends TestCase
         $command = $application->find('seed:create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -153,7 +156,7 @@ class SeedCreateTest extends TestCase
         $command = $application->find('seed:create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -166,7 +169,7 @@ class SeedCreateTest extends TestCase
         $commandLine = ['command' => $command->getName(), 'name' => 'AltTemplateDoesntExist', '--template' => $template];
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The alternative template file "' . $template . '" does not exist');
+        $this->expectExceptionMessage('The template file "' . $template . '" does not exist');
 
         $commandTester->execute($commandLine, ['decorated' => false]);
     }

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -140,7 +140,7 @@ class SeedCreateTest extends TestCase
         $this->assertFileExists($match['SeedFilename'], 'Failed to create seed file from template generator');
 
         // Does the migration match our expectation?
-        $expectedMigration = "useClassName Phinx\\Seed\\AbstractSeed / className {$commandLine['name']} / baseClassName AbstractSeed" . PHP_EOL;
+        $expectedMigration = "useClassName Phinx\\Seed\\AbstractSeed / className {$commandLine['name']} / baseClassName AbstractSeed\n";
         $this->assertStringEqualsFile($match['SeedFilename'], $expectedMigration, 'Failed to create seed file from template generator correctly.');
     }
 

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -162,7 +162,7 @@ class SeedCreateTest extends TestCase
 
         $commandTester = new CommandTester($command);
 
-        $commandLine = ['command' => $command->getName(), 'name' => 'AltTemplate', '--template' => __DIR__ . '/Templates/ThisDoesntExist.template.php.dist'];
+        $commandLine = ['command' => $command->getName(), 'name' => 'AltTemplateDoesntExist', '--template' => __DIR__ . '/Templates/ThisDoesntExist.template.php.dist'];
         $commandTester->execute($commandLine, ['decorated' => false]);
 
         // Get output.

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -140,7 +140,7 @@ class SeedCreateTest extends TestCase
         $this->assertFileExists($match['SeedFilename'], 'Failed to create seed file from template generator');
 
         // Does the migration match our expectation?
-        $expectedMigration = "useClassName Phinx\\Seed\\AbstractSeed / className {$commandLine['name']} / baseClassName AbstractSeed";
+        $expectedMigration = "useClassName Phinx\\Seed\\AbstractSeed / className {$commandLine['name']} / baseClassName AbstractSeed" . PHP_EOL;
         $this->assertStringEqualsFile($match['SeedFilename'], $expectedMigration, 'Failed to create seed file from template generator correctly.');
     }
 }

--- a/tests/Phinx/Console/Command/Templates/SimpleSeeder.template.php.dist
+++ b/tests/Phinx/Console/Command/Templates/SimpleSeeder.template.php.dist
@@ -1,0 +1,1 @@
+useClassName $useClassName / className $className / baseClassName $baseClassName


### PR DESCRIPTION
Adds the -t option to seed:create command, just like it exists for create command.

I've updated English documentation.