### PR TITLE
Provide $input, $output, and $context variable to bootstrap script

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -418,3 +418,15 @@ setting External Variables to modify the config will not work because the config
 
     paths:
         bootstrap: 'phinx-bootstrap.php'
+
+Within the bootstrap script, the following variables will be available:
+
+.. code-block:: php
+
+    /**
+     * @var string $filename The file name as provided by the configuration
+     * @var string $filePath The absolute, real path to the file
+     * @var \Symfony\Component\Console\Input\InputInterface $input The executing command's input object
+     * @var \Symfony\Component\Console\Output\OutputInterface $output The executing command's output object
+     * @var \Phinx\Console\Command\AbstractCommand $context the executing command object
+     */

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -114,7 +114,7 @@ abstract class AbstractCommand extends Command
 
         if ($bootstrap = $this->getConfig()->getBootstrapFile()) {
             $output->writeln('<info>using bootstrap</info> ' . Util::relativePath($bootstrap) . ' ');
-            Util::loadPhpFile($bootstrap);
+            Util::loadPhpFile($bootstrap, $input, $output, $this);
         }
 
         // report the paths

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -10,6 +10,8 @@ namespace Phinx\Util;
 use DateTime;
 use DateTimeZone;
 use Exception;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Util
 {
@@ -235,12 +237,15 @@ class Util
      * Takes the path to a php file and attempts to include it if readable
      *
      * @param string $filename Filename
+     * @param \Symfony\Component\Console\Input\InputInterface|null $input Input
+     * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output
+     * @param \Phinx\Console\Command\AbstractCommand|mixed|null $context Context
      *
      * @throws \Exception
      *
      * @return string
      */
-    public static function loadPhpFile($filename)
+    public static function loadPhpFile($filename, ?InputInterface $input = null, ?OutputInterface $output = null, $context = null)
     {
         $filePath = realpath($filename);
         if (!file_exists($filePath)) {
@@ -257,6 +262,9 @@ class Util
         if (!$isReadable) {
             throw new Exception(sprintf("Cannot open file %s \n", $filename));
         }
+
+        // prevent this to be propagated to the included file
+        unset($isReadable);
 
         include_once $filePath;
 


### PR DESCRIPTION
Currently, it is not possible to use the `$output` or `$input` of the command when running the bootstrap script. Which requires you to just `echo` any progress/diagnostic output or create your own output handler but then you would also have to parse the original verbosity parameters and so forth.

Passing the `$input` and `$output` parameters from the [`bootstrap()`-method](https://github.com/cakephp/phinx/blob/9457e3879b0abc02a4022941a6a535141889432e/src/Phinx/Console/Command/AbstractCommand.php#L105) will make them available in the included script as `$input` and `$output` respectively.

That would be enough for just output handling. But it would also be great to be able to access the command object itself, so there is also access to the config (via `getConfig()` and all the other information one might need during bootstrapping. Hence the `$context` parameter.

Making the parameters optional is not necessarily desired but required for backward-compatibility to be maintained. Although the [`loadPhpFile()`-method](https://github.com/cakephp/phinx/blob/9457e3879b0abc02a4022941a6a535141889432e/src/Phinx/Util/Util.php#L243) is only called by the above mentioned `bootstrap()`-method within the project, it has the public access modifier set (for obvious reasons) and hence it is part of the current API. This is also the reason why the fourth parameter is called `$context`, rather than e.g. `$command` as it could be something entirely different if used in a different context (e.g. when `loadPhpFile()` is called from within a migration, it could contain the migration object instead. Or even an array of options!