### PR TITLE
allow setting column to false to ignore it in addTimestamps

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -799,9 +799,12 @@ update   set an action to be triggered when the row is updated (use with ``CURRE
 timezone enable or disable the ``with time zone`` option for ``time`` and ``timestamp`` columns *(only applies to Postgres)*
 ======== ===========
 
-You can add ``created_at`` and ``updated_at`` timestamps to a table using the ``addTimestamps()`` method. This method also
-allows you to supply alternative names. The optional third argument allows you to change the ``timezone`` option for the
-columns being added. Additionally, you can use the ``addTimestampsWithTimezone()`` method, which is an alias to
+You can add ``created_at`` and ``updated_at`` timestamps to a table using the ``addTimestamps()`` method. This method accepts
+three arguments, where the first two allow setting alternative names for the columns while the third argument allows you to
+enable the ``timezone`` option for the columns. The defaults for these arguments are ``created_at``, ``updated_at``, and ``true``
+respectively. For the first and second argument, if you provide ``null``, then the default name will be used, and if you provide
+``false``, then that column will not be created. Please note that attempting to set both to ``false`` will throw a
+``\RuntimeException``. Additionally, you can use the ``addTimestampsWithTimezone()`` method, which is an alias to
 ``addTimestamps()`` that will always set the third argument to ``true`` (see examples below). The ``created_at`` column will
 have a default set to ``CURRENT_TIMESTAMP``. For MySQL only, ``update_at`` column will have update set to
 ``CURRENT_TIMESTAMP``.
@@ -831,6 +834,12 @@ have a default set to ``CURRENT_TIMESTAMP``. For MySQL only, ``update_at`` colum
                 // The two lines below do the same, the second one is simply cleaner.
                 $table = $this->table('books')->addTimestamps(null, 'amended_at', true)->create();
                 $table = $this->table('users')->addTimestampsWithTimezone(null, 'amended_at')->create();
+
+                // Only add the created_at column to the table
+                $table = $this->table('books')->addTimestamps(null, false);
+                // Only add the updated_at column to the table
+                $table = $this->table('users')->addTimestamps(false);
+                // Note, setting both false will throw a \RuntimeError
             }
         }
 

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -545,8 +545,8 @@ class Table
     /**
      * Add timestamp columns created_at and updated_at to the table.
      *
-     * @param string|null $createdAt Alternate name for the created_at column
-     * @param string|null $updatedAt Alternate name for the updated_at column
+     * @param string|false|null $createdAt Alternate name for the created_at column
+     * @param string|false|null $updatedAt Alternate name for the updated_at column
      * @param bool $withTimezone Whether to set the timezone option on the added columns
      *
      * @return $this
@@ -556,17 +556,25 @@ class Table
         $createdAt = $createdAt === null ? 'created_at' : $createdAt;
         $updatedAt = $updatedAt === null ? 'updated_at' : $updatedAt;
 
-        $this->addColumn($createdAt, 'timestamp', [
-                   'default' => 'CURRENT_TIMESTAMP',
-                   'update' => '',
-                   'timezone' => $withTimezone,
-             ])
-             ->addColumn($updatedAt, 'timestamp', [
-                 'null' => true,
-                 'default' => null,
-                 'update' => 'CURRENT_TIMESTAMP',
-                 'timezone' => $withTimezone,
-             ]);
+        if (!$createdAt && !$updatedAt) {
+            throw new \RuntimeException('Cannot set both created_at and updated_at columns to false');
+        }
+
+        if ($createdAt) {
+            $this->addColumn($createdAt, 'timestamp', [
+                'default' => 'CURRENT_TIMESTAMP',
+                'update' => '',
+                'timezone' => $withTimezone,
+            ]);
+        }
+        if ($updatedAt) {
+            $this->addColumn($updatedAt, 'timestamp', [
+                'null' => true,
+                'default' => null,
+                'update' => 'CURRENT_TIMESTAMP',
+                'timezone' => $withTimezone,
+            ]);
+        }
 
         return $this;
     }
@@ -576,8 +584,8 @@ class Table
      *
      * @see addTimestamps
      *
-     * @param string|null $createdAt Alternate name for the created_at column
-     * @param string|null $updatedAt Alternate name for the updated_at column
+     * @param string|false|null $createdAt Alternate name for the created_at column
+     * @param string|false|null $updatedAt Alternate name for the updated_at column
      *
      * @return $this
      */

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -158,13 +158,13 @@ class TableTest extends TestCase
             $columns[] = $action->getColumn();
         }
 
-        $this->assertEquals(1, count($columns));
+        $this->assertCount(1, $columns);
 
-        $this->assertEquals('created_at', $columns[0]->getName());
-        $this->assertEquals('timestamp', $columns[0]->getType());
-        $this->assertEquals('CURRENT_TIMESTAMP', $columns[0]->getDefault());
-        $this->assertEquals(false, $columns[0]->getTimezone());
-        $this->assertEquals('', $columns[0]->getUpdate());
+        $this->assertSame('created_at', $columns[0]->getName());
+        $this->assertSame('timestamp', $columns[0]->getType());
+        $this->assertSame('CURRENT_TIMESTAMP', $columns[0]->getDefault());
+        $this->assertFalse($columns[0]->getTimezone());
+        $this->assertSame('', $columns[0]->getUpdate());
     }
 
     /**
@@ -184,12 +184,12 @@ class TableTest extends TestCase
             $columns[] = $action->getColumn();
         }
 
-        $this->assertEquals(1, count($columns));
+        $this->assertCount(1, $columns);
 
-        $this->assertEquals('updated_at', $columns[0]->getName());
-        $this->assertEquals('timestamp', $columns[0]->getType());
-        $this->assertEquals(false, $columns[0]->getTimezone());
-        $this->assertEquals('CURRENT_TIMESTAMP', $columns[0]->getUpdate());
+        $this->assertSame('updated_at', $columns[0]->getName());
+        $this->assertSame('timestamp', $columns[0]->getType());
+        $this->assertFalse($columns[0]->getTimezone());
+        $this->assertSame('CURRENT_TIMESTAMP', $columns[0]->getUpdate());
         $this->assertTrue($columns[0]->isNull());
         $this->assertNull($columns[0]->getDefault());
     }

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -142,7 +142,6 @@ class TableTest extends TestCase
 
     /**
      * @dataProvider provideAdapters
-     *
      * @param AdapterInterface $adapter
      */
     public function testAddTimestampsNoUpdated(AdapterInterface $adapter)
@@ -168,7 +167,6 @@ class TableTest extends TestCase
 
     /**
      * @dataProvider provideAdapters
-     *
      * @param AdapterInterface $adapter
      */
     public function testAddTimestampsNoCreated(AdapterInterface $adapter)
@@ -195,7 +193,6 @@ class TableTest extends TestCase
 
     /**
      * @dataProvider provideAdapters
-     *
      * @param AdapterInterface $adapter
      */
     public function testAddTimestampsThrowsOnBothFalse(AdapterInterface $adapter)


### PR DESCRIPTION
Closes #1985 

This allows using the boolean `false` for the first two arguments to `addTimestamps` and `addTimestampsWithTimezone` to have it skip adding that column to the table. 