### PR TITLE
Remove deprecated dropTable function

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -282,21 +282,6 @@ abstract class AbstractMigration implements MigrationInterface
     }
 
     /**
-     * A short-hand method to drop the given database table.
-     *
-     * @deprecated since 0.10.0. Use $this->table($tableName)->drop()->save() instead.
-     *
-     * @param string $tableName Table name
-     *
-     * @return void
-     */
-    public function dropTable($tableName)
-    {
-        trigger_error('dropTable() is deprecated since 0.10.0. Use $this->table($tableName)->drop()->save() instead.', E_USER_DEPRECATED);
-        $this->table($tableName)->drop()->save();
-    }
-
-    /**
      * Perform checks on the migration, print a warning
      * if there are potential problems.
      *

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -305,14 +305,4 @@ class AbstractMigrationTest extends TestCase
         // Dummy assert to prevent the test being marked as risky
         $this->assertTrue(true);
     }
-
-    public function testDropTableDeprecated()
-    {
-        // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
-
-        $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
-
-        $migrationStub->dropTable('test_table');
-    }
 }


### PR DESCRIPTION
Function has been deprecated since 0.10.0. Probably safe to remove I think.