### PR TITLE
Allow setting migration_table per environment

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -191,7 +191,8 @@ Migration Table
 
 To keep track of the migration statuses for an environment, phinx creates
 a table to store this information. You can customize where this table
-is created by configuring ``default_migration_table``:
+is created by configuring ``default_migration_table`` to be used as default
+for all environments:
 
 .. code-block:: yaml
 
@@ -203,6 +204,24 @@ databases that support it, e.g. Postgres, the schema name can be prefixed
 with a period separator (``.``). For example, ``phinx.log`` will create
 the table ``log`` in the ``phinx`` schema instead of ``phinxlog`` in the
 ``public`` (default) schema.
+
+You may also specify the ``migration_table`` on a per environment basis.
+Any environment that does not have a ``migration_table`` specified will
+fallback to using the ``default_migration_table`` that is defined at the
+top level. An example of how you might use this is as follows:
+
+.. code-block:: yaml
+
+    environment:
+        default_migration_table: phinxlog
+        development:
+            migration_table: phinxlog_dev
+            # rest of the development settings
+        production:
+            # rest of the production settings
+
+In the above example, ``development`` will look to the ``phinxlog_dev``
+table for migration statues while ``production`` will use ``phinxlog``.
 
 Table Prefix and Suffix
 -----------------------

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -168,8 +168,11 @@ class Config implements ConfigInterface, NamespaceAwareInterface
         $environments = $this->getEnvironments();
 
         if (isset($environments[$name])) {
-            if (isset($this->values['environments']['default_migration_table'])) {
-                $environments[$name]['default_migration_table'] =
+            if (
+                isset($this->values['environments']['default_migration_table'])
+                && !isset($environments[$name]['migration_table'])
+            ) {
+                $environments[$name]['migration_table'] =
                     $this->values['environments']['default_migration_table'];
             }
 

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -77,7 +77,14 @@ abstract class AbstractAdapter implements AdapterInterface
         $this->options = $options;
 
         if (isset($options['default_migration_table'])) {
-            $this->setSchemaTableName($options['default_migration_table']);
+            trigger_error('The default_migration_table setting for adapter has been deprecated since 0.13.0. Use `migration_table` instead.', E_USER_DEPRECATED);
+            if (!isset($options['migration_table'])) {
+                $options['migration_table'] = $options['default_migration_table'];
+            }
+        }
+
+        if (isset($options['migration_table'])) {
+            $this->setSchemaTableName($options['migration_table']);
         }
 
         if (isset($options['data_domain'])) {

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -134,6 +134,16 @@ class ConfigTest extends AbstractConfigTest
         $config->getDefaultEnvironment();
     }
 
+    public function testEnvironmentHasMigrationTable()
+    {
+        $configArray = $this->getConfigArray();
+        $configArray['environments']['production']['migration_table'] = 'test_table';
+        $config = new Config($configArray);
+
+        $this->assertSame('phinxlog', $config->getEnvironment('testing')['migration_table']);
+        $this->assertSame('test_table', $config->getEnvironment('production')['migration_table']);
+    }
+
     /**
      * @covers \Phinx\Config\Config::offsetGet
      * @covers \Phinx\Config\Config::offsetSet

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -69,6 +69,16 @@ class PdoAdapterTest extends TestCase
     public function testOptionsSetSchemaTableName()
     {
         $this->assertEquals('phinxlog', $this->adapter->getSchemaTableName());
+        $this->adapter->setOptions(['migration_table' => 'schema_table_test']);
+        $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());
+    }
+
+    public function testOptionsSetDefaultMigrationTableThrowsDeprecation()
+    {
+        $this->assertEquals('phinxlog', $this->adapter->getSchemaTableName());
+
+        $this->expectDeprecation();
+        $this->expectExceptionMessage('The default_migration_table setting for adapter has been deprecated since 0.13.0. Use `migration_table` instead.');
         $this->adapter->setOptions(['default_migration_table' => 'schema_table_test']);
         $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());
     }


### PR DESCRIPTION
Closes #1896 

This sets it so that it is now possible to set the migration table per environment, falling back to the `default_migration_table` if one is not set for that environment. I think this is probably a more elegant solution to things. As part of this change, the `AbstractAdapter` now expects the `migration_table` to be used as an option instead of `default_migration_table`, though both are allowed, with the latter throwing a deprecation warning.