### PR TITLE
Simplify gh workflow event triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - '*'
-  pull_request:
-    branches:
-      - '*'
+on: ['push', 'pull_request']
 
 jobs:
   testsuite:


### PR DESCRIPTION
This simplifies the GH workflow trigger events, as well as should fix an issue where branches that have a `/` will not be triggered for the push event.