### PR TITLE
Add retry logic around mysql db creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           n=0
           until [ "$n" -ge 5 ]
           do
-            mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE phinx;'; && break || :
+            mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE phinx;' && break || :
             n=$((n+1))
             sleep 2
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,22 @@ jobs:
       if: matrix.php-version == '7.4' && matrix.db-type == 'mysql'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-    - name: Run PHPUnit
+    - name: Setup Database
       run: |
-        if [[ ${{ matrix.db-type }} == 'mysql' ]]; then mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE phinx;'; fi
+        if [[ ${{ matrix.db-type }} == 'mysql' ]]; then
+          n=0
+          until [ "$n" -ge 5 ]
+          do
+            mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE phinx;'; && break || :
+            n=$((n+1))
+            sleep 2
+          done
+          mysql -h 127.0.0.1 -u root -proot -D phinx -e 'SELECT 1;'
+        fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then psql -c 'CREATE DATABASE phinx;' postgresql://postgres:postgres@127.0.0.1; fi
 
+    - name: Run PHPUnit
+      run: |
         if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export SQLITE_DSN='sqlite:///phinx'; fi
         if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export MYSQL_DSN='mysql://root:root@127.0.0.1/phinx'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export PGSQL_DSN='pgsql://postgres:postgres@127.0.0.1/phinx'; fi


### PR DESCRIPTION
The mysql tests have started failing with decent frequency. This seems to be a timing error where we hit the step to create the DB before the mysql container is ready, causing the suite to fail. This surfaces as the error "ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0" in the logs.

This PR adds some basic retry logic around the command so that it will run the DB creation command 5 times over 10 seconds (with a 2 second pause between tries). This followed by a simple `SELECT 1` query to ensure the DB is up. This helps deal with the flakiness here, getting the test suite to pass consistently again. This job (https://github.com/MasterOdin/phinx/runs/2793008084?check_suite_focus=true) shows the effect where under `Setup Database` step, we have the output:

```
Warning: arning] Using a password on the command line interface can be insecure.
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
Warning: arning] Using a password on the command line interface can be insecure.
Warning: arning] Using a password on the command line interface can be insecure.
```

where we see the first time we tried to create the DB failed, but the second time passed.

