### PR TITLE
SQL Server adapter uses nvarchar(max) instead of ntext and always updates default constraint

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -609,9 +609,6 @@ SQL;
     protected function getChangeColumnInstructions($tableName, $columnName, Column $newColumn)
     {
         $columns = $this->getColumns($tableName);
-        $changeDefault =
-            $newColumn->getDefault() !== $columns[$columnName]->getDefault() ||
-            $newColumn->getType() !== $columns[$columnName]->getType();
 
         $instructions = new AlterInstructions();
 
@@ -621,9 +618,7 @@ SQL;
             );
         }
 
-        if ($changeDefault) {
-            $instructions->merge($this->getDropDefaultConstraint($tableName, $newColumn->getName()));
-        }
+        $instructions->merge($this->getDropDefaultConstraint($tableName, $newColumn->getName()));
 
         $instructions->addPostStep(sprintf(
             'ALTER TABLE %s ALTER COLUMN %s %s',
@@ -636,9 +631,7 @@ SQL;
             $instructions->addPostStep($this->getColumnCommentSqlDefinition($newColumn, $tableName));
         }
 
-        if ($changeDefault) {
-            $instructions->merge($this->getChangeDefault($tableName, $newColumn));
-        }
+        $instructions->merge($this->getChangeDefault($tableName, $newColumn));
 
         return $instructions;
     }


### PR DESCRIPTION
The first commit of this PR handles #1972, which is to remove the use of NTEXT and replace it with NVARCHAR(MAX). The existing NTEXT and TEXT parsing to the Phinx TEXT type still exists for compatibility reasons.

The second commit forces default constraints to always be dropped and readded, as SQL Server requires this to be removed if the column is ever changed.