### PR TITLE
Postgres allow change from int to bool and char to uuid

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -540,7 +540,7 @@ class PostgresAdapter extends PdoAdapter
     protected function getChangeColumnInstructions($tableName, $columnName, Column $newColumn)
     {
         $instructions = new AlterInstructions();
-        if ($newColumn->getType()==='boolean') {
+        if ($newColumn->getType() === 'boolean') {
             $sql = sprintf('ALTER COLUMN %s DROP DEFAULT', $this->quoteColumnName($columnName));
             $instructions->addAlter($sql);
         }
@@ -561,7 +561,7 @@ class PostgresAdapter extends PdoAdapter
         $sql = preg_replace('/ NULL/', '', $sql);
         //If it is set, DEFAULT is the last definition
         $sql = preg_replace('/DEFAULT .*/', '', $sql);
-        if ($newColumn->getType()==='boolean') {
+        if ($newColumn->getType() === 'boolean') {
             $sql .= sprintf(
                 ' USING (CASE WHEN %s=0 THEN FALSE ELSE TRUE END)',
                 $this->quoteColumnName($columnName)

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -555,7 +555,12 @@ class PostgresAdapter extends PdoAdapter
                 $this->quoteColumnName($columnName)
             );
         }
-
+        if ($newColumn->getType() === 'uuid') {
+            $sql .= sprintf(
+                ' USING (%s::uuid)',
+                $this->quoteColumnName($columnName)
+            );
+        }
         //NULL and DEFAULT cannot be set while changing column type
         $sql = preg_replace('/ NOT NULL/', '', $sql);
         $sql = preg_replace('/ NULL/', '', $sql);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -860,6 +860,21 @@ class PostgresAdapterTest extends TestCase
         $this->assertSame($value, $row['column1']);
     }
 
+    public function testChangeColumnFromIntegerToBoolean()
+    {
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'integer', ['default'=>0])
+              ->save();
+        $table->changeColumn('column1', 'boolean', ['default'=>'t', 'null'=>true])
+        ->save();
+        $columns = $this->adapter->getColumns('t');
+        foreach ($columns as $column) {
+            if ($column->getName() === 'column1') {
+                $this->assertTrue($column->isNull());
+                $this->assertStringContainsString("true", $column->getDefault());
+            }
+        }
+    }
     public function testChangeColumnWithDefault()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -876,6 +876,24 @@ class PostgresAdapterTest extends TestCase
         }
     }
 
+    public function testChangeColumnCharToUuid()
+    {
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'char', ['default' => null,'limit'=>36])
+              ->save();
+        $table->changeColumn('column1', 'uuid', ['default' => null, 'null' => true])
+        ->save();
+        $columns = $this->adapter->getColumns('t');
+        foreach ($columns as $column) {
+            if ($column->getName() === 'column1') {
+                $this->assertTrue($column->isNull());
+                $this->assertNull($column->getDefault());
+                $columnType = $table->getColumn('column1')->getType();
+                $this->assertSame($columnType, 'uuid');
+            }
+        }
+    }
+
     public function testChangeColumnWithDefault()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -879,7 +879,7 @@ class PostgresAdapterTest extends TestCase
     public function testChangeColumnCharToUuid()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
-        $table->addColumn('column1', 'char', ['default' => null,'limit'=>36])
+        $table->addColumn('column1', 'char', ['default' => null, 'limit' => 36])
               ->save();
         $table->changeColumn('column1', 'uuid', ['default' => null, 'null' => true])
         ->save();

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -863,9 +863,9 @@ class PostgresAdapterTest extends TestCase
     public function testChangeColumnFromIntegerToBoolean()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
-        $table->addColumn('column1', 'integer', ['default'=>0])
+        $table->addColumn('column1', 'integer', ['default' => 0])
               ->save();
-        $table->changeColumn('column1', 'boolean', ['default'=>'t', 'null'=>true])
+        $table->changeColumn('column1', 'boolean', ['default' => 't', 'null' => true])
         ->save();
         $columns = $this->adapter->getColumns('t');
         foreach ($columns as $column) {

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -875,6 +875,7 @@ class PostgresAdapterTest extends TestCase
             }
         }
     }
+
     public function testChangeColumnWithDefault()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);


### PR DESCRIPTION
For boolean start by dropping defaults since its value is not a bool,
then convert all non-zero values to boolean true.
For uuid add USING:uuid