### PR TITLE
Add type hints to codebase

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,6 +2,6 @@ parameters:
 	ignoreErrors:
 		-
 			message: "#^Call to function is_subclass_of\\(\\) with non\\-empty\\-string and 'Phinx\\\\\\\\Migration…' will always evaluate to false\\.$#"
-			count: 1
+			count: 2
 			path: src/Phinx/Console/Command/Create.php
 

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -11,6 +11,7 @@ use Closure;
 use InvalidArgumentException;
 use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Util\Util;
+use Psr\Container\ContainerInterface;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 use UnexpectedValueException;
@@ -366,7 +367,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getContainer(): ?\Psr\Container\ContainerInterface
+    public function getContainer(): ?ContainerInterface
     {
         if (!isset($this->values['container'])) {
             return null;

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -41,7 +41,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     protected $values = [];
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $configFilePath;
 
@@ -258,7 +258,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getConfigFilePath(): string
+    public function getConfigFilePath(): ?string
     {
         return $this->configFilePath;
     }

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -60,9 +60,9 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param string $configFilePath Path to the Yaml File
      * @throws \RuntimeException
-     * @return \Phinx\Config\Config
+     * @return self
      */
-    public static function fromYaml(string $configFilePath): Config
+    public static function fromYaml(string $configFilePath): self
     {
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml', true)) {
             // @codeCoverageIgnoreStart
@@ -88,9 +88,9 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param string $configFilePath Path to the JSON File
      * @throws \RuntimeException
-     * @return \Phinx\Config\Config
+     * @return self
      */
-    public static function fromJson(string $configFilePath): Config
+    public static function fromJson(string $configFilePath): self
     {
         if (!function_exists('json_decode')) {
             // @codeCoverageIgnoreStart
@@ -114,9 +114,9 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param string $configFilePath Path to the PHP File
      * @throws \RuntimeException
-     * @return \Phinx\Config\Config
+     * @return self
      */
-    public static function fromPhp(string $configFilePath): Config
+    public static function fromPhp(string $configFilePath): self
     {
         ob_start();
         /** @noinspection PhpIncludeInspection */

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -60,9 +60,9 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param string $configFilePath Path to the Yaml File
      * @throws \RuntimeException
-     * @return self
+     * @return \Phinx\Config\ConfigInterface
      */
-    public static function fromYaml(string $configFilePath): self
+    public static function fromYaml(string $configFilePath): ConfigInterface
     {
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml', true)) {
             // @codeCoverageIgnoreStart
@@ -88,9 +88,9 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param string $configFilePath Path to the JSON File
      * @throws \RuntimeException
-     * @return self
+     * @return \Phinx\Config\ConfigInterface
      */
-    public static function fromJson(string $configFilePath): self
+    public static function fromJson(string $configFilePath): ConfigInterface
     {
         if (!function_exists('json_decode')) {
             // @codeCoverageIgnoreStart
@@ -114,9 +114,9 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @param string $configFilePath Path to the PHP File
      * @throws \RuntimeException
-     * @return self
+     * @return \Phinx\Config\ConfigInterface
      */
-    public static function fromPhp(string $configFilePath): self
+    public static function fromPhp(string $configFilePath): ConfigInterface
     {
         ob_start();
         /** @noinspection PhpIncludeInspection */

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -49,7 +49,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @param array $configArray Config array
      * @param string|null $configFilePath Config file path
      */
-    public function __construct(array $configArray, $configFilePath = null)
+    public function __construct(array $configArray, ?string $configFilePath = null)
     {
         $this->configFilePath = $configFilePath;
         $this->values = $this->replaceTokens($configArray);
@@ -62,7 +62,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @throws \RuntimeException
      * @return \Phinx\Config\Config
      */
-    public static function fromYaml($configFilePath)
+    public static function fromYaml(string $configFilePath): Config
     {
         if (!class_exists('Symfony\\Component\\Yaml\\Yaml', true)) {
             // @codeCoverageIgnoreStart
@@ -90,7 +90,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @throws \RuntimeException
      * @return \Phinx\Config\Config
      */
-    public static function fromJson($configFilePath)
+    public static function fromJson(string $configFilePath): Config
     {
         if (!function_exists('json_decode')) {
             // @codeCoverageIgnoreStart
@@ -116,7 +116,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @throws \RuntimeException
      * @return \Phinx\Config\Config
      */
-    public static function fromPhp($configFilePath)
+    public static function fromPhp(string $configFilePath): Config
     {
         ob_start();
         /** @noinspection PhpIncludeInspection */
@@ -138,7 +138,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getEnvironments()
+    public function getEnvironments(): ?array
     {
         if (isset($this->values) && isset($this->values['environments'])) {
             $environments = [];
@@ -157,7 +157,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getEnvironment($name)
+    public function getEnvironment(string $name): ?array
     {
         $environments = $this->getEnvironments();
 
@@ -187,7 +187,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function hasEnvironment($name)
+    public function hasEnvironment(string $name): bool
     {
         return $this->getEnvironment($name) !== null;
     }
@@ -195,7 +195,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getDefaultEnvironment()
+    public function getDefaultEnvironment(): string
     {
         // The $PHINX_ENVIRONMENT variable overrides all other default settings
         $env = getenv('PHINX_ENVIRONMENT');
@@ -242,7 +242,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getAlias($alias)
+    public function getAlias($alias): ?string
     {
         return !empty($this->values['aliases'][$alias]) ? $this->values['aliases'][$alias] : null;
     }
@@ -250,7 +250,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getAliases()
+    public function getAliases(): array
     {
         return !empty($this->values['aliases']) ? $this->values['aliases'] : [];
     }
@@ -258,7 +258,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getConfigFilePath()
+    public function getConfigFilePath(): string
     {
         return $this->configFilePath;
     }
@@ -267,7 +267,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @inheritDoc
      * @throws \UnexpectedValueException
      */
-    public function getMigrationPaths()
+    public function getMigrationPaths(): array
     {
         if (!isset($this->values['paths']['migrations'])) {
             throw new UnexpectedValueException('Migrations path missing from config file');
@@ -281,23 +281,10 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     }
 
     /**
-     * Gets the base class name for migrations.
-     *
-     * @param bool $dropNamespace Return the base migration class name without the namespace.
-     * @return string
-     */
-    public function getMigrationBaseClassName($dropNamespace = true)
-    {
-        $className = !isset($this->values['migration_base_class']) ? 'Phinx\Migration\AbstractMigration' : $this->values['migration_base_class'];
-
-        return $dropNamespace ? (substr(strrchr($className, '\\'), 1) ?: $className) : $className;
-    }
-
-    /**
      * @inheritDoc
      * @throws \UnexpectedValueException
      */
-    public function getSeedPaths()
+    public function getSeedPaths(): array
     {
         if (!isset($this->values['paths']['seeds'])) {
             throw new UnexpectedValueException('Seeds path missing from config file');
@@ -311,12 +298,25 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     }
 
     /**
+     * Gets the base class name for migrations.
+     *
+     * @param bool $dropNamespace Return the base migration class name without the namespace.
+     * @return string
+     */
+    public function getMigrationBaseClassName(bool $dropNamespace = true): string
+    {
+        $className = !isset($this->values['migration_base_class']) ? 'Phinx\Migration\AbstractMigration' : $this->values['migration_base_class'];
+
+        return $dropNamespace ? (substr(strrchr($className, '\\'), 1) ?: $className) : $className;
+    }
+
+    /**
      * Gets the base class name for seeders.
      *
      * @param bool $dropNamespace Return the base seeder class name without the namespace.
      * @return string
      */
-    public function getSeedBaseClassName($dropNamespace = true)
+    public function getSeedBaseClassName(bool $dropNamespace = true): string
     {
         $className = !isset($this->values['seed_base_class']) ? 'Phinx\Seed\AbstractSeed' : $this->values['seed_base_class'];
 
@@ -354,7 +354,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function getDataDomain()
+    public function getDataDomain(): array
     {
         if (!isset($this->values['data_domain'])) {
             return [];
@@ -366,7 +366,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritDoc
      */
-    public function getContainer()
+    public function getContainer(): ?\Psr\Container\ContainerInterface
     {
         if (!isset($this->values['container'])) {
             return null;
@@ -380,7 +380,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @return string
      */
-    public function getVersionOrder()
+    public function getVersionOrder(): string
     {
         if (!isset($this->values['version_order'])) {
             return self::VERSION_ORDER_CREATION_TIME;
@@ -394,7 +394,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      *
      * @return bool
      */
-    public function isVersionOrderCreationTime()
+    public function isVersionOrderCreationTime(): bool
     {
         $versionOrder = $this->getVersionOrder();
 
@@ -421,7 +421,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @param array $arr Array to replace
      * @return array
      */
-    protected function replaceTokens(array $arr)
+    protected function replaceTokens(array $arr): array
     {
         // Get environment variables
         // Depending on configuration of server / OS and variables_order directive,
@@ -449,7 +449,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @param string[] $tokens Array of tokens to search for
      * @return array
      */
-    protected function recurseArrayForTokens($arr, $tokens)
+    protected function recurseArrayForTokens(array $arr, array $tokens): array
     {
         $out = [];
         foreach ($arr as $name => $value) {
@@ -476,7 +476,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @param array $options Options
      * @return array
      */
-    protected function parseAgnosticDsn(array $options)
+    protected function parseAgnosticDsn(array $options): array
     {
         $parsed = Util::parseDsn($options['dsn'] ?? '');
         if ($parsed) {
@@ -495,7 +495,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @param mixed $value Value
      * @return void
      */
-    public function offsetSet($id, $value)
+    public function offsetSet($id, $value): void
     {
         $this->values[$id] = $value;
     }
@@ -522,7 +522,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @param mixed $id ID
      * @return bool
      */
-    public function offsetExists($id)
+    public function offsetExists($id): bool
     {
         return isset($this->values[$id]);
     }
@@ -533,7 +533,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @param mixed $id ID
      * @return void
      */
-    public function offsetUnset($id)
+    public function offsetUnset($id): void
     {
         unset($this->values[$id]);
     }

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -24,7 +24,7 @@ interface ConfigInterface extends ArrayAccess
      *
      * @return array|null
      */
-    public function getEnvironments();
+    public function getEnvironments(): ?array;
 
     /**
      * Returns the configuration for a given environment.
@@ -35,7 +35,7 @@ interface ConfigInterface extends ArrayAccess
      * @param string $name Environment Name
      * @return array|null
      */
-    public function getEnvironment($name);
+    public function getEnvironment(string $name): ?array;
 
     /**
      * Does the specified environment exist in the configuration file?
@@ -43,7 +43,7 @@ interface ConfigInterface extends ArrayAccess
      * @param string $name Environment Name
      * @return bool
      */
-    public function hasEnvironment($name);
+    public function hasEnvironment(string $name): bool;
 
     /**
      * Gets the default environment name.
@@ -51,7 +51,7 @@ interface ConfigInterface extends ArrayAccess
      * @throws \RuntimeException
      * @return string
      */
-    public function getDefaultEnvironment();
+    public function getDefaultEnvironment(): string;
 
     /**
      * Get the aliased value from a supplied alias.
@@ -59,35 +59,35 @@ interface ConfigInterface extends ArrayAccess
      * @param string $alias Alias
      * @return string|null
      */
-    public function getAlias($alias);
+    public function getAlias(string $alias): ?string;
 
     /**
      * Get all the aliased values.
      *
      * @return string[]
      */
-    public function getAliases();
+    public function getAliases(): array;
 
     /**
      * Gets the config file path.
      *
      * @return string
      */
-    public function getConfigFilePath();
+    public function getConfigFilePath(): string;
 
     /**
      * Gets the paths to search for migration files.
      *
      * @return string[]
      */
-    public function getMigrationPaths();
+    public function getMigrationPaths(): array;
 
     /**
      * Gets the paths to search for seed files.
      *
      * @return string[]
      */
-    public function getSeedPaths();
+    public function getSeedPaths(): array;
 
     /**
      * Get the template file name.
@@ -108,28 +108,28 @@ interface ConfigInterface extends ArrayAccess
      *
      * @return \Psr\Container\ContainerInterface|null
      */
-    public function getContainer();
+    public function getContainer(): ?\Psr\Container\ContainerInterface;
 
     /**
      * Get the data domain array.
      *
      * @return array
      */
-    public function getDataDomain();
+    public function getDataDomain(): array;
 
     /**
      * Get the version order.
      *
      * @return string
      */
-    public function getVersionOrder();
+    public function getVersionOrder(): string;
 
     /**
      * Is version order creation time?
      *
      * @return bool
      */
-    public function isVersionOrderCreationTime();
+    public function isVersionOrderCreationTime(): bool;
 
     /**
      * Get the bootstrap file path
@@ -144,7 +144,7 @@ interface ConfigInterface extends ArrayAccess
      * @param bool $dropNamespace Return the base migration class name without the namespace.
      * @return string
      */
-    public function getMigrationBaseClassName($dropNamespace = true);
+    public function getMigrationBaseClassName(bool $dropNamespace = true): string;
 
     /**
      * Gets the base class name for seeders.
@@ -152,5 +152,5 @@ interface ConfigInterface extends ArrayAccess
      * @param bool $dropNamespace Return the base seeder class name without the namespace.
      * @return string
      */
-    public function getSeedBaseClassName($dropNamespace = true);
+    public function getSeedBaseClassName(bool $dropNamespace = true): string;
 }

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -8,6 +8,7 @@
 namespace Phinx\Config;
 
 use ArrayAccess;
+use Psr\Container\ContainerInterface;
 
 /**
  * Phinx configuration interface.
@@ -108,7 +109,7 @@ interface ConfigInterface extends ArrayAccess
      *
      * @return \Psr\Container\ContainerInterface|null
      */
-    public function getContainer(): ?\Psr\Container\ContainerInterface;
+    public function getContainer(): ?ContainerInterface;
 
     /**
      * Get the data domain array.

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -73,7 +73,7 @@ interface ConfigInterface extends ArrayAccess
      *
      * @return string
      */
-    public function getConfigFilePath(): string;
+    public function getConfigFilePath(): ?string;
 
     /**
      * Gets the paths to search for migration files.

--- a/src/Phinx/Config/NamespaceAwareInterface.php
+++ b/src/Phinx/Config/NamespaceAwareInterface.php
@@ -21,7 +21,7 @@ interface NamespaceAwareInterface
      * @param string $path Path
      * @return string|null
      */
-    public function getMigrationNamespaceByPath($path);
+    public function getMigrationNamespaceByPath(string $path): ?string;
 
     /**
      * Get Seed Namespace associated with path.
@@ -29,5 +29,5 @@ interface NamespaceAwareInterface
      * @param string $path Path
      * @return string|null
      */
-    public function getSeedNamespaceByPath($path);
+    public function getSeedNamespaceByPath(string $path): ?string;
 }

--- a/src/Phinx/Config/NamespaceAwareTrait.php
+++ b/src/Phinx/Config/NamespaceAwareTrait.php
@@ -20,14 +20,14 @@ trait NamespaceAwareTrait
      *
      * @return string[]
      */
-    abstract public function getMigrationPaths();
+    abstract public function getMigrationPaths(): array;
 
     /**
      * Gets the paths to search for seed files.
      *
      * @return string[]
      */
-    abstract public function getSeedPaths();
+    abstract public function getSeedPaths(): array;
 
     /**
      * Search $needle in $haystack and return key associate with him.
@@ -36,7 +36,7 @@ trait NamespaceAwareTrait
      * @param string[] $haystack Haystack
      * @return string|null
      */
-    protected function searchNamespace($needle, $haystack)
+    protected function searchNamespace(string $needle, array $haystack): ?string
     {
         $needle = realpath($needle);
         $haystack = array_map('realpath', $haystack);
@@ -52,7 +52,7 @@ trait NamespaceAwareTrait
      * @param string $path Path
      * @return string|null
      */
-    public function getMigrationNamespaceByPath($path)
+    public function getMigrationNamespaceByPath(string $path): ?string
     {
         $paths = $this->getMigrationPaths();
 
@@ -65,7 +65,7 @@ trait NamespaceAwareTrait
      * @param string $path Path
      * @return string|null
      */
-    public function getSeedNamespaceByPath($path)
+    public function getSeedNamespaceByPath(string $path): ?string
     {
         $paths = $this->getSeedPaths();
 

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -92,7 +92,7 @@ abstract class AbstractCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOption('--configuration', '-c', InputOption::VALUE_REQUIRED, 'The configuration file to load');
         $this->addOption('--parser', '-p', InputOption::VALUE_REQUIRED, 'Parser used to read the config file. Defaults to YAML');
@@ -105,7 +105,7 @@ abstract class AbstractCommand extends Command
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return void
      */
-    public function bootstrap(InputInterface $input, OutputInterface $output)
+    public function bootstrap(InputInterface $input, OutputInterface $output): void
     {
         /** @var \Phinx\Config\ConfigInterface|null $config */
         $config = $this->getConfig();
@@ -149,7 +149,7 @@ abstract class AbstractCommand extends Command
      * @param \Phinx\Config\ConfigInterface $config Config
      * @return $this
      */
-    public function setConfig(ConfigInterface $config)
+    public function setConfig(ConfigInterface $config): AbstractCommand
     {
         $this->config = $config;
 
@@ -161,7 +161,7 @@ abstract class AbstractCommand extends Command
      *
      * @return \Phinx\Config\ConfigInterface
      */
-    public function getConfig()
+    public function getConfig(): ConfigInterface
     {
         return $this->config;
     }
@@ -172,7 +172,7 @@ abstract class AbstractCommand extends Command
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Adapter
      * @return $this
      */
-    public function setAdapter(AdapterInterface $adapter)
+    public function setAdapter(AdapterInterface $adapter): AbstractCommand
     {
         $this->adapter = $adapter;
 
@@ -184,7 +184,7 @@ abstract class AbstractCommand extends Command
      *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function getAdapter()
+    public function getAdapter(): AdapterInterface
     {
         return $this->adapter;
     }
@@ -195,7 +195,7 @@ abstract class AbstractCommand extends Command
      * @param \Phinx\Migration\Manager $manager Manager
      * @return $this
      */
-    public function setManager(Manager $manager)
+    public function setManager(Manager $manager): AbstractCommand
     {
         $this->manager = $manager;
 
@@ -207,7 +207,7 @@ abstract class AbstractCommand extends Command
      *
      * @return \Phinx\Migration\Manager|null
      */
-    public function getManager()
+    public function getManager(): ?Manager
     {
         return $this->manager;
     }
@@ -218,7 +218,7 @@ abstract class AbstractCommand extends Command
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @return string
      */
-    protected function locateConfigFile(InputInterface $input)
+    protected function locateConfigFile(InputInterface $input): string
     {
         $configFile = $input->getOption('configuration');
 
@@ -260,7 +260,7 @@ abstract class AbstractCommand extends Command
      * @throws \InvalidArgumentException
      * @return void
      */
-    protected function loadConfig(InputInterface $input, OutputInterface $output)
+    protected function loadConfig(InputInterface $input, OutputInterface $output): void
     {
         $configFilePath = $this->locateConfigFile($input);
         $output->writeln('<info>using config file</info> ' . Util::relativePath($configFilePath));
@@ -313,7 +313,7 @@ abstract class AbstractCommand extends Command
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return void
      */
-    protected function loadManager(InputInterface $input, OutputInterface $output)
+    protected function loadManager(InputInterface $input, OutputInterface $output): void
     {
         if ($this->getManager() === null) {
             $manager = new Manager($this->getConfig(), $input, $output);
@@ -336,7 +336,7 @@ abstract class AbstractCommand extends Command
      * @throws \InvalidArgumentException
      * @return void
      */
-    protected function verifyMigrationDirectory($path)
+    protected function verifyMigrationDirectory(string $path): void
     {
         if (!is_dir($path)) {
             throw new InvalidArgumentException(sprintf(
@@ -360,7 +360,7 @@ abstract class AbstractCommand extends Command
      * @throws \InvalidArgumentException
      * @return void
      */
-    protected function verifySeedDirectory($path)
+    protected function verifySeedDirectory(string $path): void
     {
         if (!is_dir($path)) {
             throw new InvalidArgumentException(sprintf(
@@ -382,7 +382,7 @@ abstract class AbstractCommand extends Command
      *
      * @return string
      */
-    protected function getMigrationTemplateFilename()
+    protected function getMigrationTemplateFilename(): string
     {
         return __DIR__ . self::DEFAULT_MIGRATION_TEMPLATE;
     }
@@ -392,7 +392,7 @@ abstract class AbstractCommand extends Command
      *
      * @return string
      */
-    protected function getSeedTemplateFilename()
+    protected function getSeedTemplateFilename(): string
     {
         return __DIR__ . self::DEFAULT_SEED_TEMPLATE;
     }

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -149,7 +149,7 @@ abstract class AbstractCommand extends Command
      * @param \Phinx\Config\ConfigInterface $config Config
      * @return $this
      */
-    public function setConfig(ConfigInterface $config): AbstractCommand
+    public function setConfig(ConfigInterface $config)
     {
         $this->config = $config;
 
@@ -172,7 +172,7 @@ abstract class AbstractCommand extends Command
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Adapter
      * @return $this
      */
-    public function setAdapter(AdapterInterface $adapter): AbstractCommand
+    public function setAdapter(AdapterInterface $adapter)
     {
         $this->adapter = $adapter;
 
@@ -195,7 +195,7 @@ abstract class AbstractCommand extends Command
      * @param \Phinx\Migration\Manager $manager Manager
      * @return $this
      */
-    public function setManager(Manager $manager): AbstractCommand
+    public function setManager(Manager $manager)
     {
         $this->manager = $manager;
 

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -44,7 +44,7 @@ abstract class AbstractCommand extends Command
     protected const DEFAULT_SEED_TEMPLATE = '/../../Seed/Seed.template.php.dist';
 
     /**
-     * @var \Phinx\Config\ConfigInterface
+     * @var \Phinx\Config\ConfigInterface|null
      */
     protected $config;
 
@@ -107,7 +107,6 @@ abstract class AbstractCommand extends Command
      */
     public function bootstrap(InputInterface $input, OutputInterface $output): void
     {
-        /** @var \Phinx\Config\ConfigInterface|null $config */
         $config = $this->getConfig();
         if (!$config) {
             $this->loadConfig($input, $output);
@@ -159,9 +158,9 @@ abstract class AbstractCommand extends Command
     /**
      * Gets the config.
      *
-     * @return \Phinx\Config\ConfigInterface
+     * @return \Phinx\Config\ConfigInterface|null
      */
-    public function getConfig(): ConfigInterface
+    public function getConfig(): ?ConfigInterface
     {
         return $this->config;
     }

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -24,7 +24,7 @@ class Breakpoint extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -56,7 +56,7 @@ EOT
      * @throws \InvalidArgumentException
      * @return int integer 0 on success, or an error code.
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -36,7 +36,7 @@ class Create extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -65,7 +65,7 @@ class Create extends AbstractCommand
      *
      * @return \Symfony\Component\Console\Question\ConfirmationQuestion
      */
-    protected function getCreateMigrationDirectoryQuestion()
+    protected function getCreateMigrationDirectoryQuestion(): ConfirmationQuestion
     {
         return new ConfirmationQuestion('Create migrations directory? [y]/n ', true);
     }
@@ -76,7 +76,7 @@ class Create extends AbstractCommand
      * @param string[] $paths Paths
      * @return \Symfony\Component\Console\Question\ChoiceQuestion
      */
-    protected function getSelectMigrationPathQuestion(array $paths)
+    protected function getSelectMigrationPathQuestion(array $paths): ChoiceQuestion
     {
         return new ChoiceQuestion('Which migrations path would you like to use?', $paths, 0);
     }
@@ -89,7 +89,7 @@ class Create extends AbstractCommand
      * @throws \Exception
      * @return string
      */
-    protected function getMigrationPath(InputInterface $input, OutputInterface $output)
+    protected function getMigrationPath(InputInterface $input, OutputInterface $output): string
     {
         // First, try the non-interactive option:
         $path = $input->getOption('path');
@@ -136,7 +136,7 @@ class Create extends AbstractCommand
      * @throws \InvalidArgumentException
      * @return int 0 on success
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -201,7 +201,9 @@ class Create extends AbstractCommand
         }
 
         // Get the alternative template and static class options from the command line, but only allow one of them.
+        /** @var string|null */
         $altTemplate = $input->getOption('template');
+        /** @var string|null */
         $creationClassName = $input->getOption('class');
         if ($altTemplate && $creationClassName) {
             throw new InvalidArgumentException('Cannot use --template and --class at the same time');

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -201,9 +201,9 @@ class Create extends AbstractCommand
         }
 
         // Get the alternative template and static class options from the command line, but only allow one of them.
-        /** @var string|null */
+        /** @var string|null $altTemplate */
         $altTemplate = $input->getOption('template');
-        /** @var string|null */
+        /** @var string|null $creationClassName */
         $creationClassName = $input->getOption('class');
         if ($altTemplate && $creationClassName) {
             throw new InvalidArgumentException('Cannot use --template and --class at the same time');

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -38,7 +38,7 @@ class Init extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Initialize the application for Phinx')
             ->addOption(
@@ -63,7 +63,7 @@ class Init extends Command
      * @param \Symfony\Component\Console\Output\OutputInterface $output Interface implemented by all output classes.
      * @return int 0 on success
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $format = strtolower($input->getOption('format'));
         $path = $this->resolvePath($input, $format);
@@ -82,7 +82,7 @@ class Init extends Command
      * @throws \InvalidArgumentException
      * @return string
      */
-    protected function resolvePath(InputInterface $input, $format)
+    protected function resolvePath(InputInterface $input, string $format): string
     {
         // get the migration path from the config
         $path = (string)$input->getArgument('path');
@@ -134,7 +134,7 @@ class Init extends Command
      * @throws \RuntimeException
      * @return void
      */
-    protected function writeConfig($path, $format = AbstractCommand::FORMAT_DEFAULT)
+    protected function writeConfig(string $path, string $format = AbstractCommand::FORMAT_DEFAULT): void
     {
         // Check if dir is writable
         $dirname = dirname($path);

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -23,7 +23,7 @@ class ListAliases extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -38,7 +38,7 @@ class ListAliases extends AbstractCommand
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return int 0 on success
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -26,7 +26,7 @@ class Migrate extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -57,7 +57,7 @@ EOT
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return int integer 0 on success, or an error code.
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -25,7 +25,7 @@ class Rollback extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -65,7 +65,7 @@ EOT
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return int integer 0 on success, or an error code.
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 
@@ -136,7 +136,7 @@ EOT
      * @throws \InvalidArgumentException
      * @return string The target
      */
-    public function getTargetFromDate($date)
+    public function getTargetFromDate(string $date): string
     {
         if (!preg_match('/^\d{4,14}$/', $date)) {
             throw new InvalidArgumentException('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -31,7 +31,7 @@ class SeedCreate extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -54,7 +54,7 @@ class SeedCreate extends AbstractCommand
      *
      * @return \Symfony\Component\Console\Question\ConfirmationQuestion
      */
-    protected function getCreateSeedDirectoryQuestion()
+    protected function getCreateSeedDirectoryQuestion(): ConfirmationQuestion
     {
         return new ConfirmationQuestion('Create seeds directory? [y]/n ', true);
     }
@@ -65,7 +65,7 @@ class SeedCreate extends AbstractCommand
      * @param string[] $paths Paths
      * @return \Symfony\Component\Console\Question\ChoiceQuestion
      */
-    protected function getSelectSeedPathQuestion(array $paths)
+    protected function getSelectSeedPathQuestion(array $paths): ChoiceQuestion
     {
         return new ChoiceQuestion('Which seeds path would you like to use?', $paths, 0);
     }
@@ -78,7 +78,7 @@ class SeedCreate extends AbstractCommand
      * @throws \Exception
      * @return string
      */
-    protected function getSeedPath(InputInterface $input, OutputInterface $output)
+    protected function getSeedPath(InputInterface $input, OutputInterface $output): string
     {
         // First, try the non-interactive option:
         $path = $input->getOption('path');
@@ -125,7 +125,7 @@ class SeedCreate extends AbstractCommand
      * @throws \InvalidArgumentException
      * @return int 0 on success
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -23,7 +23,7 @@ class SeedRun extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -51,7 +51,7 @@ EOT
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return int integer 0 on success, or an error code.
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -23,7 +23,7 @@ class Status extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -50,7 +50,7 @@ EOT
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return int 0 if all migrations are up, or an error code
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -29,7 +29,7 @@ class Test extends AbstractCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -56,7 +56,7 @@ EOT
      * @throws \InvalidArgumentException
      * @return int 0 on success
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->loadConfig($input, $output);
         $this->loadManager($input, $output);

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -56,7 +56,7 @@ class PhinxApplication extends Application
      * @param \Symfony\Component\Console\Output\OutputInterface $output An Output instance
      * @return int 0 if everything went fine, or an error code
      */
-    public function doRun(InputInterface $input, OutputInterface $output)
+    public function doRun(InputInterface $input, OutputInterface $output): int
     {
         // always show the version information except when the user invokes the help
         // command as that already does it

--- a/src/Phinx/Db/Action/Action.php
+++ b/src/Phinx/Db/Action/Action.php
@@ -31,7 +31,7 @@ abstract class Action
      *
      * @return \Phinx\Db\Table\Table
      */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->table;
     }

--- a/src/Phinx/Db/Action/AddColumn.php
+++ b/src/Phinx/Db/Action/AddColumn.php
@@ -40,7 +40,7 @@ class AddColumn extends Action
      * @param mixed $options The column options
      * @return \Phinx\Db\Action\AddColumn
      */
-    public static function build(Table $table, $columnName, $type = null, $options = [])
+    public static function build(Table $table, string $columnName, $type = null, $options = []): AddColumn
     {
         $column = new Column();
         $column->setName($columnName);
@@ -55,7 +55,7 @@ class AddColumn extends Action
      *
      * @return \Phinx\Db\Table\Column
      */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }

--- a/src/Phinx/Db/Action/AddColumn.php
+++ b/src/Phinx/Db/Action/AddColumn.php
@@ -38,9 +38,9 @@ class AddColumn extends Action
      * @param string $columnName The column name
      * @param mixed $type The column type
      * @param array $options The column options
-     * @return self
+     * @return static
      */
-    public static function build(Table $table, string $columnName, $type = null, array $options = []): AddColumn
+    public static function build(Table $table, string $columnName, $type = null, array $options = [])
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/AddColumn.php
+++ b/src/Phinx/Db/Action/AddColumn.php
@@ -37,10 +37,10 @@ class AddColumn extends Action
      * @param \Phinx\Db\Table\Table $table The table to add the column to
      * @param string $columnName The column name
      * @param mixed $type The column type
-     * @param mixed $options The column options
+     * @param array $options The column options
      * @return self
      */
-    public static function build(Table $table, string $columnName, $type = null, $options = []): AddColumn
+    public static function build(Table $table, string $columnName, $type = null, array $options = []): AddColumn
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/AddColumn.php
+++ b/src/Phinx/Db/Action/AddColumn.php
@@ -38,7 +38,7 @@ class AddColumn extends Action
      * @param string $columnName The column name
      * @param mixed $type The column type
      * @param mixed $options The column options
-     * @return \Phinx\Db\Action\AddColumn
+     * @return self
      */
     public static function build(Table $table, string $columnName, $type = null, $options = []): AddColumn
     {

--- a/src/Phinx/Db/Action/AddForeignKey.php
+++ b/src/Phinx/Db/Action/AddForeignKey.php
@@ -43,7 +43,7 @@ class AddForeignKey extends Action
      * @param string|null $name The name of the foreign key
      * @return \Phinx\Db\Action\AddForeignKey
      */
-    public static function build(Table $table, $columns, $referencedTable, $referencedColumns = ['id'], array $options = [], $name = null)
+    public static function build(Table $table, $columns, $referencedTable, $referencedColumns = ['id'], array $options = [], ?string $name = null): AddForeignKey
     {
         if (is_string($referencedColumns)) {
             $referencedColumns = [$referencedColumns]; // str to array
@@ -71,7 +71,7 @@ class AddForeignKey extends Action
      *
      * @return \Phinx\Db\Table\ForeignKey
      */
-    public function getForeignKey()
+    public function getForeignKey(): ForeignKey
     {
         return $this->foreignKey;
     }

--- a/src/Phinx/Db/Action/AddForeignKey.php
+++ b/src/Phinx/Db/Action/AddForeignKey.php
@@ -41,7 +41,7 @@ class AddForeignKey extends Action
      * @param string|string[] $referencedColumns The columns in the referenced table
      * @param array $options Extra options for the foreign key
      * @param string|null $name The name of the foreign key
-     * @return \Phinx\Db\Action\AddForeignKey
+     * @return self
      */
     public static function build(Table $table, $columns, $referencedTable, $referencedColumns = ['id'], array $options = [], ?string $name = null): AddForeignKey
     {

--- a/src/Phinx/Db/Action/AddForeignKey.php
+++ b/src/Phinx/Db/Action/AddForeignKey.php
@@ -41,9 +41,9 @@ class AddForeignKey extends Action
      * @param string|string[] $referencedColumns The columns in the referenced table
      * @param array $options Extra options for the foreign key
      * @param string|null $name The name of the foreign key
-     * @return self
+     * @return static
      */
-    public static function build(Table $table, $columns, $referencedTable, $referencedColumns = ['id'], array $options = [], ?string $name = null): AddForeignKey
+    public static function build(Table $table, $columns, $referencedTable, $referencedColumns = ['id'], array $options = [], ?string $name = null)
     {
         if (is_string($referencedColumns)) {
             $referencedColumns = [$referencedColumns]; // str to array

--- a/src/Phinx/Db/Action/AddIndex.php
+++ b/src/Phinx/Db/Action/AddIndex.php
@@ -40,7 +40,7 @@ class AddIndex extends Action
      * @param array $options Additional options for the index creation
      * @return \Phinx\Db\Action\AddIndex
      */
-    public static function build(Table $table, $columns, array $options = [])
+    public static function build(Table $table, $columns, array $options = []): AddIndex
     {
         // create a new index object if strings or an array of strings were supplied
         $index = $columns;
@@ -64,7 +64,7 @@ class AddIndex extends Action
      *
      * @return \Phinx\Db\Table\Index
      */
-    public function getIndex()
+    public function getIndex(): Index
     {
         return $this->index;
     }

--- a/src/Phinx/Db/Action/AddIndex.php
+++ b/src/Phinx/Db/Action/AddIndex.php
@@ -48,10 +48,6 @@ class AddIndex extends Action
         if (!$columns instanceof Index) {
             $index = new Index();
 
-            if (is_string($columns)) {
-                $columns = [$columns]; // str to array
-            }
-
             $index->setColumns($columns);
             $index->setOptions($options);
         }

--- a/src/Phinx/Db/Action/AddIndex.php
+++ b/src/Phinx/Db/Action/AddIndex.php
@@ -38,7 +38,7 @@ class AddIndex extends Action
      * @param \Phinx\Db\Table\Table $table The table to add the index to
      * @param mixed $columns The columns to index
      * @param array $options Additional options for the index creation
-     * @return \Phinx\Db\Action\AddIndex
+     * @return self
      */
     public static function build(Table $table, $columns, array $options = []): AddIndex
     {

--- a/src/Phinx/Db/Action/AddIndex.php
+++ b/src/Phinx/Db/Action/AddIndex.php
@@ -38,9 +38,9 @@ class AddIndex extends Action
      * @param \Phinx\Db\Table\Table $table The table to add the index to
      * @param mixed $columns The columns to index
      * @param array $options Additional options for the index creation
-     * @return self
+     * @return static
      */
-    public static function build(Table $table, $columns, array $options = []): AddIndex
+    public static function build(Table $table, $columns, array $options = [])
     {
         // create a new index object if strings or an array of strings were supplied
         $index = $columns;

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -53,9 +53,9 @@ class ChangeColumn extends Action
      * @param string $columnName The name of the column to change
      * @param string|\Phinx\Db\Table\Column|\Phinx\Util\Literal $type The type of the column
      * @param array $options Additional options for the column
-     * @return self
+     * @return static
      */
-    public static function build(Table $table, string $columnName, $type = null, array $options = []): ChangeColumn
+    public static function build(Table $table, string $columnName, $type = null, array $options = [])
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -30,10 +30,10 @@ class ChangeColumn extends Action
      * Constructor
      *
      * @param \Phinx\Db\Table\Table $table The table to alter
-     * @param mixed $columnName The name fo the column to change
+     * @param string $columnName The name of the column to change
      * @param \Phinx\Db\Table\Column $column The column definition
      */
-    public function __construct(Table $table, $columnName, Column $column)
+    public function __construct(Table $table, string $columnName, Column $column)
     {
         parent::__construct($table);
         $this->columnName = $columnName;
@@ -55,7 +55,7 @@ class ChangeColumn extends Action
      * @param mixed $options Additional options for the column
      * @return \Phinx\Db\Action\ChangeColumn
      */
-    public static function build(Table $table, $columnName, $type = null, $options = [])
+    public static function build(Table $table, string $columnName, $type = null, $options = []): ChangeColumn
     {
         $column = new Column();
         $column->setName($columnName);
@@ -70,7 +70,7 @@ class ChangeColumn extends Action
      *
      * @return string
      */
-    public function getColumnName()
+    public function getColumnName(): string
     {
         return $this->columnName;
     }
@@ -80,7 +80,7 @@ class ChangeColumn extends Action
      *
      * @return \Phinx\Db\Table\Column
      */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -52,10 +52,10 @@ class ChangeColumn extends Action
      * @param \Phinx\Db\Table\Table $table The table to alter
      * @param mixed $columnName The name of the column to change
      * @param mixed $type The type of the column
-     * @param mixed $options Additional options for the column
+     * @param array $options Additional options for the column
      * @return self
      */
-    public static function build(Table $table, string $columnName, $type = null, $options = []): ChangeColumn
+    public static function build(Table $table, string $columnName, $type = null, array $options = []): ChangeColumn
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -53,7 +53,7 @@ class ChangeColumn extends Action
      * @param mixed $columnName The name of the column to change
      * @param mixed $type The type of the column
      * @param mixed $options Additional options for the column
-     * @return \Phinx\Db\Action\ChangeColumn
+     * @return self
      */
     public static function build(Table $table, string $columnName, $type = null, $options = []): ChangeColumn
     {

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -50,8 +50,8 @@ class ChangeColumn extends Action
      * out of the provided arguments
      *
      * @param \Phinx\Db\Table\Table $table The table to alter
-     * @param mixed $columnName The name of the column to change
-     * @param mixed $type The type of the column
+     * @param string $columnName The name of the column to change
+     * @param string|\Phinx\Db\Table\Column|\Phinx\Util\Literal $type The type of the column
      * @param array $options Additional options for the column
      * @return self
      */

--- a/src/Phinx/Db/Action/ChangeComment.php
+++ b/src/Phinx/Db/Action/ChangeComment.php
@@ -24,7 +24,7 @@ class ChangeComment extends Action
      * @param \Phinx\Db\Table\Table $table The table to be changed
      * @param string|null $newComment The new comment for the table
      */
-    public function __construct(Table $table, $newComment)
+    public function __construct(Table $table, ?string $newComment)
     {
         parent::__construct($table);
         $this->newComment = $newComment;
@@ -35,7 +35,7 @@ class ChangeComment extends Action
      *
      * @return string|null
      */
-    public function getNewComment()
+    public function getNewComment(): ?string
     {
         return $this->newComment;
     }

--- a/src/Phinx/Db/Action/DropForeignKey.php
+++ b/src/Phinx/Db/Action/DropForeignKey.php
@@ -38,9 +38,9 @@ class DropForeignKey extends Action
      * @param \Phinx\Db\Table\Table $table The table to delete the foreign key from
      * @param string|string[] $columns The columns participating in the foreign key
      * @param string|null $constraint The constraint name
-     * @return self
+     * @return static
      */
-    public static function build(Table $table, $columns, ?string $constraint = null): DropForeignKey
+    public static function build(Table $table, $columns, ?string $constraint = null)
     {
         if (is_string($columns)) {
             $columns = [$columns];

--- a/src/Phinx/Db/Action/DropForeignKey.php
+++ b/src/Phinx/Db/Action/DropForeignKey.php
@@ -38,7 +38,7 @@ class DropForeignKey extends Action
      * @param \Phinx\Db\Table\Table $table The table to delete the foreign key from
      * @param string|string[] $columns The columns participating in the foreign key
      * @param string|null $constraint The constraint name
-     * @return \Phinx\Db\Action\DropForeignKey
+     * @return self
      */
     public static function build(Table $table, $columns, ?string $constraint = null): DropForeignKey
     {

--- a/src/Phinx/Db/Action/DropForeignKey.php
+++ b/src/Phinx/Db/Action/DropForeignKey.php
@@ -40,7 +40,7 @@ class DropForeignKey extends Action
      * @param string|null $constraint The constraint name
      * @return \Phinx\Db\Action\DropForeignKey
      */
-    public static function build(Table $table, $columns, $constraint = null)
+    public static function build(Table $table, $columns, ?string $constraint = null): DropForeignKey
     {
         if (is_string($columns)) {
             $columns = [$columns];
@@ -61,7 +61,7 @@ class DropForeignKey extends Action
      *
      * @return \Phinx\Db\Table\ForeignKey
      */
-    public function getForeignKey()
+    public function getForeignKey(): ForeignKey
     {
         return $this->foreignKey;
     }

--- a/src/Phinx/Db/Action/DropIndex.php
+++ b/src/Phinx/Db/Action/DropIndex.php
@@ -37,9 +37,9 @@ class DropIndex extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the index is
      * @param string[] $columns the indexed columns
-     * @return \Phinx\Db\Action\DropIndex
+     * @return self
      */
-    public static function build(Table $table, array $columns = []): DropIndex
+    public static function build(Table $table, array $columns = [])
     {
         $index = new Index();
         $index->setColumns($columns);
@@ -53,9 +53,9 @@ class DropIndex extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the index is
      * @param string $name The name of the index
-     * @return \Phinx\Db\Action\DropIndex
+     * @return self
      */
-    public static function buildFromName(Table $table, string $name): DropIndex
+    public static function buildFromName(Table $table, string $name)
     {
         $index = new Index();
         $index->setName($name);

--- a/src/Phinx/Db/Action/DropIndex.php
+++ b/src/Phinx/Db/Action/DropIndex.php
@@ -37,7 +37,7 @@ class DropIndex extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the index is
      * @param string[] $columns the indexed columns
-     * @return self
+     * @return static
      */
     public static function build(Table $table, array $columns = [])
     {
@@ -53,7 +53,7 @@ class DropIndex extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the index is
      * @param string $name The name of the index
-     * @return self
+     * @return static
      */
     public static function buildFromName(Table $table, string $name)
     {

--- a/src/Phinx/Db/Action/DropIndex.php
+++ b/src/Phinx/Db/Action/DropIndex.php
@@ -39,7 +39,7 @@ class DropIndex extends Action
      * @param string[] $columns the indexed columns
      * @return \Phinx\Db\Action\DropIndex
      */
-    public static function build(Table $table, array $columns = [])
+    public static function build(Table $table, array $columns = []): DropIndex
     {
         $index = new Index();
         $index->setColumns($columns);
@@ -55,7 +55,7 @@ class DropIndex extends Action
      * @param string $name The name of the index
      * @return \Phinx\Db\Action\DropIndex
      */
-    public static function buildFromName(Table $table, $name)
+    public static function buildFromName(Table $table, string $name): DropIndex
     {
         $index = new Index();
         $index->setName($name);
@@ -68,7 +68,7 @@ class DropIndex extends Action
      *
      * @return \Phinx\Db\Table\Index
      */
-    public function getIndex()
+    public function getIndex(): Index
     {
         return $this->index;
     }

--- a/src/Phinx/Db/Action/RemoveColumn.php
+++ b/src/Phinx/Db/Action/RemoveColumn.php
@@ -36,10 +36,10 @@ class RemoveColumn extends Action
      * passed arguments.
      *
      * @param \Phinx\Db\Table\Table $table The table where the column is
-     * @param mixed $columnName The name of the column to drop
+     * @param string $columnName The name of the column to drop
      * @return \Phinx\Db\Action\RemoveColumn
      */
-    public static function build(Table $table, $columnName)
+    public static function build(Table $table, string $columnName): RemoveColumn
     {
         $column = new Column();
         $column->setName($columnName);
@@ -52,7 +52,7 @@ class RemoveColumn extends Action
      *
      * @return \Phinx\Db\Table\Column
      */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }

--- a/src/Phinx/Db/Action/RemoveColumn.php
+++ b/src/Phinx/Db/Action/RemoveColumn.php
@@ -37,7 +37,7 @@ class RemoveColumn extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the column is
      * @param string $columnName The name of the column to drop
-     * @return \Phinx\Db\Action\RemoveColumn
+     * @return self
      */
     public static function build(Table $table, string $columnName): RemoveColumn
     {

--- a/src/Phinx/Db/Action/RemoveColumn.php
+++ b/src/Phinx/Db/Action/RemoveColumn.php
@@ -37,9 +37,9 @@ class RemoveColumn extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the column is
      * @param string $columnName The name of the column to drop
-     * @return self
+     * @return static
      */
-    public static function build(Table $table, string $columnName): RemoveColumn
+    public static function build(Table $table, string $columnName)
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/RenameColumn.php
+++ b/src/Phinx/Db/Action/RenameColumn.php
@@ -31,9 +31,9 @@ class RenameColumn extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table where the column is
      * @param \Phinx\Db\Table\Column $column The column to be renamed
-     * @param mixed $newName The new name for the column
+     * @param string $newName The new name for the column
      */
-    public function __construct(Table $table, Column $column, $newName)
+    public function __construct(Table $table, Column $column, string $newName)
     {
         parent::__construct($table);
         $this->newName = $newName;
@@ -49,7 +49,7 @@ class RenameColumn extends Action
      * @param mixed $newName The new name for the column
      * @return \Phinx\Db\Action\RenameColumn
      */
-    public static function build(Table $table, $columnName, $newName)
+    public static function build(Table $table, string $columnName, string $newName): RenameColumn
     {
         $column = new Column();
         $column->setName($columnName);
@@ -62,7 +62,7 @@ class RenameColumn extends Action
      *
      * @return \Phinx\Db\Table\Column
      */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }
@@ -72,7 +72,7 @@ class RenameColumn extends Action
      *
      * @return string
      */
-    public function getNewName()
+    public function getNewName(): string
     {
         return $this->newName;
     }

--- a/src/Phinx/Db/Action/RenameColumn.php
+++ b/src/Phinx/Db/Action/RenameColumn.php
@@ -47,7 +47,7 @@ class RenameColumn extends Action
      * @param \Phinx\Db\Table\Table $table The table where the column is
      * @param mixed $columnName The name of the column to be changed
      * @param mixed $newName The new name for the column
-     * @return \Phinx\Db\Action\RenameColumn
+     * @return self
      */
     public static function build(Table $table, string $columnName, string $newName): RenameColumn
     {

--- a/src/Phinx/Db/Action/RenameColumn.php
+++ b/src/Phinx/Db/Action/RenameColumn.php
@@ -47,9 +47,9 @@ class RenameColumn extends Action
      * @param \Phinx\Db\Table\Table $table The table where the column is
      * @param string $columnName The name of the column to be changed
      * @param string $newName The new name for the column
-     * @return self
+     * @return static
      */
-    public static function build(Table $table, string $columnName, string $newName): RenameColumn
+    public static function build(Table $table, string $columnName, string $newName)
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/RenameColumn.php
+++ b/src/Phinx/Db/Action/RenameColumn.php
@@ -45,8 +45,8 @@ class RenameColumn extends Action
      * arguments
      *
      * @param \Phinx\Db\Table\Table $table The table where the column is
-     * @param mixed $columnName The name of the column to be changed
-     * @param mixed $newName The new name for the column
+     * @param string $columnName The name of the column to be changed
+     * @param string $newName The new name for the column
      * @return self
      */
     public static function build(Table $table, string $columnName, string $newName): RenameColumn

--- a/src/Phinx/Db/Action/RenameTable.php
+++ b/src/Phinx/Db/Action/RenameTable.php
@@ -22,9 +22,9 @@ class RenameTable extends Action
      * Constructor
      *
      * @param \Phinx\Db\Table\Table $table The table to be renamed
-     * @param mixed $newName The new name for the table
+     * @param string $newName The new name for the table
      */
-    public function __construct(Table $table, $newName)
+    public function __construct(Table $table, string $newName)
     {
         parent::__construct($table);
         $this->newName = $newName;
@@ -35,7 +35,7 @@ class RenameTable extends Action
      *
      * @return string
      */
-    public function getNewName()
+    public function getNewName(): string
     {
         return $this->newName;
     }

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -29,7 +29,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input = null;
+    protected $input;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -27,9 +27,9 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $options = [];
 
     /**
-     * @var \Symfony\Component\Console\Input\InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input;
+    protected $input = null;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface
@@ -135,7 +135,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function getInput(): InputInterface
+    public function getInput(): ?InputInterface
     {
         return $this->input;
     }

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -72,7 +72,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): AdapterInterface
     {
         $this->options = $options;
 
@@ -97,7 +97,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
@@ -105,7 +105,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function hasOption($name)
+    public function hasOption(string $name): bool
     {
         return isset($this->options[$name]);
     }
@@ -113,7 +113,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function getOption($name)
+    public function getOption(string $name)
     {
         if (!$this->hasOption($name)) {
             return null;
@@ -125,7 +125,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function setInput(InputInterface $input)
+    public function setInput(InputInterface $input): AdapterInterface
     {
         $this->input = $input;
 
@@ -135,7 +135,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function getInput()
+    public function getInput(): InputInterface
     {
         return $this->input;
     }
@@ -143,7 +143,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function setOutput(OutputInterface $output)
+    public function setOutput(OutputInterface $output): AdapterInterface
     {
         $this->output = $output;
 
@@ -153,7 +153,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         if ($this->output === null) {
             $output = new NullOutput();
@@ -167,7 +167,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @inheritDoc
      * @return array
      */
-    public function getVersions()
+    public function getVersions(): array
     {
         $rows = $this->getVersionLog();
 
@@ -179,7 +179,7 @@ abstract class AbstractAdapter implements AdapterInterface
      *
      * @return string
      */
-    public function getSchemaTableName()
+    public function getSchemaTableName(): string
     {
         return $this->schemaTableName;
     }
@@ -190,7 +190,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $schemaTableName Schema Table Name
      * @return $this
      */
-    public function setSchemaTableName($schemaTableName)
+    public function setSchemaTableName(string $schemaTableName)
     {
         $this->schemaTableName = $schemaTableName;
 
@@ -202,7 +202,7 @@ abstract class AbstractAdapter implements AdapterInterface
      *
      * @return array
      */
-    public function getDataDomain()
+    public function getDataDomain(): array
     {
         return $this->dataDomain;
     }
@@ -276,7 +276,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritdoc
      */
-    public function getColumnForType($columnName, $type, array $options)
+    public function getColumnForType(string $columnName, string $type, array $options): Column
     {
         $column = new Column();
         $column->setName($columnName);
@@ -298,7 +298,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function createSchemaTable()
+    public function createSchemaTable(): void
     {
         try {
             $options = [
@@ -325,7 +325,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function getAdapterType()
+    public function getAdapterType(): string
     {
         return $this->getOption('adapter');
     }
@@ -333,7 +333,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function isValidColumnType(Column $column)
+    public function isValidColumnType(Column $column): bool
     {
         return $column->getType() instanceof Literal || in_array($column->getType(), $this->getColumnTypes(), true);
     }
@@ -343,7 +343,7 @@ abstract class AbstractAdapter implements AdapterInterface
      *
      * @return bool
      */
-    public function isDryRunEnabled()
+    public function isDryRunEnabled(): bool
     {
         /** @var \Symfony\Component\Console\Input\InputInterface|null $input */
         $input = $this->getInput();
@@ -357,7 +357,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $tableName The name of the table
      * @return void
      */
-    protected function addCreatedTable($tableName)
+    protected function addCreatedTable(string $tableName): void
     {
         $tableName = $this->quoteTableName($tableName);
         if (substr_compare($tableName, 'phinxlog', -strlen('phinxlog')) !== 0) {
@@ -372,7 +372,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $newTableName New name of the table
      * @return void
      */
-    protected function updateCreatedTableName($tableName, $newTableName)
+    protected function updateCreatedTableName(string $tableName, string $newTableName): void
     {
         $tableName = $this->quoteTableName($tableName);
         $newTableName = $this->quoteTableName($newTableName);
@@ -388,7 +388,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $tableName The name of the table
      * @return void
      */
-    protected function removeCreatedTable($tableName)
+    protected function removeCreatedTable(string $tableName): void
     {
         $tableName = $this->quoteTableName($tableName);
         $key = array_search($tableName, $this->createdTables, true);
@@ -403,7 +403,7 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param string $tableName The name of the table
      * @return bool
      */
-    protected function hasCreatedTable($tableName)
+    protected function hasCreatedTable(string $tableName): bool
     {
         $tableName = $this->quoteTableName($tableName);
 

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -26,9 +26,9 @@ class AdapterFactory
     /**
      * Get the factory singleton instance.
      *
-     * @return self
+     * @return \Phinx\Db\Adapter\AdapterFactory
      */
-    public static function instance(): AdapterFactory
+    public static function instance()
     {
         if (!static::$instance) {
             static::$instance = new static();
@@ -61,7 +61,7 @@ class AdapterFactory
     ];
 
     /**
-     * Add or replace an adapter with a fully qualified class name.
+     * Register an adapter class with a given name.
      *
      * @param string $name Name
      * @param object|string $class Class

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -140,7 +140,7 @@ class AdapterFactory
      *
      * @param string $name Name
      * @throws \RuntimeException
-     * @return string|object
+     * @return object|string
      */
     protected function getWrapperClass(string $name)
     {

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -64,11 +64,11 @@ class AdapterFactory
      * Add or replace an adapter with a fully qualified class name.
      *
      * @param string $name Name
-     * @param string $class Class
+     * @param object $class Class
      * @throws \RuntimeException
      * @return $this
      */
-    public function registerAdapter(string $name, string $class)
+    public function registerAdapter(string $name, $class)
     {
         if (!is_subclass_of($class, 'Phinx\Db\Adapter\AdapterInterface')) {
             throw new RuntimeException(sprintf(
@@ -86,9 +86,9 @@ class AdapterFactory
      *
      * @param string $name Name
      * @throws \RuntimeException
-     * @return string
+     * @return object
      */
-    protected function getClass(string $name): string
+    protected function getClass(string $name)
     {
         if (empty($this->adapters[$name])) {
             throw new RuntimeException(sprintf(

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -40,7 +40,7 @@ class AdapterFactory
     /**
      * Class map of database adapters, indexed by PDO::ATTR_DRIVER_NAME.
      *
-     * @var string[]
+     * @var (object|string)[]
      */
     protected $adapters = [
         'mysql' => 'Phinx\Db\Adapter\MysqlAdapter',
@@ -52,7 +52,7 @@ class AdapterFactory
     /**
      * Class map of adapters wrappers, indexed by name.
      *
-     * @var string[]
+     * @var (string|object)[]
      */
     protected $wrappers = [
         'prefix' => 'Phinx\Db\Adapter\TablePrefixAdapter',
@@ -64,7 +64,7 @@ class AdapterFactory
      * Add or replace an adapter with a fully qualified class name.
      *
      * @param string $name Name
-     * @param object $class Class
+     * @param string|object $class Class
      * @throws \RuntimeException
      * @return $this
      */
@@ -73,7 +73,7 @@ class AdapterFactory
         if (!is_subclass_of($class, 'Phinx\Db\Adapter\AdapterInterface')) {
             throw new RuntimeException(sprintf(
                 'Adapter class "%s" must implement Phinx\\Db\\Adapter\\AdapterInterface',
-                $class
+                is_string($class) ? $class : get_class($class)
             ));
         }
         $this->adapters[$name] = $class;
@@ -118,16 +118,16 @@ class AdapterFactory
      * Add or replace a wrapper with a fully qualified class name.
      *
      * @param string $name Name
-     * @param string $class Class
+     * @param string|object $class Class
      * @throws \RuntimeException
      * @return $this
      */
-    public function registerWrapper(string $name, string $class)
+    public function registerWrapper(string $name, $class)
     {
         if (!is_subclass_of($class, 'Phinx\Db\Adapter\WrapperInterface')) {
             throw new RuntimeException(sprintf(
                 'Wrapper class "%s" must be implement Phinx\\Db\\Adapter\\WrapperInterface',
-                $class
+                is_string($class) ? $class : get_class($class)
             ));
         }
         $this->wrappers[$name] = $class;
@@ -140,9 +140,9 @@ class AdapterFactory
      *
      * @param string $name Name
      * @throws \RuntimeException
-     * @return string
+     * @return string|object
      */
-    protected function getWrapperClass(string $name): string
+    protected function getWrapperClass(string $name)
     {
         if (empty($this->wrappers[$name])) {
             throw new RuntimeException(sprintf(

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -52,7 +52,7 @@ class AdapterFactory
     /**
      * Class map of adapters wrappers, indexed by name.
      *
-     * @var (string|object)[]
+     * @var array<object|string>
      */
     protected $wrappers = [
         'prefix' => 'Phinx\Db\Adapter\TablePrefixAdapter',
@@ -64,7 +64,7 @@ class AdapterFactory
      * Add or replace an adapter with a fully qualified class name.
      *
      * @param string $name Name
-     * @param string|object $class Class
+     * @param object|string $class Class
      * @throws \RuntimeException
      * @return $this
      */
@@ -118,7 +118,7 @@ class AdapterFactory
      * Add or replace a wrapper with a fully qualified class name.
      *
      * @param string $name Name
-     * @param string|object $class Class
+     * @param object|string $class Class
      * @throws \RuntimeException
      * @return $this
      */

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -26,9 +26,9 @@ class AdapterFactory
     /**
      * Get the factory singleton instance.
      *
-     * @return \Phinx\Db\Adapter\AdapterFactory
+     * @return self
      */
-    public static function instance()
+    public static function instance(): AdapterFactory
     {
         if (!static::$instance) {
             static::$instance = new static();
@@ -68,7 +68,7 @@ class AdapterFactory
      * @throws \RuntimeException
      * @return $this
      */
-    public function registerAdapter($name, $class)
+    public function registerAdapter(string $name, string $class)
     {
         if (!is_subclass_of($class, 'Phinx\Db\Adapter\AdapterInterface')) {
             throw new RuntimeException(sprintf(
@@ -88,7 +88,7 @@ class AdapterFactory
      * @throws \RuntimeException
      * @return string
      */
-    protected function getClass($name)
+    protected function getClass(string $name): string
     {
         if (empty($this->adapters[$name])) {
             throw new RuntimeException(sprintf(
@@ -107,7 +107,7 @@ class AdapterFactory
      * @param array $options Options
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function getAdapter($name, array $options)
+    public function getAdapter(string $name, array $options): AdapterInterface
     {
         $class = $this->getClass($name);
 
@@ -122,7 +122,7 @@ class AdapterFactory
      * @throws \RuntimeException
      * @return $this
      */
-    public function registerWrapper($name, $class)
+    public function registerWrapper(string $name, string $class)
     {
         if (!is_subclass_of($class, 'Phinx\Db\Adapter\WrapperInterface')) {
             throw new RuntimeException(sprintf(
@@ -142,7 +142,7 @@ class AdapterFactory
      * @throws \RuntimeException
      * @return string
      */
-    protected function getWrapperClass($name)
+    protected function getWrapperClass(string $name): string
     {
         if (empty($this->wrappers[$name])) {
             throw new RuntimeException(sprintf(
@@ -161,7 +161,7 @@ class AdapterFactory
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Adapter
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function getWrapper($name, AdapterInterface $adapter)
+    public function getWrapper(string $name, AdapterInterface $adapter): AdapterInterface
     {
         $class = $this->getWrapperClass($name);
 

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -438,10 +438,10 @@ interface AdapterInterface
      * Converts the Phinx logical type to the adapter's SQL type.
      *
      * @param string|\Phinx\Util\Literal $type Type
-     * @param int|null $limit Limit
+     * @param float|null $limit Limit
      * @return array
      */
-    public function getSqlType($type, ?int $limit = null): array;
+    public function getSqlType($type, ?float $limit = null): array;
 
     /**
      * Creates a new database.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -124,9 +124,9 @@ interface AdapterInterface
     /**
      * Gets the console input.
      *
-     * @return \Symfony\Component\Console\Input\InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface|null
      */
-    public function getInput(): InputInterface;
+    public function getInput(): ?InputInterface;
 
     /**
      * Sets the console output.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -72,7 +72,7 @@ interface AdapterInterface
      *
      * @return array
      */
-    public function getVersions();
+    public function getVersions(): array;
 
     /**
      * Get all migration log entries, indexed by version creation time and sorted ascendingly by the configuration's
@@ -80,22 +80,22 @@ interface AdapterInterface
      *
      * @return array
      */
-    public function getVersionLog();
+    public function getVersionLog(): array;
 
     /**
      * Set adapter configuration options.
      *
      * @param array $options Options
-     * @return \Phinx\Db\Adapter\AdapterInterface
+     * @return $this
      */
-    public function setOptions(array $options);
+    public function setOptions(array $options): AdapterInterface;
 
     /**
      * Get all adapter options.
      *
      * @return array
      */
-    public function getOptions();
+    public function getOptions(): array;
 
     /**
      * Check if an option has been set.
@@ -103,7 +103,7 @@ interface AdapterInterface
      * @param string $name Name
      * @return bool
      */
-    public function hasOption($name);
+    public function hasOption(string $name): bool;
 
     /**
      * Get a single adapter option, or null if the option does not exist.
@@ -111,37 +111,37 @@ interface AdapterInterface
      * @param string $name Name
      * @return mixed
      */
-    public function getOption($name);
+    public function getOption(string $name);
 
     /**
      * Sets the console input.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     * @return \Phinx\Db\Adapter\AdapterInterface
+     * @return $this
      */
-    public function setInput(InputInterface $input);
+    public function setInput(InputInterface $input): AdapterInterface;
 
     /**
      * Gets the console input.
      *
      * @return \Symfony\Component\Console\Input\InputInterface
      */
-    public function getInput();
+    public function getInput(): InputInterface;
 
     /**
      * Sets the console output.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return \Phinx\Db\Adapter\AdapterInterface
+     * @return $this
      */
-    public function setOutput(OutputInterface $output);
+    public function setOutput(OutputInterface $output): AdapterInterface;
 
     /**
      * Gets the console output.
      *
      * @return \Symfony\Component\Console\Output\OutputInterface
      */
-    public function getOutput();
+    public function getOutput(): OutputInterface;
 
     /**
      * Returns a new Phinx\Db\Table\Column using the existent data domain.
@@ -151,7 +151,7 @@ interface AdapterInterface
      * @param array $options Options array
      * @return \Phinx\Db\Table\Column
      */
-    public function getColumnForType($columnName, $type, array $options);
+    public function getColumnForType(string $columnName, string $type, array $options): Column;
 
     /**
      * Records a migration being run.
@@ -160,54 +160,54 @@ interface AdapterInterface
      * @param string $direction Direction
      * @param string $startTime Start Time
      * @param string $endTime End Time
-     * @return \Phinx\Db\Adapter\AdapterInterface
+     * @return $this
      */
-    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime);
+    public function migrated(MigrationInterface $migration, string $direction, string $startTime, string $endTime): AdapterInterface;
 
     /**
      * Toggle a migration breakpoint.
      *
      * @param \Phinx\Migration\MigrationInterface $migration Migration
-     * @return \Phinx\Db\Adapter\AdapterInterface
+     * @return $this
      */
-    public function toggleBreakpoint(MigrationInterface $migration);
+    public function toggleBreakpoint(MigrationInterface $migration): AdapterInterface;
 
     /**
      * Reset all migration breakpoints.
      *
      * @return int The number of breakpoints reset
      */
-    public function resetAllBreakpoints();
+    public function resetAllBreakpoints(): int;
 
     /**
      * Set a migration breakpoint.
      *
      * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint set
-     * @return \Phinx\Db\Adapter\AdapterInterface
+     * @return $this
      */
-    public function setBreakpoint(MigrationInterface $migration);
+    public function setBreakpoint(MigrationInterface $migration): AdapterInterface;
 
     /**
      * Unset a migration breakpoint.
      *
      * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint unset
-     * @return \Phinx\Db\Adapter\AdapterInterface
+     * @return $this
      */
-    public function unsetBreakpoint(MigrationInterface $migration);
+    public function unsetBreakpoint(MigrationInterface $migration): AdapterInterface;
 
     /**
      * Creates the schema table.
      *
      * @return void
      */
-    public function createSchemaTable();
+    public function createSchemaTable(): void;
 
     /**
      * Returns the adapter type.
      *
      * @return string
      */
-    public function getAdapterType();
+    public function getAdapterType(): string;
 
     /**
      * Initializes the database connection.
@@ -215,42 +215,42 @@ interface AdapterInterface
      * @throws \RuntimeException When the requested database driver is not installed.
      * @return void
      */
-    public function connect();
+    public function connect(): void;
 
     /**
      * Closes the database connection.
      *
      * @return void
      */
-    public function disconnect();
+    public function disconnect(): void;
 
     /**
      * Does the adapter support transactions?
      *
      * @return bool
      */
-    public function hasTransactions();
+    public function hasTransactions(): bool;
 
     /**
      * Begin a transaction.
      *
      * @return void
      */
-    public function beginTransaction();
+    public function beginTransaction(): void;
 
     /**
      * Commit a transaction.
      *
      * @return void
      */
-    public function commitTransaction();
+    public function commitTransaction(): void;
 
     /**
      * Rollback a transaction.
      *
      * @return void
      */
-    public function rollbackTransaction();
+    public function rollbackTransaction(): void;
 
     /**
      * Executes a SQL statement and returns the number of affected rows.
@@ -259,7 +259,7 @@ interface AdapterInterface
      * @param array $params parameters to use for prepared query
      * @return int
      */
-    public function execute($sql, array $params = []);
+    public function execute(string $sql, array $params = []): int;
 
     /**
      * Executes a list of migration actions for the given table
@@ -268,14 +268,14 @@ interface AdapterInterface
      * @param \Phinx\Db\Action\Action[] $actions The table to execute the actions for
      * @return void
      */
-    public function executeActions(Table $table, array $actions);
+    public function executeActions(Table $table, array $actions): void;
 
     /**
      * Returns a new Query object
      *
      * @return \Cake\Database\Query
      */
-    public function getQueryBuilder();
+    public function getQueryBuilder(): \Cake\Database\Query;
 
     /**
      * Executes a SQL statement.
@@ -286,7 +286,7 @@ interface AdapterInterface
      * @param array $params parameters to use for prepared query
      * @return mixed
      */
-    public function query($sql, array $params = []);
+    public function query(string $sql, array $params = []);
 
     /**
      * Executes a query and returns only one row as an array.
@@ -294,7 +294,7 @@ interface AdapterInterface
      * @param string $sql SQL
      * @return array|false
      */
-    public function fetchRow($sql);
+    public function fetchRow(string $sql);
 
     /**
      * Executes a query and returns an array of rows.
@@ -302,7 +302,7 @@ interface AdapterInterface
      * @param string $sql SQL
      * @return array
      */
-    public function fetchAll($sql);
+    public function fetchAll(string $sql): array;
 
     /**
      * Inserts data into a table.
@@ -311,7 +311,7 @@ interface AdapterInterface
      * @param array $row Row
      * @return void
      */
-    public function insert(Table $table, $row);
+    public function insert(Table $table, array $row): void;
 
     /**
      * Inserts data into a table in a bulk.
@@ -320,7 +320,7 @@ interface AdapterInterface
      * @param array $rows Rows
      * @return void
      */
-    public function bulkinsert(Table $table, $rows);
+    public function bulkinsert(Table $table, array $rows): void;
 
     /**
      * Quotes a table name for use in a query.
@@ -328,7 +328,7 @@ interface AdapterInterface
      * @param string $tableName Table name
      * @return string
      */
-    public function quoteTableName($tableName);
+    public function quoteTableName(string $tableName): string;
 
     /**
      * Quotes a column name for use in a query.
@@ -336,7 +336,7 @@ interface AdapterInterface
      * @param string $columnName Table name
      * @return string
      */
-    public function quoteColumnName($columnName);
+    public function quoteColumnName(string $columnName): string;
 
     /**
      * Checks to see if a table exists.
@@ -344,7 +344,7 @@ interface AdapterInterface
      * @param string $tableName Table name
      * @return bool
      */
-    public function hasTable($tableName);
+    public function hasTable(string $tableName): bool;
 
     /**
      * Creates the specified database table.
@@ -354,7 +354,7 @@ interface AdapterInterface
      * @param \Phinx\Db\Table\Index[] $indexes List of indexes for the table
      * @return void
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []);
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void;
 
     /**
      * Truncates the specified table
@@ -362,7 +362,7 @@ interface AdapterInterface
      * @param string $tableName Table name
      * @return void
      */
-    public function truncateTable($tableName);
+    public function truncateTable(string $tableName): void;
 
     /**
      * Returns table columns
@@ -370,7 +370,7 @@ interface AdapterInterface
      * @param string $tableName Table name
      * @return \Phinx\Db\Table\Column[]
      */
-    public function getColumns($tableName);
+    public function getColumns(string $tableName): array;
 
     /**
      * Checks to see if a column exists.
@@ -379,7 +379,7 @@ interface AdapterInterface
      * @param string $columnName Column name
      * @return bool
      */
-    public function hasColumn($tableName, $columnName);
+    public function hasColumn(string $tableName, string $columnName): bool;
 
     /**
      * Checks to see if an index exists.
@@ -388,7 +388,7 @@ interface AdapterInterface
      * @param string|string[] $columns Column(s)
      * @return bool
      */
-    public function hasIndex($tableName, $columns);
+    public function hasIndex(string $tableName, $columns): bool;
 
     /**
      * Checks to see if an index specified by name exists.
@@ -397,7 +397,7 @@ interface AdapterInterface
      * @param string $indexName Index name
      * @return bool
      */
-    public function hasIndexByName($tableName, $indexName);
+    public function hasIndexByName(string $tableName, string $indexName): bool;
 
     /**
      * Checks to see if the specified primary key exists.
@@ -407,7 +407,7 @@ interface AdapterInterface
      * @param string|null $constraint Constraint name
      * @return bool
      */
-    public function hasPrimaryKey($tableName, $columns, $constraint = null);
+    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool;
 
     /**
      * Checks to see if a foreign key exists.
@@ -417,14 +417,14 @@ interface AdapterInterface
      * @param string|null $constraint Constraint name
      * @return bool
      */
-    public function hasForeignKey($tableName, $columns, $constraint = null);
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool;
 
     /**
      * Returns an array of the supported Phinx column types.
      *
      * @return string[]
      */
-    public function getColumnTypes();
+    public function getColumnTypes(): array;
 
     /**
      * Checks that the given column is of a supported type.
@@ -432,7 +432,7 @@ interface AdapterInterface
      * @param \Phinx\Db\Table\Column $column Column
      * @return bool
      */
-    public function isValidColumnType(Column $column);
+    public function isValidColumnType(Column $column): bool;
 
     /**
      * Converts the Phinx logical type to the adapter's SQL type.
@@ -441,7 +441,7 @@ interface AdapterInterface
      * @param int|null $limit Limit
      * @return array
      */
-    public function getSqlType($type, $limit = null);
+    public function getSqlType(string $type, ?int $limit = null): array;
 
     /**
      * Creates a new database.
@@ -450,7 +450,7 @@ interface AdapterInterface
      * @param array $options Options
      * @return void
      */
-    public function createDatabase($name, $options = []);
+    public function createDatabase(string $name, array $options = []): void;
 
     /**
      * Checks to see if a database exists.
@@ -458,7 +458,7 @@ interface AdapterInterface
      * @param string $name Database Name
      * @return bool
      */
-    public function hasDatabase($name);
+    public function hasDatabase(string $name): bool;
 
     /**
      * Drops the specified database.
@@ -466,7 +466,7 @@ interface AdapterInterface
      * @param string $name Database Name
      * @return void
      */
-    public function dropDatabase($name);
+    public function dropDatabase(string $name): void;
 
     /**
      * Creates the specified schema or throws an exception
@@ -475,7 +475,7 @@ interface AdapterInterface
      * @param string $schemaName Schema Name
      * @return void
      */
-    public function createSchema($schemaName = 'public');
+    public function createSchema(string $schemaName = 'public'): void;
 
     /**
      * Drops the specified schema table or throws an exception
@@ -484,7 +484,7 @@ interface AdapterInterface
      * @param string $schemaName Schema name
      * @return void
      */
-    public function dropSchema($schemaName);
+    public function dropSchema(string $schemaName): void;
 
     /**
      * Cast a value to a boolean appropriate for the adapter.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -437,7 +437,7 @@ interface AdapterInterface
     /**
      * Converts the Phinx logical type to the adapter's SQL type.
      *
-     * @param string|\Phinx\Util\Literal $type Type
+     * @param \Phinx\Util\Literal|string $type Type
      * @param float|null $limit Limit
      * @return array
      */

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -7,6 +7,7 @@
 
 namespace Phinx\Db\Adapter;
 
+use Cake\Database\Query;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
 use Phinx\Migration\MigrationInterface;
@@ -88,7 +89,7 @@ interface AdapterInterface
      * @param array $options Options
      * @return $this
      */
-    public function setOptions(array $options): AdapterInterface;
+    public function setOptions(array $options);
 
     /**
      * Get all adapter options.
@@ -119,7 +120,7 @@ interface AdapterInterface
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @return $this
      */
-    public function setInput(InputInterface $input): AdapterInterface;
+    public function setInput(InputInterface $input);
 
     /**
      * Gets the console input.
@@ -134,7 +135,7 @@ interface AdapterInterface
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return $this
      */
-    public function setOutput(OutputInterface $output): AdapterInterface;
+    public function setOutput(OutputInterface $output);
 
     /**
      * Gets the console output.
@@ -162,7 +163,7 @@ interface AdapterInterface
      * @param string $endTime End Time
      * @return $this
      */
-    public function migrated(MigrationInterface $migration, string $direction, string $startTime, string $endTime): AdapterInterface;
+    public function migrated(MigrationInterface $migration, string $direction, string $startTime, string $endTime);
 
     /**
      * Toggle a migration breakpoint.
@@ -170,7 +171,7 @@ interface AdapterInterface
      * @param \Phinx\Migration\MigrationInterface $migration Migration
      * @return $this
      */
-    public function toggleBreakpoint(MigrationInterface $migration): AdapterInterface;
+    public function toggleBreakpoint(MigrationInterface $migration);
 
     /**
      * Reset all migration breakpoints.
@@ -185,7 +186,7 @@ interface AdapterInterface
      * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint set
      * @return $this
      */
-    public function setBreakpoint(MigrationInterface $migration): AdapterInterface;
+    public function setBreakpoint(MigrationInterface $migration);
 
     /**
      * Unset a migration breakpoint.
@@ -193,7 +194,7 @@ interface AdapterInterface
      * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint unset
      * @return $this
      */
-    public function unsetBreakpoint(MigrationInterface $migration): AdapterInterface;
+    public function unsetBreakpoint(MigrationInterface $migration);
 
     /**
      * Creates the schema table.
@@ -275,7 +276,7 @@ interface AdapterInterface
      *
      * @return \Cake\Database\Query
      */
-    public function getQueryBuilder(): \Cake\Database\Query;
+    public function getQueryBuilder(): Query;
 
     /**
      * Executes a SQL statement.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -437,11 +437,11 @@ interface AdapterInterface
     /**
      * Converts the Phinx logical type to the adapter's SQL type.
      *
-     * @param string $type Type
+     * @param string|\Phinx\Util\Literal $type Type
      * @param int|null $limit Limit
      * @return array
      */
-    public function getSqlType(string $type, ?int $limit = null): array;
+    public function getSqlType($type, ?int $limit = null): array;
 
     /**
      * Creates a new database.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -440,10 +440,10 @@ interface AdapterInterface
      * Converts the Phinx logical type to the adapter's SQL type.
      *
      * @param \Phinx\Util\Literal|string $type Type
-     * @param float|null $limit Limit
+     * @param int|null $limit Limit
      * @return array
      */
-    public function getSqlType($type, ?float $limit = null): array;
+    public function getSqlType($type, ?int $limit = null): array;
 
     /**
      * Creates a new database.

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -7,6 +7,7 @@
 
 namespace Phinx\Db\Adapter;
 
+use Cake\Database\Query;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
 use Phinx\Migration\MigrationInterface;
@@ -479,7 +480,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getQueryBuilder(): \Cake\Database\Query
+    public function getQueryBuilder(): Query
     {
         return $this->getAdapter()->getQueryBuilder();
     }

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -399,7 +399,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType($type, ?float $limit = null): array
     {
         return $this->getAdapter()->getSqlType($type, $limit);
     }

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -399,7 +399,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getSqlType(string $type, ?int $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         return $this->getAdapter()->getSqlType($type, $limit);
     }

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -39,7 +39,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function setAdapter(AdapterInterface $adapter)
+    public function setAdapter(AdapterInterface $adapter): AdapterInterface
     {
         $this->adapter = $adapter;
 
@@ -49,7 +49,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getAdapter()
+    public function getAdapter(): AdapterInterface
     {
         return $this->adapter;
     }
@@ -57,7 +57,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): AdapterInterface
     {
         $this->adapter->setOptions($options);
 
@@ -67,7 +67,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->adapter->getOptions();
     }
@@ -75,7 +75,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasOption($name)
+    public function hasOption(string $name): bool
     {
         return $this->adapter->hasOption($name);
     }
@@ -83,7 +83,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getOption($name)
+    public function getOption(string $name)
     {
         return $this->adapter->getOption($name);
     }
@@ -91,7 +91,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function setInput(InputInterface $input)
+    public function setInput(InputInterface $input): AdapterInterface
     {
         $this->adapter->setInput($input);
 
@@ -101,7 +101,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getInput()
+    public function getInput(): InputInterface
     {
         return $this->adapter->getInput();
     }
@@ -109,7 +109,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function setOutput(OutputInterface $output)
+    public function setOutput(OutputInterface $output): AdapterInterface
     {
         $this->adapter->setOutput($output);
 
@@ -119,7 +119,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->adapter->getOutput();
     }
@@ -127,7 +127,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getColumnForType($columnName, $type, array $options)
+    public function getColumnForType(string $columnName, string $type, array $options): Column
     {
         return $this->adapter->getColumnForType($columnName, $type, $options);
     }
@@ -135,7 +135,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function connect()
+    public function connect(): void
     {
         $this->getAdapter()->connect();
     }
@@ -143,7 +143,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->getAdapter()->disconnect();
     }
@@ -151,7 +151,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function execute($sql, array $params = [])
+    public function execute(string $sql, array $params = []): int
     {
         return $this->getAdapter()->execute($sql, $params);
     }
@@ -159,7 +159,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function query($sql, array $params = [])
+    public function query(string $sql, array $params = [])
     {
         return $this->getAdapter()->query($sql, $params);
     }
@@ -167,7 +167,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function insert(Table $table, $row)
+    public function insert(Table $table, array $row): void
     {
         $this->getAdapter()->insert($table, $row);
     }
@@ -175,7 +175,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function bulkinsert(Table $table, $rows)
+    public function bulkinsert(Table $table, array $rows): void
     {
         $this->getAdapter()->bulkinsert($table, $rows);
     }
@@ -183,7 +183,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function fetchRow($sql)
+    public function fetchRow(string $sql)
     {
         return $this->getAdapter()->fetchRow($sql);
     }
@@ -191,7 +191,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function fetchAll($sql)
+    public function fetchAll(string $sql): array
     {
         return $this->getAdapter()->fetchAll($sql);
     }
@@ -199,7 +199,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getVersions()
+    public function getVersions(): array
     {
         return $this->getAdapter()->getVersions();
     }
@@ -207,7 +207,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getVersionLog()
+    public function getVersionLog(): array
     {
         return $this->getAdapter()->getVersionLog();
     }
@@ -215,7 +215,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
+    public function migrated(MigrationInterface $migration, string $direction, string $startTime, string $endTime): AdapterInterface
     {
         $this->getAdapter()->migrated($migration, $direction, $startTime, $endTime);
 
@@ -225,7 +225,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function toggleBreakpoint(MigrationInterface $migration)
+    public function toggleBreakpoint(MigrationInterface $migration): AdapterInterface
     {
         $this->getAdapter()->toggleBreakpoint($migration);
 
@@ -235,7 +235,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function resetAllBreakpoints()
+    public function resetAllBreakpoints(): int
     {
         return $this->getAdapter()->resetAllBreakpoints();
     }
@@ -243,7 +243,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function setBreakpoint(MigrationInterface $migration)
+    public function setBreakpoint(MigrationInterface $migration): AdapterInterface
     {
         $this->getAdapter()->setBreakpoint($migration);
 
@@ -253,7 +253,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function unsetBreakpoint(MigrationInterface $migration)
+    public function unsetBreakpoint(MigrationInterface $migration): AdapterInterface
     {
         $this->getAdapter()->unsetBreakpoint($migration);
 
@@ -263,7 +263,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function createSchemaTable()
+    public function createSchemaTable(): void
     {
         $this->getAdapter()->createSchemaTable();
     }
@@ -271,7 +271,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getColumnTypes()
+    public function getColumnTypes(): array
     {
         return $this->getAdapter()->getColumnTypes();
     }
@@ -279,7 +279,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function isValidColumnType(Column $column)
+    public function isValidColumnType(Column $column): bool
     {
         return $this->getAdapter()->isValidColumnType($column);
     }
@@ -287,7 +287,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasTransactions()
+    public function hasTransactions(): bool
     {
         return $this->getAdapter()->hasTransactions();
     }
@@ -295,7 +295,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function beginTransaction()
+    public function beginTransaction(): void
     {
         $this->getAdapter()->beginTransaction();
     }
@@ -303,7 +303,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function commitTransaction()
+    public function commitTransaction(): void
     {
         $this->getAdapter()->commitTransaction();
     }
@@ -311,7 +311,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): void
     {
         $this->getAdapter()->rollbackTransaction();
     }
@@ -319,7 +319,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function quoteTableName($tableName)
+    public function quoteTableName(string $tableName): string
     {
         return $this->getAdapter()->quoteTableName($tableName);
     }
@@ -327,7 +327,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function quoteColumnName($columnName)
+    public function quoteColumnName(string $columnName): string
     {
         return $this->getAdapter()->quoteColumnName($columnName);
     }
@@ -335,7 +335,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasTable($tableName)
+    public function hasTable(string $tableName): bool
     {
         return $this->getAdapter()->hasTable($tableName);
     }
@@ -343,7 +343,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = [])
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
     {
         $this->getAdapter()->createTable($table, $columns, $indexes);
     }
@@ -351,7 +351,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getColumns($tableName)
+    public function getColumns(string $tableName): array
     {
         return $this->getAdapter()->getColumns($tableName);
     }
@@ -359,7 +359,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasColumn($tableName, $columnName)
+    public function hasColumn(string $tableName, string $columnName): bool
     {
         return $this->getAdapter()->hasColumn($tableName, $columnName);
     }
@@ -367,7 +367,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasIndex($tableName, $columns)
+    public function hasIndex(string $tableName, $columns): bool
     {
         return $this->getAdapter()->hasIndex($tableName, $columns);
     }
@@ -375,7 +375,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasIndexByName($tableName, $indexName)
+    public function hasIndexByName(string $tableName, string $indexName): bool
     {
         return $this->getAdapter()->hasIndexByName($tableName, $indexName);
     }
@@ -383,7 +383,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         return $this->getAdapter()->hasPrimaryKey($tableName, $columns, $constraint);
     }
@@ -391,7 +391,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasForeignKey($tableName, $columns, $constraint = null)
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         return $this->getAdapter()->hasForeignKey($tableName, $columns, $constraint);
     }
@@ -399,7 +399,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getSqlType($type, $limit = null)
+    public function getSqlType(string $type, ?int $limit = null): array
     {
         return $this->getAdapter()->getSqlType($type, $limit);
     }
@@ -407,7 +407,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function createDatabase($name, $options = [])
+    public function createDatabase(string $name, array $options = []): void
     {
         $this->getAdapter()->createDatabase($name, $options);
     }
@@ -415,7 +415,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasDatabase($name)
+    public function hasDatabase(string $name): bool
     {
         return $this->getAdapter()->hasDatabase($name);
     }
@@ -423,7 +423,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function dropDatabase($name)
+    public function dropDatabase(string $name): void
     {
         $this->getAdapter()->dropDatabase($name);
     }
@@ -431,7 +431,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function createSchema($schemaName = 'public')
+    public function createSchema(string $schemaName = 'public'): void
     {
         $this->getAdapter()->createSchema($schemaName);
     }
@@ -439,7 +439,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function dropSchema($schemaName)
+    public function dropSchema(string $schemaName): void
     {
         $this->getAdapter()->dropSchema($schemaName);
     }
@@ -447,7 +447,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function truncateTable($tableName)
+    public function truncateTable(string $tableName): void
     {
         $this->getAdapter()->truncateTable($tableName);
     }
@@ -471,7 +471,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function executeActions(Table $table, array $actions)
+    public function executeActions(Table $table, array $actions): void
     {
         $this->getAdapter()->executeActions($table, $actions);
     }
@@ -479,7 +479,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): \Cake\Database\Query
     {
         return $this->getAdapter()->getQueryBuilder();
     }

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -400,7 +400,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getSqlType($type, ?float $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         return $this->getAdapter()->getSqlType($type, $limit);
     }

--- a/src/Phinx/Db/Adapter/DirectActionInterface.php
+++ b/src/Phinx/Db/Adapter/DirectActionInterface.php
@@ -25,7 +25,7 @@ interface DirectActionInterface
      * @param string $newName New Name
      * @return void
      */
-    public function renameTable($tableName, $newName);
+    public function renameTable(string $tableName, string $newName): void;
 
     /**
      * Drops the specified database table.
@@ -33,7 +33,7 @@ interface DirectActionInterface
      * @param string $tableName Table name
      * @return void
      */
-    public function dropTable($tableName);
+    public function dropTable(string $tableName): void;
 
     /**
      * Changes the primary key of the specified database table.
@@ -42,7 +42,7 @@ interface DirectActionInterface
      * @param string|string[]|null $newColumns Column name(s) to belong to the primary key, or null to drop the key
      * @return void
      */
-    public function changePrimaryKey(Table $table, $newColumns);
+    public function changePrimaryKey(Table $table, $newColumns): void;
 
     /**
      * Changes the comment of the specified database table.
@@ -51,7 +51,7 @@ interface DirectActionInterface
      * @param string|null $newComment New comment string, or null to drop the comment
      * @return void
      */
-    public function changeComment(Table $table, $newComment);
+    public function changeComment(Table $table, ?string $newComment): void;
 
     /**
      * Adds the specified column to a database table.
@@ -60,7 +60,7 @@ interface DirectActionInterface
      * @param \Phinx\Db\Table\Column $column Column
      * @return void
      */
-    public function addColumn(Table $table, Column $column);
+    public function addColumn(Table $table, Column $column): void;
 
     /**
      * Renames the specified column.
@@ -70,7 +70,7 @@ interface DirectActionInterface
      * @param string $newColumnName New Column Name
      * @return void
      */
-    public function renameColumn($tableName, $columnName, $newColumnName);
+    public function renameColumn(string $tableName, string $columnName, string $newColumnName): void;
 
     /**
      * Change a table column type.
@@ -80,7 +80,7 @@ interface DirectActionInterface
      * @param \Phinx\Db\Table\Column $newColumn New Column
      * @return void
      */
-    public function changeColumn($tableName, $columnName, Column $newColumn);
+    public function changeColumn(string $tableName, string $columnName, Column $newColumn): void;
 
     /**
      * Drops the specified column.
@@ -89,7 +89,7 @@ interface DirectActionInterface
      * @param string $columnName Column Name
      * @return void
      */
-    public function dropColumn($tableName, $columnName);
+    public function dropColumn(string $tableName, string $columnName): void;
 
     /**
      * Adds the specified index to a database table.
@@ -98,16 +98,16 @@ interface DirectActionInterface
      * @param \Phinx\Db\Table\Index $index Index
      * @return void
      */
-    public function addIndex(Table $table, Index $index);
+    public function addIndex(Table $table, Index $index): void;
 
     /**
      * Drops the specified index from a database table.
      *
      * @param string $tableName the name of the table
-     * @param mixed $columns Column(s)
+     * @param string|string[] $columns Column(s)
      * @return void
      */
-    public function dropIndex($tableName, $columns);
+    public function dropIndex(string $tableName, $columns): void;
 
     /**
      * Drops the index specified by name from a database table.
@@ -116,7 +116,7 @@ interface DirectActionInterface
      * @param string $indexName The name of the index
      * @return void
      */
-    public function dropIndexByName($tableName, $indexName);
+    public function dropIndexByName(string $tableName, string $indexName): void;
 
     /**
      * Adds the specified foreign key to a database table.
@@ -125,7 +125,7 @@ interface DirectActionInterface
      * @param \Phinx\Db\Table\ForeignKey $foreignKey The foreign key to add
      * @return void
      */
-    public function addForeignKey(Table $table, ForeignKey $foreignKey);
+    public function addForeignKey(Table $table, ForeignKey $foreignKey): void;
 
     /**
      * Drops the specified foreign key from a database table.
@@ -135,5 +135,5 @@ interface DirectActionInterface
      * @param string|null $constraint Constraint name
      * @return void
      */
-    public function dropForeignKey($tableName, $columns, $constraint = null);
+    public function dropForeignKey(string $tableName, array $columns, ?string $constraint = null): void;
 }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -905,7 +905,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType($type, ?float $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -86,7 +86,7 @@ class MysqlAdapter extends PdoAdapter
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function connect()
+    public function connect(): void
     {
         if ($this->connection === null) {
             if (!class_exists('PDO') || !in_array('mysql', PDO::getAvailableDrivers(), true)) {
@@ -145,7 +145,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->connection = null;
     }
@@ -153,7 +153,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasTransactions()
+    public function hasTransactions(): bool
     {
         return true;
     }
@@ -161,7 +161,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function beginTransaction()
+    public function beginTransaction(): void
     {
         $this->execute('START TRANSACTION');
     }
@@ -169,7 +169,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function commitTransaction()
+    public function commitTransaction(): void
     {
         $this->execute('COMMIT');
     }
@@ -177,7 +177,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): void
     {
         $this->execute('ROLLBACK');
     }
@@ -185,7 +185,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function quoteTableName($tableName)
+    public function quoteTableName(string $tableName): string
     {
         return str_replace('.', '`.`', $this->quoteColumnName($tableName));
     }
@@ -193,7 +193,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function quoteColumnName($columnName)
+    public function quoteColumnName(string $columnName): string
     {
         return '`' . str_replace('`', '``', $columnName) . '`';
     }
@@ -201,7 +201,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasTable($tableName)
+    public function hasTable(string $tableName): bool
     {
         if ($this->hasCreatedTable($tableName)) {
             return true;
@@ -226,7 +226,7 @@ class MysqlAdapter extends PdoAdapter
      * @param string $tableName The table name
      * @return bool
      */
-    protected function hasTableWithSchema($schema, $tableName)
+    protected function hasTableWithSchema(string $schema, string $tableName): bool
     {
         $result = $this->fetchRow(sprintf(
             "SELECT TABLE_NAME
@@ -242,7 +242,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = [])
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
     {
         // This method is based on the MySQL docs here: http://dev.mysql.com/doc/refman/5.1/en/create-index.html
         $defaultOptions = [
@@ -320,7 +320,7 @@ class MysqlAdapter extends PdoAdapter
             if (is_string($options['primary_key'])) { // handle primary_key => 'id'
                 $sql .= $this->quoteColumnName($options['primary_key']);
             } elseif (is_array($options['primary_key'])) { // handle primary_key => array('tag_id', 'resource_id')
-                $sql .= implode(',', array_map([$this, 'quoteColumnName'], $options['primary_key']));
+                $sql .= implode(',', array_map([$this, 'quoteColumnName'], (array)$options['primary_key']));
             }
             $sql .= ')';
         } else {
@@ -346,7 +346,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns)
+    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -379,7 +379,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getChangeCommentInstructions(Table $table, $newComment)
+    protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -394,7 +394,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getRenameTableInstructions($tableName, $newTableName)
+    protected function getRenameTableInstructions(string $tableName, string $newTableName): AlterInstructions
     {
         $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
@@ -409,7 +409,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropTableInstructions($tableName)
+    protected function getDropTableInstructions(string $tableName): AlterInstructions
     {
         $this->removeCreatedTable($tableName);
         $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
@@ -420,7 +420,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function truncateTable($tableName)
+    public function truncateTable(string $tableName): void
     {
         $sql = sprintf(
             'TRUNCATE TABLE %s',
@@ -433,7 +433,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getColumns($tableName)
+    public function getColumns(string $tableName): array
     {
         $columns = [];
         $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName)));
@@ -466,7 +466,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasColumn($tableName, $columnName)
+    public function hasColumn(string $tableName, string $columnName): bool
     {
         $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName)));
         foreach ($rows as $column) {
@@ -481,7 +481,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddColumnInstructions(Table $table, Column $column)
+    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
     {
         $alter = sprintf(
             'ADD %s %s',
@@ -500,7 +500,7 @@ class MysqlAdapter extends PdoAdapter
      * @param \Phinx\Db\Table\Column $column The column being altered.
      * @return string The appropriate SQL fragment.
      */
-    protected function afterClause(Column $column)
+    protected function afterClause(Column $column): string
     {
         $after = $column->getAfter();
         if (empty($after)) {
@@ -519,7 +519,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getRenameColumnInstructions($tableName, $columnName, $newColumnName)
+    protected function getRenameColumnInstructions(string $tableName, string $columnName, string $newColumnName): AlterInstructions
     {
         $rows = $this->fetchAll(sprintf('SHOW FULL COLUMNS FROM %s', $this->quoteTableName($tableName)));
 
@@ -553,7 +553,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getChangeColumnInstructions($tableName, $columnName, Column $newColumn)
+    protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions
     {
         $alter = sprintf(
             'CHANGE %s %s %s%s',
@@ -569,7 +569,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropColumnInstructions($tableName, $columnName)
+    protected function getDropColumnInstructions(string $tableName, string $columnName): AlterInstructions
     {
         $alter = sprintf('DROP COLUMN %s', $this->quoteColumnName($columnName));
 
@@ -582,7 +582,7 @@ class MysqlAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return array
      */
-    protected function getIndexes($tableName)
+    protected function getIndexes(string $tableName): array
     {
         $indexes = [];
         $rows = $this->fetchAll(sprintf('SHOW INDEXES FROM %s', $this->quoteTableName($tableName)));
@@ -599,7 +599,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasIndex($tableName, $columns)
+    public function hasIndex(string $tableName, $columns): bool
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -620,7 +620,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasIndexByName($tableName, $indexName)
+    public function hasIndexByName(string $tableName, string $indexName): bool
     {
         $indexes = $this->getIndexes($tableName);
 
@@ -636,7 +636,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddIndexInstructions(Table $table, Index $index)
+    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -667,7 +667,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getDropIndexByColumnsInstructions($tableName, $columns)
+    protected function getDropIndexByColumnsInstructions(string $tableName, $columns): AlterInstructions
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -696,7 +696,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getDropIndexByNameInstructions($tableName, $indexName)
+    protected function getDropIndexByNameInstructions(string $tableName, $indexName): AlterInstructions
     {
         $indexes = $this->getIndexes($tableName);
 
@@ -718,7 +718,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         $primaryKey = $this->getPrimaryKey($tableName);
 
@@ -744,7 +744,7 @@ class MysqlAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return array
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         $options = $this->getOptions();
         $rows = $this->fetchAll(sprintf(
@@ -775,7 +775,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasForeignKey($tableName, $columns, $constraint = null)
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -804,7 +804,7 @@ class MysqlAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return array
      */
-    protected function getForeignKeys($tableName)
+    protected function getForeignKeys(string $tableName): array
     {
         if (strpos($tableName, '.') !== false) {
             [$schema, $tableName] = explode('.', $tableName);
@@ -839,7 +839,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey)
+    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
     {
         $alter = sprintf(
             'ADD %s',
@@ -852,7 +852,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropForeignKeyInstructions($tableName, $constraint)
+    protected function getDropForeignKeyInstructions(string $tableName, string $constraint): AlterInstructions
     {
         $alter = sprintf(
             'DROP FOREIGN KEY %s',
@@ -867,7 +867,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getDropForeignKeyByColumnsInstructions($tableName, $columns)
+    protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -905,7 +905,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, $limit = null)
+    public function getSqlType(string $type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:
@@ -1237,7 +1237,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function createDatabase($name, $options = [])
+    public function createDatabase(string $name, array $options = []): void
     {
         $charset = $options['charset'] ?? 'utf8';
 
@@ -1256,7 +1256,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasDatabase($name)
+    public function hasDatabase(string $name): bool
     {
         $rows = $this->fetchAll(
             sprintf(
@@ -1277,7 +1277,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function dropDatabase($name)
+    public function dropDatabase(string $name): void
     {
         $this->execute(sprintf('DROP DATABASE IF EXISTS `%s`', $name));
         $this->createdTables = [];
@@ -1289,7 +1289,7 @@ class MysqlAdapter extends PdoAdapter
      * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
-    protected function getColumnSqlDefinition(Column $column)
+    protected function getColumnSqlDefinition(Column $column): string
     {
         if ($column->getType() instanceof Literal) {
             $def = (string)$column->getType();
@@ -1351,7 +1351,7 @@ class MysqlAdapter extends PdoAdapter
      * @param \Phinx\Db\Table\Index $index Index
      * @return string
      */
-    protected function getIndexSqlDefinition(Index $index)
+    protected function getIndexSqlDefinition(Index $index): string
     {
         $def = '';
         $limit = '';
@@ -1408,7 +1408,7 @@ class MysqlAdapter extends PdoAdapter
      * @param \Phinx\Db\Table\ForeignKey $foreignKey Foreign key
      * @return string
      */
-    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey)
+    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey): string
     {
         $def = '';
         if ($foreignKey->getConstraint()) {
@@ -1440,7 +1440,7 @@ class MysqlAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return array
      */
-    public function describeTable($tableName)
+    public function describeTable(string $tableName): array
     {
         $options = $this->getOptions();
 
@@ -1454,7 +1454,9 @@ class MysqlAdapter extends PdoAdapter
             $tableName
         );
 
-        return $this->fetchRow($sql);
+        $table = $this->fetchRow($sql);
+
+        return $table !== false ? $table : [];
     }
 
     /**
@@ -1462,7 +1464,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @return string[]
      */
-    public function getColumnTypes()
+    public function getColumnTypes(): array
     {
         return array_merge(parent::getColumnTypes(), static::$specificColumnTypes);
     }
@@ -1470,7 +1472,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection()
+    public function getDecoratedConnection(): Connection
     {
         $options = $this->getOptions();
         $options = [

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -905,7 +905,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType(string $type, ?int $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -56,24 +56,29 @@ class MysqlAdapter extends PdoAdapter
         self::PHINX_TYPE_BOOLEAN => true,
     ];
 
+    // These constants roughly correspond to the maximum allowed value for each field,
+    // except for the `_LONG` and `_BIG` variants, which are maxed at 32-bit
+    // PHP_INT_MAX value. The `INT_REGULAR` field is just arbitrarily half of INT_BIG
+    // as its actual value is its regular value is larger than PHP_INT_MAX. We do this
+    // to keep consistent the type hints for getSqlType and Column::$limit being integers.
     public const TEXT_TINY = 255;
     public const TEXT_SMALL = 255; /* deprecated, alias of TEXT_TINY */
     public const TEXT_REGULAR = 65535;
     public const TEXT_MEDIUM = 16777215;
-    public const TEXT_LONG = 4294967295;
+    public const TEXT_LONG = 2147483647;
 
     // According to https://dev.mysql.com/doc/refman/5.0/en/blob.html BLOB sizes are the same as TEXT
     public const BLOB_TINY = 255;
     public const BLOB_SMALL = 255; /* deprecated, alias of BLOB_TINY */
     public const BLOB_REGULAR = 65535;
     public const BLOB_MEDIUM = 16777215;
-    public const BLOB_LONG = 4294967295;
+    public const BLOB_LONG = 2147483647;
 
     public const INT_TINY = 255;
     public const INT_SMALL = 65535;
     public const INT_MEDIUM = 16777215;
-    public const INT_REGULAR = 4294967295;
-    public const INT_BIG = 18446744073709551615;
+    public const INT_REGULAR = 1073741823;
+    public const INT_BIG = 2147483647;
 
     public const BIT = 64;
 
@@ -907,7 +912,7 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?float $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -52,7 +52,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $message The message to show
      * @return void
      */
-    protected function verboseLog($message)
+    protected function verboseLog($message): void
     {
         if (
             !$this->isDryRunEnabled() &&
@@ -73,7 +73,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param array $options Connection options
      * @return \PDO
      */
-    protected function createPdoConnection($dsn, $username = null, $password = null, array $options = [])
+    protected function createPdoConnection(string $dsn, ?string $username = null, ?string $password = null, array $options = []): PDO
     {
         $adapterOptions = $this->getOptions() + [
             'attr_errmode' => PDO::ERRMODE_EXCEPTION,
@@ -104,7 +104,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): AdapterInterface
     {
         parent::setOptions($options);
 
@@ -121,7 +121,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param \PDO $connection Connection
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function setConnection(PDO $connection)
+    public function setConnection(PDO $connection): AdapterInterface
     {
         $this->connection = $connection;
 
@@ -154,7 +154,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @return \PDO
      */
-    public function getConnection()
+    public function getConnection(): PDO
     {
         if ($this->connection === null) {
             $this->connect();
@@ -166,21 +166,21 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function connect()
+    public function connect(): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function disconnect()
+    public function disconnect(): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function execute($sql, array $params = [])
+    public function execute(string $sql, array $params = []): int
     {
         $sql = rtrim($sql, "; \t\n\r\0\x0B") . ';';
         $this->verboseLog($sql);
@@ -205,12 +205,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @return \Cake\Database\Connection
      */
-    abstract public function getDecoratedConnection();
+    abstract public function getDecoratedConnection(): \Cake\Database\Connection;
 
     /**
      * @inheritDoc
      */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): \Cake\Database\Query
     {
         return $this->getDecoratedConnection()->newQuery();
     }
@@ -221,7 +221,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $sql SQL
      * @return \PDOStatement|false
      */
-    public function query($sql, array $params = [])
+    public function query(string $sql, array $params = [])
     {
         if (empty($params)) {
             return $this->getConnection()->query($sql);
@@ -235,7 +235,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function fetchRow($sql)
+    public function fetchRow(string $sql)
     {
         return $this->query($sql)->fetch();
     }
@@ -243,7 +243,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function fetchAll($sql)
+    public function fetchAll(string $sql): array
     {
         return $this->query($sql)->fetchAll();
     }
@@ -251,7 +251,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function insert(Table $table, $row)
+    public function insert(Table $table, array $row): void
     {
         $sql = sprintf(
             'INSERT INTO %s ',
@@ -301,7 +301,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $value The string to quote
      * @return string
      */
-    protected function quoteString($value)
+    protected function quoteString(string $value): string
     {
         return $this->getConnection()->quote($value);
     }
@@ -309,7 +309,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function bulkinsert(Table $table, $rows)
+    public function bulkinsert(Table $table, array $rows): void
     {
         $sql = sprintf(
             'INSERT INTO %s ',
@@ -351,7 +351,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function getVersions()
+    public function getVersions(): array
     {
         $rows = $this->getVersionLog();
 
@@ -363,7 +363,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @throws \RuntimeException
      */
-    public function getVersionLog()
+    public function getVersionLog(): array
     {
         $result = [];
 
@@ -399,7 +399,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
+    public function migrated(MigrationInterface $migration, string $direction, string $startTime, string $endTime): AdapterInterface
     {
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
@@ -437,7 +437,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function toggleBreakpoint(MigrationInterface $migration)
+    public function toggleBreakpoint(MigrationInterface $migration): AdapterInterface
     {
         $this->query(
             sprintf(
@@ -458,7 +458,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function resetAllBreakpoints()
+    public function resetAllBreakpoints(): int
     {
         return $this->execute(
             sprintf(
@@ -474,7 +474,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function setBreakpoint(MigrationInterface $migration)
+    public function setBreakpoint(MigrationInterface $migration): AdapterInterface
     {
         return $this->markBreakpoint($migration, true);
     }
@@ -482,7 +482,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function unsetBreakpoint(MigrationInterface $migration)
+    public function unsetBreakpoint(MigrationInterface $migration): AdapterInterface
     {
         return $this->markBreakpoint($migration, false);
     }
@@ -494,7 +494,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param bool $state The required state of the breakpoint
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    protected function markBreakpoint(MigrationInterface $migration, $state)
+    protected function markBreakpoint(MigrationInterface $migration, bool $state): AdapterInterface
     {
         $this->query(
             sprintf(
@@ -517,7 +517,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @throws \BadMethodCallException
      * @return void
      */
-    public function createSchema($schemaName = 'public')
+    public function createSchema(string $schemaName = 'public'): void
     {
         throw new BadMethodCallException('Creating a schema is not supported');
     }
@@ -528,7 +528,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropSchema($name)
+    public function dropSchema(string $name): void
     {
         throw new BadMethodCallException('Dropping a schema is not supported');
     }
@@ -536,7 +536,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function getColumnTypes()
+    public function getColumnTypes(): array
     {
         return [
             'string',
@@ -582,7 +582,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param int $attribute One of the PDO::ATTR_* constants
      * @return mixed
      */
-    public function getAttribute($attribute)
+    public function getAttribute(int $attribute)
     {
         return $this->connection->getAttribute($attribute);
     }
@@ -594,7 +594,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string|null $columnType column type added
      * @return string
      */
-    protected function getDefaultValueDefinition($default, $columnType = null)
+    protected function getDefaultValueDefinition($default, ?string $columnType = null): string
     {
         // Ensure a defaults of CURRENT_TIMESTAMP(3) is not quoted.
         if (is_string($default) && strpos($default, 'CURRENT_TIMESTAMP') !== 0) {
@@ -615,7 +615,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param \Phinx\Db\Util\AlterInstructions $instructions The object containing the alter sequence
      * @return void
      */
-    protected function executeAlterSteps($tableName, AlterInstructions $instructions)
+    protected function executeAlterSteps(string $tableName, AlterInstructions $instructions): void
     {
         $alter = sprintf('ALTER TABLE %s %%s', $this->quoteTableName($tableName));
         $instructions->execute($alter, [$this, 'execute']);
@@ -624,7 +624,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function addColumn(Table $table, Column $column)
+    public function addColumn(Table $table, Column $column): void
     {
         $instructions = $this->getAddColumnInstructions($table, $column);
         $this->executeAlterSteps($table->getName(), $instructions);
@@ -637,12 +637,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param \Phinx\Db\Table\Column $column Column
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getAddColumnInstructions(Table $table, Column $column);
+    abstract protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function renameColumn($tableName, $columnName, $newColumnName)
+    public function renameColumn(string $tableName, string $columnName, string $newColumnName): void
     {
         $instructions = $this->getRenameColumnInstructions($tableName, $columnName, $newColumnName);
         $this->executeAlterSteps($tableName, $instructions);
@@ -656,12 +656,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $newColumnName New Column Name
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getRenameColumnInstructions($tableName, $columnName, $newColumnName);
+    abstract protected function getRenameColumnInstructions(string $tableName, string $columnName, string $newColumnName): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function changeColumn($tableName, $columnName, Column $newColumn)
+    public function changeColumn(string $tableName, string $columnName, Column $newColumn): void
     {
         $instructions = $this->getChangeColumnInstructions($tableName, $columnName, $newColumn);
         $this->executeAlterSteps($tableName, $instructions);
@@ -675,12 +675,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param \Phinx\Db\Table\Column $newColumn New Column
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getChangeColumnInstructions($tableName, $columnName, Column $newColumn);
+    abstract protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function dropColumn($tableName, $columnName)
+    public function dropColumn(string $tableName, string $columnName): void
     {
         $instructions = $this->getDropColumnInstructions($tableName, $columnName);
         $this->executeAlterSteps($tableName, $instructions);
@@ -693,12 +693,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $columnName Column Name
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getDropColumnInstructions($tableName, $columnName);
+    abstract protected function getDropColumnInstructions(string $tableName, string $columnName): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function addIndex(Table $table, Index $index)
+    public function addIndex(Table $table, Index $index): void
     {
         $instructions = $this->getAddIndexInstructions($table, $index);
         $this->executeAlterSteps($table->getName(), $instructions);
@@ -711,12 +711,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param \Phinx\Db\Table\Index $index Index
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getAddIndexInstructions(Table $table, Index $index);
+    abstract protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function dropIndex($tableName, $columns)
+    public function dropIndex(string $tableName, $columns): void
     {
         $instructions = $this->getDropIndexByColumnsInstructions($tableName, $columns);
         $this->executeAlterSteps($tableName, $instructions);
@@ -726,15 +726,15 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * Returns the instructions to drop the specified index from a database table.
      *
      * @param string $tableName The name of of the table where the index is
-     * @param mixed $columns Column(s)
+     * @param string|string[] $columns Column(s)
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getDropIndexByColumnsInstructions($tableName, $columns);
+    abstract protected function getDropIndexByColumnsInstructions(string $tableName, $columns): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function dropIndexByName($tableName, $indexName)
+    public function dropIndexByName(string $tableName, string $indexName): void
     {
         $instructions = $this->getDropIndexByNameInstructions($tableName, $indexName);
         $this->executeAlterSteps($tableName, $instructions);
@@ -747,12 +747,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $indexName The name of the index
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getDropIndexByNameInstructions($tableName, $indexName);
+    abstract protected function getDropIndexByNameInstructions(string $tableName, string $indexName): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function addForeignKey(Table $table, ForeignKey $foreignKey)
+    public function addForeignKey(Table $table, ForeignKey $foreignKey): void
     {
         $instructions = $this->getAddForeignKeyInstructions($table, $foreignKey);
         $this->executeAlterSteps($table->getName(), $instructions);
@@ -765,12 +765,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param \Phinx\Db\Table\ForeignKey $foreignKey The foreign key to add
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey);
+    abstract protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions;
 
     /**
      * @inheritDoc
      */
-    public function dropForeignKey($tableName, $columns, $constraint = null)
+    public function dropForeignKey(string $tableName, array $columns, ?string $constraint = null): void
     {
         if ($constraint) {
             $instructions = $this->getDropForeignKeyInstructions($tableName, $constraint);
@@ -788,7 +788,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $constraint Constraint name
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getDropForeignKeyInstructions($tableName, $constraint);
+    abstract protected function getDropForeignKeyInstructions(string $tableName, string $constraint): AlterInstructions;
 
     /**
      * Returns the instructions to drop the specified foreign key from a database table.
@@ -797,12 +797,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string[] $columns The list of column names
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getDropForeignKeyByColumnsInstructions($tableName, $columns);
+    abstract protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function dropTable($tableName)
+    public function dropTable(string $tableName): void
     {
         $instructions = $this->getDropTableInstructions($tableName);
         $this->executeAlterSteps($tableName, $instructions);
@@ -814,12 +814,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $tableName Table name
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getDropTableInstructions($tableName);
+    abstract protected function getDropTableInstructions(string $tableName): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function renameTable($tableName, $newTableName)
+    public function renameTable(string $tableName, string $newTableName): void
     {
         $instructions = $this->getRenameTableInstructions($tableName, $newTableName);
         $this->executeAlterSteps($tableName, $instructions);
@@ -832,12 +832,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string $newTableName New Name
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getRenameTableInstructions($tableName, $newTableName);
+    abstract protected function getRenameTableInstructions(string $tableName, string $newTableName): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function changePrimaryKey(Table $table, $newColumns)
+    public function changePrimaryKey(Table $table, $newColumns): void
     {
         $instructions = $this->getChangePrimaryKeyInstructions($table, $newColumns);
         $this->executeAlterSteps($table->getName(), $instructions);
@@ -850,12 +850,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string|string[]|null $newColumns Column name(s) to belong to the primary key, or null to drop the key
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getChangePrimaryKeyInstructions(Table $table, $newColumns);
+    abstract protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions;
 
     /**
      * @inheritdoc
      */
-    public function changeComment(Table $table, $newComment)
+    public function changeComment(Table $table, $newComment): void
     {
         $instructions = $this->getChangeCommentInstructions($table, $newComment);
         $this->executeAlterSteps($table->getName(), $instructions);
@@ -868,7 +868,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param string|null $newComment New comment string, or null to drop the comment
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    abstract protected function getChangeCommentInstructions(Table $table, $newComment);
+    abstract protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions;
 
     /**
      * {@inheritDoc}
@@ -876,25 +876,29 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function executeActions(Table $table, array $actions)
+    public function executeActions(Table $table, array $actions): void
     {
         $instructions = new AlterInstructions();
 
         foreach ($actions as $action) {
             switch (true) {
                 case $action instanceof AddColumn:
+                    /** @var \Phinx\Db\Action\AddColumn $action */
                     $instructions->merge($this->getAddColumnInstructions($table, $action->getColumn()));
                     break;
 
                 case $action instanceof AddIndex:
+                    /** @var \Phinx\Db\Action\AddIndex $action */
                     $instructions->merge($this->getAddIndexInstructions($table, $action->getIndex()));
                     break;
 
                 case $action instanceof AddForeignKey:
+                    /** @var \Phinx\Db\Action\AddForeignKey $action */
                     $instructions->merge($this->getAddForeignKeyInstructions($table, $action->getForeignKey()));
                     break;
 
                 case $action instanceof ChangeColumn:
+                    /** @var \Phinx\Db\Action\ChangeColumn $action */
                     $instructions->merge($this->getChangeColumnInstructions(
                         $table->getName(),
                         $action->getColumnName(),
@@ -903,6 +907,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof DropForeignKey && !$action->getForeignKey()->getConstraint():
+                    /** @var \Phinx\Db\Action\DropForeignKey $action */
                     $instructions->merge($this->getDropForeignKeyByColumnsInstructions(
                         $table->getName(),
                         $action->getForeignKey()->getColumns()
@@ -910,6 +915,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof DropForeignKey && $action->getForeignKey()->getConstraint():
+                    /** @var \Phinx\Db\Action\DropForeignKey $action */
                     $instructions->merge($this->getDropForeignKeyInstructions(
                         $table->getName(),
                         $action->getForeignKey()->getConstraint()
@@ -917,6 +923,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof DropIndex && $action->getIndex()->getName() !== null:
+                    /** @var \Phinx\Db\Action\DropIndex $action */
                     $instructions->merge($this->getDropIndexByNameInstructions(
                         $table->getName(),
                         $action->getIndex()->getName()
@@ -924,6 +931,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof DropIndex && $action->getIndex()->getName() == null:
+                    /** @var \Phinx\Db\Action\DropIndex $action */
                     $instructions->merge($this->getDropIndexByColumnsInstructions(
                         $table->getName(),
                         $action->getIndex()->getColumns()
@@ -931,12 +939,14 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof DropTable:
+                    /** @var \Phinx\Db\Action\DropTable $action */
                     $instructions->merge($this->getDropTableInstructions(
                         $table->getName()
                     ));
                     break;
 
                 case $action instanceof RemoveColumn:
+                    /** @var \Phinx\Db\Action\RemoveColumn $action */
                     $instructions->merge($this->getDropColumnInstructions(
                         $table->getName(),
                         $action->getColumn()->getName()
@@ -944,6 +954,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof RenameColumn:
+                    /** @var \Phinx\Db\Action\RenameColumn $action */
                     $instructions->merge($this->getRenameColumnInstructions(
                         $table->getName(),
                         $action->getColumn()->getName(),
@@ -952,6 +963,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof RenameTable:
+                    /** @var \Phinx\Db\Action\RenameTable $action */
                     $instructions->merge($this->getRenameTableInstructions(
                         $table->getName(),
                         $action->getNewName()
@@ -959,6 +971,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof ChangePrimaryKey:
+                    /** @var \Phinx\Db\Action\ChangePrimaryKey $action */
                     $instructions->merge($this->getChangePrimaryKeyInstructions(
                         $table,
                         $action->getNewColumns()
@@ -966,6 +979,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                     break;
 
                 case $action instanceof ChangeComment:
+                    /** @var \Phinx\Db\Action\ChangeComment $action */
                     $instructions->merge($this->getChangeCommentInstructions(
                         $table,
                         $action->getNewComment()

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -472,7 +472,9 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function setBreakpoint(MigrationInterface $migration): AdapterInterface
     {
-        return $this->markBreakpoint($migration, true);
+        $this->markBreakpoint($migration, true);
+
+        return $this;
     }
 
     /**
@@ -480,7 +482,9 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function unsetBreakpoint(MigrationInterface $migration): AdapterInterface
     {
-        return $this->markBreakpoint($migration, false);
+        $this->markBreakpoint($migration, false);
+
+        return $this;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -8,6 +8,8 @@
 namespace Phinx\Db\Adapter;
 
 use BadMethodCallException;
+use Cake\Database\Connection;
+use Cake\Database\Query;
 use InvalidArgumentException;
 use PDO;
 use PDOException;
@@ -201,12 +203,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      *
      * @return \Cake\Database\Connection
      */
-    abstract public function getDecoratedConnection(): \Cake\Database\Connection;
+    abstract public function getDecoratedConnection(): Connection;
 
     /**
      * @inheritDoc
      */
-    public function getQueryBuilder(): \Cake\Database\Query
+    public function getQueryBuilder(): Query
     {
         return $this->getDecoratedConnection()->newQuery();
     }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -166,16 +166,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function connect(): void
-    {
-    }
+    abstract public function connect(): void;
 
     /**
      * @inheritDoc
      */
-    public function disconnect(): void
-    {
-    }
+    abstract public function disconnect(): void;
 
     /**
      * @inheritDoc

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -961,7 +961,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?float $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_TEXT:

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -961,7 +961,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType($type, ?float $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_TEXT:

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -961,7 +961,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType(string $type, ?int $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_TEXT:

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -49,7 +49,7 @@ class PostgresAdapter extends PdoAdapter
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function connect()
+    public function connect(): void
     {
         if ($this->connection === null) {
             if (!class_exists('PDO') || !in_array('pgsql', PDO::getAvailableDrivers(), true)) {
@@ -99,7 +99,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->connection = null;
     }
@@ -107,7 +107,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasTransactions()
+    public function hasTransactions(): bool
     {
         return true;
     }
@@ -115,7 +115,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function beginTransaction()
+    public function beginTransaction(): void
     {
         $this->execute('BEGIN');
     }
@@ -123,7 +123,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function commitTransaction()
+    public function commitTransaction(): void
     {
         $this->execute('COMMIT');
     }
@@ -131,7 +131,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): void
     {
         $this->execute('ROLLBACK');
     }
@@ -142,7 +142,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $schemaName Schema Name
      * @return string
      */
-    public function quoteSchemaName($schemaName)
+    public function quoteSchemaName(string $schemaName): string
     {
         return $this->quoteColumnName($schemaName);
     }
@@ -150,7 +150,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function quoteTableName($tableName)
+    public function quoteTableName(string $tableName): string
     {
         $parts = $this->getSchemaName($tableName);
 
@@ -160,7 +160,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function quoteColumnName($columnName)
+    public function quoteColumnName(string $columnName): string
     {
         return '"' . $columnName . '"';
     }
@@ -168,7 +168,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasTable($tableName)
+    public function hasTable(string $tableName): bool
     {
         if ($this->hasCreatedTable($tableName)) {
             return true;
@@ -192,7 +192,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = [])
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
     {
         $queries = [];
 
@@ -284,7 +284,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns)
+    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions
     {
         $parts = $this->getSchemaName($table->getName());
 
@@ -326,7 +326,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getChangeCommentInstructions(Table $table, $newComment)
+    protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -347,7 +347,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getRenameTableInstructions($tableName, $newTableName)
+    protected function getRenameTableInstructions(string $tableName, string $newTableName): AlterInstructions
     {
         $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
@@ -362,7 +362,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropTableInstructions($tableName)
+    protected function getDropTableInstructions(string $tableName): AlterInstructions
     {
         $this->removeCreatedTable($tableName);
         $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
@@ -373,7 +373,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function truncateTable($tableName)
+    public function truncateTable(string $tableName): void
     {
         $sql = sprintf(
             'TRUNCATE TABLE %s RESTART IDENTITY',
@@ -386,7 +386,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getColumns($tableName)
+    public function getColumns(string $tableName): array
     {
         $parts = $this->getSchemaName($tableName);
         $columns = [];
@@ -461,7 +461,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasColumn($tableName, $columnName)
+    public function hasColumn(string $tableName, string $columnName): bool
     {
         $parts = $this->getSchemaName($tableName);
         $sql = sprintf(
@@ -481,7 +481,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddColumnInstructions(Table $table, Column $column)
+    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $instructions->addAlter(sprintf(
@@ -502,7 +502,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getRenameColumnInstructions($tableName, $columnName, $newColumnName)
+    protected function getRenameColumnInstructions(string $tableName, string $columnName, string $newColumnName): AlterInstructions
     {
         $parts = $this->getSchemaName($tableName);
         $sql = sprintf(
@@ -535,7 +535,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getChangeColumnInstructions($tableName, $columnName, Column $newColumn)
+    protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions
     {
         $instructions = new AlterInstructions();
         if ($newColumn->getType() === 'boolean') {
@@ -621,7 +621,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropColumnInstructions($tableName, $columnName)
+    protected function getDropColumnInstructions(string $tableName, string $columnName): AlterInstructions
     {
         $alter = sprintf(
             'DROP COLUMN %s',
@@ -681,7 +681,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasIndex($tableName, $columns)
+    public function hasIndex(string $tableName, $columns): bool
     {
         if (is_string($columns)) {
             $columns = [$columns];
@@ -699,7 +699,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasIndexByName($tableName, $indexName)
+    public function hasIndexByName(string $tableName, string $indexName): bool
     {
         $indexes = $this->getIndexes($tableName);
         foreach ($indexes as $name => $index) {
@@ -714,7 +714,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddIndexInstructions(Table $table, Index $index)
+    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $instructions->addPostStep($this->getIndexSqlDefinition($index, $table->getName()));
@@ -727,7 +727,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getDropIndexByColumnsInstructions($tableName, $columns)
+    protected function getDropIndexByColumnsInstructions(string $tableName, $columns): AlterInstructions
     {
         $parts = $this->getSchemaName($tableName);
 
@@ -755,7 +755,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropIndexByNameInstructions($tableName, $indexName)
+    protected function getDropIndexByNameInstructions(string $tableName, string $indexName): AlterInstructions
     {
         $parts = $this->getSchemaName($tableName);
 
@@ -770,7 +770,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         $primaryKey = $this->getPrimaryKey($tableName);
 
@@ -796,7 +796,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return array
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         $parts = $this->getSchemaName($tableName);
         $rows = $this->fetchAll(sprintf(
@@ -828,7 +828,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasForeignKey($tableName, $columns, $constraint = null)
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -858,7 +858,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return array
      */
-    protected function getForeignKeys($tableName)
+    protected function getForeignKeys(string $tableName): array
     {
         $parts = $this->getSchemaName($tableName);
         $foreignKeys = [];
@@ -890,7 +890,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey)
+    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
     {
         $alter = sprintf(
             'ADD %s',
@@ -903,7 +903,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropForeignKeyInstructions($tableName, $constraint)
+    protected function getDropForeignKeyInstructions($tableName, $constraint): AlterInstructions
     {
         $alter = sprintf(
             'DROP CONSTRAINT %s',
@@ -916,7 +916,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropForeignKeyByColumnsInstructions($tableName, $columns)
+    protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -961,7 +961,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, $limit = null)
+    public function getSqlType(string $type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_TEXT:
@@ -1030,7 +1030,7 @@ class PostgresAdapter extends PdoAdapter
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      * @return string Phinx type
      */
-    public function getPhinxType($sqlType)
+    public function getPhinxType(string $sqlType): string
     {
         switch ($sqlType) {
             case 'character varying':
@@ -1097,7 +1097,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function createDatabase($name, $options = [])
+    public function createDatabase(string $name, array $options = []): void
     {
         $charset = $options['charset'] ?? 'utf8';
         $this->execute(sprintf("CREATE DATABASE %s WITH ENCODING = '%s'", $name, $charset));
@@ -1106,7 +1106,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasDatabase($name)
+    public function hasDatabase(string $name): bool
     {
         $sql = sprintf("SELECT count(*) FROM pg_database WHERE datname = '%s'", $name);
         $result = $this->fetchRow($sql);
@@ -1117,7 +1117,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function dropDatabase($name)
+    public function dropDatabase($name): void
     {
         $this->disconnect();
         $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $name));
@@ -1132,7 +1132,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string|null $columnType column type added
      * @return string
      */
-    protected function getDefaultValueDefinition($default, $columnType = null)
+    protected function getDefaultValueDefinition($default, ?string $columnType = null): string
     {
         if (is_string($default) && $default !== 'CURRENT_TIMESTAMP') {
             $default = $this->getConnection()->quote($default);
@@ -1151,7 +1151,7 @@ class PostgresAdapter extends PdoAdapter
      * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
-    protected function getColumnSqlDefinition(Column $column)
+    protected function getColumnSqlDefinition(Column $column): string
     {
         $buffer = [];
         if ($column->isIdentity()) {
@@ -1223,7 +1223,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return string
      */
-    protected function getColumnCommentSqlDefinition(Column $column, $tableName)
+    protected function getColumnCommentSqlDefinition(Column $column, string $tableName): string
     {
         // passing 'null' is to remove column comment
         $comment = strcasecmp($column->getComment(), 'NULL') !== 0
@@ -1245,7 +1245,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return string
      */
-    protected function getIndexSqlDefinition(Index $index, $tableName)
+    protected function getIndexSqlDefinition(Index $index, string $tableName): string
     {
         $parts = $this->getSchemaName($tableName);
         $columnNames = $index->getColumns();
@@ -1285,7 +1285,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return string
      */
-    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, $tableName)
+    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
         $parts = $this->getSchemaName($tableName);
 
@@ -1307,7 +1307,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function createSchemaTable()
+    public function createSchemaTable(): void
     {
         // Create the public/custom schema if it doesn't already exist
         if ($this->hasSchema($this->getGlobalSchemaName()) === false) {
@@ -1322,7 +1322,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getVersions()
+    public function getVersions(): array
     {
         $this->setSearchPath();
 
@@ -1332,7 +1332,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getVersionLog()
+    public function getVersionLog(): array
     {
         $this->setSearchPath();
 
@@ -1345,7 +1345,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $schemaName Schema Name
      * @return void
      */
-    public function createSchema($schemaName = 'public')
+    public function createSchema(string $schemaName = 'public'): void
     {
         // from postgres 9.3 we can use "CREATE SCHEMA IF NOT EXISTS schema_name"
         $sql = sprintf('CREATE SCHEMA IF NOT EXISTS %s', $this->quoteSchemaName($schemaName));
@@ -1358,7 +1358,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $schemaName Schema Name
      * @return bool
      */
-    public function hasSchema($schemaName)
+    public function hasSchema(string $schemaName): bool
     {
         $sql = sprintf(
             'SELECT count(*)
@@ -1377,7 +1377,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $schemaName Schema name
      * @return void
      */
-    public function dropSchema($schemaName)
+    public function dropSchema(string $schemaName): void
     {
         $sql = sprintf('DROP SCHEMA IF EXISTS %s CASCADE', $this->quoteSchemaName($schemaName));
         $this->execute($sql);
@@ -1394,7 +1394,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @return void
      */
-    public function dropAllSchemas()
+    public function dropAllSchemas(): void
     {
         foreach ($this->getAllSchemas() as $schema) {
             $this->dropSchema($schema);
@@ -1406,7 +1406,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @return array
      */
-    public function getAllSchemas()
+    public function getAllSchemas(): array
     {
         $sql = "SELECT schema_name
                 FROM information_schema.schemata
@@ -1423,7 +1423,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getColumnTypes()
+    public function getColumnTypes(): array
     {
         return array_merge(parent::getColumnTypes(), static::$specificColumnTypes);
     }
@@ -1431,7 +1431,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function isValidColumnType(Column $column)
+    public function isValidColumnType(Column $column): bool
     {
         // If not a standard column type, maybe it is array type?
         return parent::isValidColumnType($column) || $this->isArrayType($column->getType());
@@ -1440,10 +1440,10 @@ class PostgresAdapter extends PdoAdapter
     /**
      * Check if the given column is an array of a valid type.
      *
-     * @param string $columnType Column type
+     * @param string|\Phinx\Util\Literal $columnType Column type
      * @return bool
      */
-    protected function isArrayType($columnType)
+    protected function isArrayType($columnType): bool
     {
         if (!preg_match('/^([a-z]+)(?:\[\]){1,}$/', $columnType, $matches)) {
             return false;
@@ -1458,7 +1458,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return array
      */
-    protected function getSchemaName($tableName)
+    protected function getSchemaName(string $tableName): array
     {
         $schema = $this->getGlobalSchemaName();
         $table = $tableName;
@@ -1477,7 +1477,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @return string
      */
-    protected function getGlobalSchemaName()
+    protected function getGlobalSchemaName(): string
     {
         $options = $this->getOptions();
 
@@ -1495,7 +1495,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection()
+    public function getDecoratedConnection(): Connection
     {
         $options = $this->getOptions();
         $options = [
@@ -1517,7 +1517,7 @@ class PostgresAdapter extends PdoAdapter
      *
      * @return void
      */
-    public function setSearchPath()
+    public function setSearchPath(): void
     {
         $this->execute(
             sprintf(

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -39,7 +39,7 @@ class ProxyAdapter extends AdapterWrapper
     /**
      * @inheritDoc
      */
-    public function getAdapterType()
+    public function getAdapterType(): string
     {
         return 'ProxyAdapter';
     }
@@ -47,7 +47,7 @@ class ProxyAdapter extends AdapterWrapper
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = [])
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
     {
         $this->commands[] = new CreateTable($table);
     }
@@ -55,7 +55,7 @@ class ProxyAdapter extends AdapterWrapper
     /**
      * @inheritDoc
      */
-    public function executeActions(Table $table, array $actions)
+    public function executeActions(Table $table, array $actions): void
     {
         $this->commands = array_merge($this->commands, $actions);
     }
@@ -66,25 +66,29 @@ class ProxyAdapter extends AdapterWrapper
      * @throws \Phinx\Migration\IrreversibleMigrationException if a command cannot be reversed.
      * @return \Phinx\Db\Plan\Intent
      */
-    public function getInvertedCommands()
+    public function getInvertedCommands(): Intent
     {
         $inverted = new Intent();
 
         foreach (array_reverse($this->commands) as $command) {
             switch (true) {
                 case $command instanceof CreateTable:
+                    /** @var \Phinx\Db\Action\CreateTable $command */
                     $inverted->addAction(new DropTable($command->getTable()));
                     break;
 
                 case $command instanceof RenameTable:
+                    /** @var \Phinx\Db\Action\RenameTable $command */
                     $inverted->addAction(new RenameTable(new Table($command->getNewName()), $command->getTable()->getName()));
                     break;
 
                 case $command instanceof AddColumn:
+                    /** @var \Phinx\Db\Action\AddColumn $command */
                     $inverted->addAction(new RemoveColumn($command->getTable(), $command->getColumn()));
                     break;
 
                 case $command instanceof RenameColumn:
+                    /** @var \Phinx\Db\Action\RenameColumn $command */
                     $column = clone $command->getColumn();
                     $name = $column->getName();
                     $column->setName($command->getNewName());
@@ -92,10 +96,12 @@ class ProxyAdapter extends AdapterWrapper
                     break;
 
                 case $command instanceof AddIndex:
+                    /** @var \Phinx\Db\Action\AddIndex $command */
                     $inverted->addAction(new DropIndex($command->getTable(), $command->getIndex()));
                     break;
 
                 case $command instanceof AddForeignKey:
+                    /** @var \Phinx\Db\Action\AddForeignKey $command */
                     $inverted->addAction(new DropForeignKey($command->getTable(), $command->getForeignKey()));
                     break;
 
@@ -115,7 +121,7 @@ class ProxyAdapter extends AdapterWrapper
      *
      * @return void
      */
-    public function executeInvertedCommands()
+    public function executeInvertedCommands(): void
     {
         $plan = new Plan($this->getInvertedCommands());
         $plan->executeInverse($this->getAdapter());

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1396,7 +1396,7 @@ PCRE_PATTERN;
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType($type, ?float $limit = null): array
     {
         $typeLC = strtolower($type);
         if ($type instanceof Literal) {

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1394,9 +1394,11 @@ PCRE_PATTERN;
     /**
      * {@inheritDoc}
      *
+     * @param string|\Phinx\Db\Literal $type Type
+     * @param int|null $limit Limit
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType(string $type, ?int $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         $typeLC = strtolower($type);
         if ($type instanceof Literal) {

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -518,7 +518,7 @@ class SQLiteAdapter extends PdoAdapter
      * a string value, a string representing an expression, or some other scalar
      *
      * @param mixed $default The default-value expression to interpret
-     * @param string $t The Phinx type of the column
+     * @param string $columnType The Phinx type of the column
      * @return mixed
      */
     protected function parseDefaultValue($default, string $columnType)
@@ -1394,8 +1394,6 @@ PCRE_PATTERN;
     /**
      * {@inheritDoc}
      *
-     * @param string|\Phinx\Db\Literal $type Type
-     * @param int|null $limit Limit
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
     public function getSqlType($type, ?int $limit = null): array

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -131,7 +131,7 @@ class SQLiteAdapter extends PdoAdapter
      * @param string $ver The version to check against e.g. '3.28.0'
      * @return bool
      */
-    public function databaseVersionAtLeast($ver)
+    public function databaseVersionAtLeast($ver): bool
     {
         $actual = $this->query('SELECT sqlite_version()')->fetchColumn();
 
@@ -145,7 +145,7 @@ class SQLiteAdapter extends PdoAdapter
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function connect()
+    public function connect(): void
     {
         if ($this->connection === null) {
             if (!class_exists('PDO') || !in_array('sqlite', PDO::getAvailableDrivers(), true)) {
@@ -179,7 +179,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): AdapterInterface
     {
         parent::setOptions($options);
 
@@ -198,7 +198,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->connection = null;
     }
@@ -206,7 +206,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasTransactions()
+    public function hasTransactions(): bool
     {
         return true;
     }
@@ -214,7 +214,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function beginTransaction()
+    public function beginTransaction(): void
     {
         $this->getConnection()->beginTransaction();
     }
@@ -222,7 +222,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function commitTransaction()
+    public function commitTransaction(): void
     {
         $this->getConnection()->commit();
     }
@@ -230,7 +230,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): void
     {
         $this->getConnection()->rollBack();
     }
@@ -238,7 +238,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function quoteTableName($tableName)
+    public function quoteTableName($tableName): string
     {
         return str_replace('.', '`.`', $this->quoteColumnName($tableName));
     }
@@ -246,7 +246,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function quoteColumnName($columnName)
+    public function quoteColumnName($columnName): string
     {
         return '`' . str_replace('`', '``', $columnName) . '`';
     }
@@ -256,7 +256,7 @@ class SQLiteAdapter extends PdoAdapter
      * @param bool $quoted Whether to return the schema name and table name escaped and quoted. If quoted, the schema (if any) will also be appended with a dot
      * @return array
      */
-    protected function getSchemaName($tableName, $quoted = false)
+    protected function getSchemaName(string $tableName, bool $quoted = false): array
     {
         if (preg_match("/.\.([^\.]+)$/", $tableName, $match)) {
             $table = $match[1];
@@ -281,7 +281,7 @@ class SQLiteAdapter extends PdoAdapter
      * @param string $pragma The pragma to query
      * @return array
      */
-    protected function getTableInfo($tableName, $pragma = 'table_info')
+    protected function getTableInfo(string $tableName, string $pragma = 'table_info'): array
     {
         $info = $this->getSchemaName($tableName, true);
 
@@ -296,7 +296,7 @@ class SQLiteAdapter extends PdoAdapter
      * @param string $tableName The name of the table to find
      * @return array
      */
-    protected function resolveTable($tableName)
+    protected function resolveTable(string $tableName): array
     {
         $info = $this->getSchemaName($tableName);
         if ($info['schema'] === '') {
@@ -345,7 +345,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasTable($tableName)
+    public function hasTable(string $tableName): bool
     {
         return $this->hasCreatedTable($tableName) || $this->resolveTable($tableName)['exists'];
     }
@@ -353,7 +353,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = [])
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
     {
         // Add the default primary key
         $options = $table->getOptions();
@@ -421,7 +421,7 @@ class SQLiteAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns)
+    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -458,7 +458,7 @@ class SQLiteAdapter extends PdoAdapter
      *
      * @throws \BadMethodCallException
      */
-    protected function getChangeCommentInstructions(Table $table, $newComment)
+    protected function getChangeCommentInstructions(Table $table, $newComment): AlterInstructions
     {
         throw new BadMethodCallException('SQLite does not have table comments');
     }
@@ -466,7 +466,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getRenameTableInstructions($tableName, $newTableName)
+    protected function getRenameTableInstructions(string $tableName, string $newTableName): AlterInstructions
     {
         $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
@@ -481,7 +481,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropTableInstructions($tableName)
+    protected function getDropTableInstructions(string $tableName): AlterInstructions
     {
         $this->removeCreatedTable($tableName);
         $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
@@ -492,7 +492,7 @@ class SQLiteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function truncateTable($tableName)
+    public function truncateTable(string $tableName): void
     {
         $info = $this->resolveTable($tableName);
         // first try deleting the rows
@@ -517,13 +517,13 @@ class SQLiteAdapter extends PdoAdapter
      * Parses a default-value expression to yield either a Literal representing
      * a string value, a string representing an expression, or some other scalar
      *
-     * @param mixed $v The default-value expression to interpret
+     * @param mixed $default The default-value expression to interpret
      * @param string $t The Phinx type of the column
      * @return mixed
      */
-    protected function parseDefaultValue($v, $t)
+    protected function parseDefaultValue($default, string $columnType)
     {
-        if ($v === null) {
+        if ($default === null) {
             return null;
         }
 
@@ -541,47 +541,47 @@ class SQLiteAdapter extends PdoAdapter
                 .                               # Any other single character
             /sx
 PCRE_PATTERN;
-        preg_match_all($pattern, $v, $matches);
+        preg_match_all($pattern, $default, $matches);
         // strip out any comment tokens
         $matches = array_map(function ($v) {
             return preg_match('/^(?:\/\*|--)/', $v) ? ' ' : $v;
         }, $matches[0]);
         // reconstitute the string, trimming whitespace as well as parentheses
-        $vClean = trim(implode('', $matches));
-        $vBare = rtrim(ltrim($vClean, $trimChars . '('), $trimChars . ')');
+        $defaultClean = trim(implode('', $matches));
+        $defaultBare = rtrim(ltrim($defaultClean, $trimChars . '('), $trimChars . ')');
 
         // match the string against one of several patterns
-        if (preg_match('/^CURRENT_(?:DATE|TIME|TIMESTAMP)$/i', $vBare)) {
+        if (preg_match('/^CURRENT_(?:DATE|TIME|TIMESTAMP)$/i', $defaultBare)) {
             // magic date or time
-            return strtoupper($vBare);
-        } elseif (preg_match('/^\'(?:[^\']|\'\')*\'$/i', $vBare)) {
+            return strtoupper($defaultBare);
+        } elseif (preg_match('/^\'(?:[^\']|\'\')*\'$/i', $defaultBare)) {
             // string literal
-            $str = str_replace("''", "'", substr($vBare, 1, strlen($vBare) - 2));
+            $str = str_replace("''", "'", substr($defaultBare, 1, strlen($defaultBare) - 2));
 
             return Literal::from($str);
-        } elseif (preg_match('/^[+-]?\d+$/i', $vBare)) {
-            $int = (int)$vBare;
+        } elseif (preg_match('/^[+-]?\d+$/i', $defaultBare)) {
+            $int = (int)$defaultBare;
             // integer literal
-            if ($t === self::PHINX_TYPE_BOOLEAN && ($int === 0 || $int === 1)) {
+            if ($columnType === self::PHINX_TYPE_BOOLEAN && ($int === 0 || $int === 1)) {
                 return (bool)$int;
             } else {
                 return $int;
             }
-        } elseif (preg_match('/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i', $vBare)) {
+        } elseif (preg_match('/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i', $defaultBare)) {
             // float literal
-            return (float)$vBare;
-        } elseif (preg_match('/^0x[0-9a-f]+$/i', $vBare)) {
+            return (float)$defaultBare;
+        } elseif (preg_match('/^0x[0-9a-f]+$/i', $defaultBare)) {
             // hexadecimal literal
-            return hexdec(substr($vBare, 2));
-        } elseif (preg_match('/^null$/i', $vBare)) {
+            return hexdec(substr($defaultBare, 2));
+        } elseif (preg_match('/^null$/i', $defaultBare)) {
             // null literal
             return null;
-        } elseif (preg_match('/^true|false$/i', $vBare)) {
+        } elseif (preg_match('/^true|false$/i', $defaultBare)) {
             // boolean literal
-            return filter_var($vClean, \FILTER_VALIDATE_BOOLEAN);
+            return filter_var($defaultClean, \FILTER_VALIDATE_BOOLEAN);
         } else {
             // any other expression: return the expression with parentheses, but without comments
-            return Expression::from($vClean);
+            return Expression::from($defaultClean);
         }
     }
 
@@ -593,7 +593,7 @@ PCRE_PATTERN;
      * @param string $tableName The name of the table
      * @return string|null
      */
-    protected function resolveIdentity($tableName)
+    protected function resolveIdentity(string $tableName): ?string
     {
         $result = null;
         // make sure the table has only one primary key column which is of type integer
@@ -631,7 +631,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function getColumns($tableName)
+    public function getColumns(string $tableName): array
     {
         $columns = [];
 
@@ -660,7 +660,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function hasColumn($tableName, $columnName)
+    public function hasColumn(string $tableName, string $columnName): bool
     {
         $rows = $this->getTableInfo($tableName);
         foreach ($rows as $column) {
@@ -675,7 +675,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getAddColumnInstructions(Table $table, Column $column)
+    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
     {
         $tableName = $table->getName();
 
@@ -723,7 +723,7 @@ PCRE_PATTERN;
      * @param string $tableName The table name to get the create statement for
      * @return string
      */
-    protected function getDeclaringSql($tableName)
+    protected function getDeclaringSql(string $tableName): string
     {
         $rows = $this->fetchAll("SELECT * FROM sqlite_master WHERE `type` = 'table'");
 
@@ -744,7 +744,7 @@ PCRE_PATTERN;
      * @param string $indexName The table index
      * @return string
      */
-    protected function getDeclaringIndexSql($tableName, $indexName)
+    protected function getDeclaringIndexSql(string $tableName, string $indexName): string
     {
         $rows = $this->fetchAll("SELECT * FROM sqlite_master WHERE `type` = 'index'");
 
@@ -767,7 +767,7 @@ PCRE_PATTERN;
      * @param string[] $selectColumns The list of columns in the tmp table
      * @return void
      */
-    protected function copyDataToNewTable($tableName, $tmpTableName, $writeColumns, $selectColumns)
+    protected function copyDataToNewTable(string $tableName, string $tmpTableName, array $writeColumns, array $selectColumns): void
     {
         $sql = sprintf(
             'INSERT INTO %s(%s) SELECT %s FROM %s',
@@ -787,7 +787,7 @@ PCRE_PATTERN;
      * @param string $tableName The table name to copy the data to
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    protected function copyAndDropTmpTable($instructions, $tableName)
+    protected function copyAndDropTmpTable(AlterInstructions $instructions, string $tableName): AlterInstructions
     {
         $instructions->addPostStep(function ($state) use ($tableName) {
             $this->copyDataToNewTable(
@@ -820,7 +820,7 @@ PCRE_PATTERN;
      * @throws \InvalidArgumentException
      * @return array
      */
-    protected function calculateNewTableColumns($tableName, $columnName, $newColumnName)
+    protected function calculateNewTableColumns(string $tableName, $columnName, $newColumnName): array
     {
         $columns = $this->fetchAll(sprintf('pragma table_info(%s)', $this->quoteTableName($tableName)));
         $selectColumns = [];
@@ -864,7 +864,7 @@ PCRE_PATTERN;
      * @param string $tableName The table to modify
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    protected function beginAlterByCopyTable($tableName)
+    protected function beginAlterByCopyTable(string $tableName): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $instructions->addPostStep(function ($state) use ($tableName) {
@@ -895,7 +895,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getRenameColumnInstructions($tableName, $columnName, $newColumnName)
+    protected function getRenameColumnInstructions(string $tableName, string $columnName, string $newColumnName): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($tableName);
 
@@ -922,7 +922,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getChangeColumnInstructions($tableName, $columnName, Column $newColumn)
+    protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($tableName);
 
@@ -951,7 +951,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getDropColumnInstructions($tableName, $columnName)
+    protected function getDropColumnInstructions(string $tableName, string $columnName): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($tableName);
 
@@ -986,7 +986,7 @@ PCRE_PATTERN;
      * @param string $tableName Table name
      * @return array
      */
-    protected function getIndexes($tableName)
+    protected function getIndexes(string $tableName): array
     {
         $indexes = [];
         $schema = $this->getSchemaName($tableName, true)['schema'];
@@ -1011,7 +1011,7 @@ PCRE_PATTERN;
      * @param string|string[] $columns The columns of the index
      * @return array
      */
-    protected function resolveIndex($tableName, $columns)
+    protected function resolveIndex(string $tableName, $columns): array
     {
         $columns = array_map('strtolower', (array)$columns);
         $indexes = $this->getIndexes($tableName);
@@ -1030,7 +1030,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function hasIndex($tableName, $columns)
+    public function hasIndex(string $tableName, $columns): bool
     {
         return (bool)$this->resolveIndex($tableName, $columns);
     }
@@ -1038,7 +1038,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function hasIndexByName($tableName, $indexName)
+    public function hasIndexByName(string $tableName, string $indexName): bool
     {
         $indexName = strtolower($indexName);
         $indexes = $this->getIndexes($tableName);
@@ -1055,7 +1055,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getAddIndexInstructions(Table $table, Index $index)
+    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
     {
         $indexColumnArray = [];
         foreach ($index->getColumns() as $column) {
@@ -1075,7 +1075,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getDropIndexByColumnsInstructions($tableName, $columns)
+    protected function getDropIndexByColumnsInstructions(string $tableName, $columns): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $indexNames = $this->resolveIndex($tableName, $columns);
@@ -1096,7 +1096,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getDropIndexByNameInstructions($tableName, $indexName)
+    protected function getDropIndexByNameInstructions(string $tableName, string $indexName): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $indexName = strtolower($indexName);
@@ -1127,7 +1127,7 @@ PCRE_PATTERN;
      *
      * @throws \InvalidArgumentException
      */
-    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         if ($constraint !== null) {
             throw new InvalidArgumentException('SQLite does not support named constraints.');
@@ -1149,7 +1149,7 @@ PCRE_PATTERN;
      * @param string $tableName Table name
      * @return string[]
      */
-    protected function getPrimaryKey($tableName)
+    protected function getPrimaryKey(string $tableName): array
     {
         $primaryKey = [];
 
@@ -1167,7 +1167,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function hasForeignKey($tableName, $columns, $constraint = null)
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         if ($constraint !== null) {
             return preg_match(
@@ -1197,7 +1197,7 @@ PCRE_PATTERN;
      * @param string $tableName Table name
      * @return array
      */
-    protected function getForeignKeys($tableName)
+    protected function getForeignKeys(string $tableName): array
     {
         $foreignKeys = [];
 
@@ -1218,7 +1218,7 @@ PCRE_PATTERN;
      * @param string $column Column Name
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    protected function getAddPrimaryKeyInstructions(Table $table, $column)
+    protected function getAddPrimaryKeyInstructions(Table $table, string $column): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($table->getName());
 
@@ -1261,7 +1261,7 @@ PCRE_PATTERN;
      * @param string $column Column Name
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    protected function getDropPrimaryKeyInstructions($table, $column)
+    protected function getDropPrimaryKeyInstructions(Table $table, string $column): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($table->getName());
 
@@ -1288,7 +1288,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey)
+    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($table->getName());
 
@@ -1340,7 +1340,7 @@ PCRE_PATTERN;
      *
      * @throws \BadMethodCallException
      */
-    protected function getDropForeignKeyInstructions($tableName, $constraint)
+    protected function getDropForeignKeyInstructions(string $tableName, string $constraint): AlterInstructions
     {
         throw new BadMethodCallException('SQLite does not have named foreign keys');
     }
@@ -1350,7 +1350,7 @@ PCRE_PATTERN;
      *
      * @throws \InvalidArgumentException
      */
-    protected function getDropForeignKeyByColumnsInstructions($tableName, $columns)
+    protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($tableName);
 
@@ -1396,7 +1396,7 @@ PCRE_PATTERN;
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, $limit = null)
+    public function getSqlType(string $type, ?int $limit = null): array
     {
         $typeLC = strtolower($type);
         if ($type instanceof Literal) {
@@ -1418,7 +1418,7 @@ PCRE_PATTERN;
      * @param string|null $sqlTypeDef SQL Type definition
      * @return array
      */
-    public function getPhinxType($sqlTypeDef)
+    public function getPhinxType(?string $sqlTypeDef): array
     {
         $limit = null;
         $scale = null;
@@ -1464,7 +1464,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function createDatabase($name, $options = [])
+    public function createDatabase(string $name, array $options = []): void
     {
         touch($name . $this->suffix);
     }
@@ -1472,7 +1472,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function hasDatabase($name)
+    public function hasDatabase(string $name): bool
     {
         return is_file($name . $this->suffix);
     }
@@ -1480,7 +1480,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function dropDatabase($name)
+    public function dropDatabase(string $name): void
     {
         $this->createdTables = [];
         if ($this->getOption('memory')) {
@@ -1498,7 +1498,7 @@ PCRE_PATTERN;
      * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
-    protected function getColumnSqlDefinition(Column $column)
+    protected function getColumnSqlDefinition(Column $column): string
     {
         $isLiteralType = $column->getType() instanceof Literal;
         if ($isLiteralType) {
@@ -1533,7 +1533,7 @@ PCRE_PATTERN;
      * @param \Phinx\Db\Table\Column $column Column
      * @return string
      */
-    protected function getCommentDefinition(Column $column)
+    protected function getCommentDefinition(Column $column): string
     {
         if ($column->getComment()) {
             return ' /* ' . $column->getComment() . ' */ ';
@@ -1549,7 +1549,7 @@ PCRE_PATTERN;
      * @param \Phinx\Db\Table\Index $index Index
      * @return string
      */
-    protected function getIndexSqlDefinition(Table $table, Index $index)
+    protected function getIndexSqlDefinition(Table $table, Index $index): string
     {
         if ($index->getType() === Index::UNIQUE) {
             $def = 'UNIQUE INDEX';
@@ -1573,7 +1573,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function getColumnTypes()
+    public function getColumnTypes(): array
     {
         return array_keys(static::$supportedColumnTypes);
     }
@@ -1584,7 +1584,7 @@ PCRE_PATTERN;
      * @param \Phinx\Db\Table\ForeignKey $foreignKey Foreign key
      * @return string
      */
-    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey)
+    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey): string
     {
         $def = '';
         if ($foreignKey->getConstraint()) {
@@ -1613,7 +1613,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection()
+    public function getDecoratedConnection(): \Cake\Database\Connection
     {
         $options = $this->getOptions();
         $options['quoteIdentifiers'] = true;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1396,7 +1396,7 @@ PCRE_PATTERN;
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?float $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         $typeLC = strtolower($type);
         if ($type instanceof Literal) {

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1613,7 +1613,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection(): \Cake\Database\Connection
+    public function getDecoratedConnection(): Connection
     {
         $options = $this->getOptions();
         $options['quoteIdentifiers'] = true;

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -58,7 +58,7 @@ class SqlServerAdapter extends PdoAdapter
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function connect()
+    public function connect(): void
     {
         if ($this->connection === null) {
             if (!class_exists('PDO') || !in_array('sqlsrv', PDO::getAvailableDrivers(), true)) {
@@ -116,7 +116,7 @@ class SqlServerAdapter extends PdoAdapter
      * @throws \RuntimeException
      * @return void
      */
-    protected function connectDblib()
+    protected function connectDblib(): void
     {
         if (!class_exists('PDO') || !in_array('dblib', PDO::getAvailableDrivers(), true)) {
             // @codeCoverageIgnoreStart
@@ -150,7 +150,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->connection = null;
     }
@@ -158,7 +158,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasTransactions()
+    public function hasTransactions(): bool
     {
         return true;
     }
@@ -166,7 +166,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function beginTransaction()
+    public function beginTransaction(): void
     {
         $this->execute('BEGIN TRANSACTION');
     }
@@ -174,7 +174,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function commitTransaction()
+    public function commitTransaction(): void
     {
         $this->execute('COMMIT TRANSACTION');
     }
@@ -182,7 +182,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): void
     {
         $this->execute('ROLLBACK TRANSACTION');
     }
@@ -190,7 +190,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function quoteTableName($tableName)
+    public function quoteTableName(string $tableName): string
     {
         return str_replace('.', '].[', $this->quoteColumnName($tableName));
     }
@@ -198,7 +198,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function quoteColumnName($columnName)
+    public function quoteColumnName(string $columnName): string
     {
         return '[' . str_replace(']', '\]', $columnName) . ']';
     }
@@ -206,7 +206,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasTable($tableName)
+    public function hasTable(string $tableName): bool
     {
         if ($this->hasCreatedTable($tableName)) {
             return true;
@@ -220,7 +220,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = [])
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
     {
         $options = $table->getOptions();
 
@@ -292,7 +292,7 @@ class SqlServerAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns)
+    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -336,7 +336,7 @@ class SqlServerAdapter extends PdoAdapter
      * SqlServer does not implement this functionality, and so will always throw an exception if used.
      * @throws \BadMethodCallException
      */
-    protected function getChangeCommentInstructions(Table $table, $newComment)
+    protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions
     {
         throw new BadMethodCallException('SqlServer does not have table comments');
     }
@@ -348,7 +348,7 @@ class SqlServerAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return string
      */
-    protected function getColumnCommentSqlDefinition(Column $column, $tableName)
+    protected function getColumnCommentSqlDefinition(Column $column, $tableName): string
     {
         // passing 'null' is to remove column comment
         $currentComment = $this->getColumnComment($tableName, $column->getName());
@@ -369,7 +369,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getRenameTableInstructions($tableName, $newTableName)
+    protected function getRenameTableInstructions(string $tableName, string $newTableName): AlterInstructions
     {
         $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
@@ -384,7 +384,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getDropTableInstructions($tableName)
+    protected function getDropTableInstructions(string $tableName): AlterInstructions
     {
         $this->removeCreatedTable($tableName);
         $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
@@ -395,7 +395,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function truncateTable($tableName)
+    public function truncateTable(string $tableName): void
     {
         $sql = sprintf(
             'TRUNCATE TABLE %s',
@@ -408,9 +408,9 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @param string $tableName Table name
      * @param string $columnName Column name
-     * @return string|false
+     * @return string|null
      */
-    public function getColumnComment($tableName, $columnName)
+    public function getColumnComment(string $tableName, string $columnName): ?string
     {
         $sql = sprintf("SELECT cast(extended_properties.[value] as nvarchar(4000)) comment
   FROM sys.schemas
@@ -429,13 +429,13 @@ class SqlServerAdapter extends PdoAdapter
             return trim($row['comment']);
         }
 
-        return false;
+        return null;
     }
 
     /**
      * @inheritDoc
      */
-    public function getColumns($tableName)
+    public function getColumns(string $tableName): array
     {
         $columns = [];
         $sql = sprintf(
@@ -480,7 +480,7 @@ class SqlServerAdapter extends PdoAdapter
      * @param string $default Default
      * @return int|string|null
      */
-    protected function parseDefault($default)
+    protected function parseDefault(string $default)
     {
         $result = preg_replace(["/\('(.*)'\)/", "/\(\((.*)\)\)/", "/\((.*)\)/"], '$1', $default);
 
@@ -496,7 +496,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasColumn($tableName, $columnName)
+    public function hasColumn(string $tableName, string $columnName): bool
     {
         $sql = sprintf(
             "SELECT count(*) as [count]
@@ -513,7 +513,7 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddColumnInstructions(Table $table, Column $column)
+    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
     {
         $alter = sprintf(
             'ALTER TABLE %s ADD %s %s',
@@ -530,7 +530,7 @@ class SqlServerAdapter extends PdoAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getRenameColumnInstructions($tableName, $columnName, $newColumnName)
+    protected function getRenameColumnInstructions(string $tableName, string $columnName, string $newColumnName): AlterInstructions
     {
         if (!$this->hasColumn($tableName, $columnName)) {
             throw new InvalidArgumentException("The specified column does not exist: $columnName");
@@ -569,7 +569,7 @@ SQL;
      * @param \Phinx\Db\Table\Column $newColumn The column to alter
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    protected function getChangeDefault($tableName, Column $newColumn)
+    protected function getChangeDefault(string $tableName, Column $newColumn): AlterInstructions
     {
         $constraintName = "DF_{$tableName}_{$newColumn->getName()}";
         $default = $newColumn->getDefault();
@@ -599,7 +599,7 @@ SQL;
     /**
      * @inheritDoc
      */
-    protected function getChangeColumnInstructions($tableName, $columnName, Column $newColumn)
+    protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions
     {
         $columns = $this->getColumns($tableName);
         $changeDefault =
@@ -639,7 +639,7 @@ SQL;
     /**
      * @inheritDoc
      */
-    protected function getDropColumnInstructions($tableName, $columnName)
+    protected function getDropColumnInstructions(string $tableName, string $columnName): AlterInstructions
     {
         $instructions = $this->getDropDefaultConstraint($tableName, $columnName);
 
@@ -657,7 +657,7 @@ SQL;
      * @param string|null $columnName Column name
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    protected function getDropDefaultConstraint($tableName, $columnName)
+    protected function getDropDefaultConstraint(string $tableName, ?string $columnName): AlterInstructions
     {
         $defaultConstraint = $this->getDefaultConstraint($tableName, $columnName);
 
@@ -673,7 +673,7 @@ SQL;
      * @param string $columnName Column name
      * @return string|false
      */
-    protected function getDefaultConstraint($tableName, $columnName)
+    protected function getDefaultConstraint(string $tableName, string $columnName)
     {
         $sql = "SELECT
     default_constraints.name
@@ -707,7 +707,7 @@ WHERE
      * @param int $indexId Index ID
      * @return array
      */
-    protected function getIndexColums($tableId, $indexId)
+    protected function getIndexColums(int $tableId, int $indexId): array
     {
         $sql = "SELECT AC.[name] AS [column_name]
 FROM sys.[index_columns] IC
@@ -730,7 +730,7 @@ ORDER BY IC.[key_ordinal];";
      * @param string $tableName Table name
      * @return array
      */
-    public function getIndexes($tableName)
+    public function getIndexes(string $tableName): array
     {
         $indexes = [];
         $sql = "SELECT I.[name] AS [index_name], I.[index_id] as [index_id], T.[object_id] as [table_id]
@@ -751,7 +751,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    public function hasIndex($tableName, $columns)
+    public function hasIndex(string $tableName, $columns): bool
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -774,7 +774,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    public function hasIndexByName($tableName, $indexName)
+    public function hasIndexByName(string $tableName, string $indexName): bool
     {
         $indexes = $this->getIndexes($tableName);
 
@@ -790,7 +790,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    protected function getAddIndexInstructions(Table $table, Index $index)
+    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
     {
         $sql = $this->getIndexSqlDefinition($index, $table->getName());
 
@@ -802,7 +802,7 @@ ORDER BY T.[name], I.[index_id];";
      *
      * @throws \InvalidArgumentException
      */
-    protected function getDropIndexByColumnsInstructions($tableName, $columns)
+    protected function getDropIndexByColumnsInstructions(string $tableName, $columns): AlterInstructions
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -836,7 +836,7 @@ ORDER BY T.[name], I.[index_id];";
      *
      * @throws \InvalidArgumentException
      */
-    protected function getDropIndexByNameInstructions($tableName, $indexName)
+    protected function getDropIndexByNameInstructions(string $tableName, string $indexName): AlterInstructions
     {
         $indexes = $this->getIndexes($tableName);
         $instructions = new AlterInstructions();
@@ -862,7 +862,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         $primaryKey = $this->getPrimaryKey($tableName);
 
@@ -888,7 +888,7 @@ ORDER BY T.[name], I.[index_id];";
      * @param string $tableName Table name
      * @return array
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         $rows = $this->fetchAll(sprintf(
             "SELECT
@@ -917,7 +917,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    public function hasForeignKey($tableName, $columns, $constraint = null)
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -947,7 +947,7 @@ ORDER BY T.[name], I.[index_id];";
      * @param string $tableName Table name
      * @return array
      */
-    protected function getForeignKeys($tableName)
+    protected function getForeignKeys(string $tableName): array
     {
         $foreignKeys = [];
         $rows = $this->fetchAll(sprintf(
@@ -977,7 +977,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey)
+    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $instructions->addPostStep(sprintf(
@@ -992,7 +992,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    protected function getDropForeignKeyInstructions($tableName, $constraint)
+    protected function getDropForeignKeyInstructions(string $tableName, string $constraint): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $instructions->addPostStep(sprintf(
@@ -1007,7 +1007,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    protected function getDropForeignKeyByColumnsInstructions($tableName, $columns)
+    protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -1042,7 +1042,7 @@ ORDER BY T.[name], I.[index_id];";
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, $limit = null)
+    public function getSqlType(string $type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:
@@ -1101,7 +1101,7 @@ ORDER BY T.[name], I.[index_id];";
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      * @return string Phinx type
      */
-    public function getPhinxType($sqlType)
+    public function getPhinxType(string $sqlType): string
     {
         switch ($sqlType) {
             case 'nvarchar':
@@ -1154,7 +1154,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    public function createDatabase($name, $options = [])
+    public function createDatabase(string $name, array $options = []): void
     {
         if (isset($options['collation'])) {
             $this->execute(sprintf('CREATE DATABASE [%s] COLLATE [%s]', $name, $options['collation']));
@@ -1167,7 +1167,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    public function hasDatabase($name)
+    public function hasDatabase(string $name): bool
     {
         $result = $this->fetchRow(
             sprintf(
@@ -1182,7 +1182,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    public function dropDatabase($name)
+    public function dropDatabase(string $name): void
     {
         $sql = <<<SQL
 USE master;
@@ -1201,7 +1201,7 @@ SQL;
      * @param bool $create Create column flag
      * @return string
      */
-    protected function getColumnSqlDefinition(Column $column, $create = true)
+    protected function getColumnSqlDefinition(Column $column, bool $create = true): string
     {
         $buffer = [];
         if ($column->getType() instanceof Literal) {
@@ -1257,7 +1257,7 @@ SQL;
      * @param string $tableName Table name
      * @return string
      */
-    protected function getIndexSqlDefinition(Index $index, $tableName)
+    protected function getIndexSqlDefinition(Index $index, string $tableName): string
     {
         $columnNames = $index->getColumns();
         if (is_string($index->getName())) {
@@ -1294,7 +1294,7 @@ SQL;
      * @param string $tableName Table name
      * @return string
      */
-    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, $tableName)
+    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
         $constraintName = $foreignKey->getConstraint() ?: $tableName . '_' . implode('_', $foreignKey->getColumns());
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName);
@@ -1313,7 +1313,7 @@ SQL;
     /**
      * @inheritDoc
      */
-    public function getColumnTypes()
+    public function getColumnTypes(): array
     {
         return array_merge(parent::getColumnTypes(), static::$specificColumnTypes);
     }
@@ -1327,7 +1327,7 @@ SQL;
      * @param string $endTime End Time
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
+    public function migrated(MigrationInterface $migration, string $direction, string $startTime, string $endTime): AdapterInterface
     {
         $startTime = str_replace(' ', 'T', $startTime);
         $endTime = str_replace(' ', 'T', $endTime);
@@ -1338,7 +1338,7 @@ SQL;
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection()
+    public function getDecoratedConnection(): Connection
     {
         $options = $this->getOptions();
         $options = [

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1042,7 +1042,7 @@ ORDER BY T.[name], I.[index_id];";
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType($type, ?float $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -354,7 +354,7 @@ class SqlServerAdapter extends PdoAdapter
         $currentComment = $this->getColumnComment($tableName, $column->getName());
 
         $comment = strcasecmp($column->getComment(), 'NULL') !== 0 ? $this->getConnection()->quote($column->getComment()) : '\'\'';
-        $command = $currentComment === false ? 'sp_addextendedproperty' : 'sp_updateextendedproperty';
+        $command = $currentComment === null ? 'sp_addextendedproperty' : 'sp_updateextendedproperty';
 
         return sprintf(
             "EXECUTE %s N'MS_Description', N%s, N'SCHEMA', N'%s', N'TABLE', N'%s', N'COLUMN', N'%s';",
@@ -1042,7 +1042,7 @@ ORDER BY T.[name], I.[index_id];";
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType(string $type, ?int $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -477,11 +477,14 @@ class SqlServerAdapter extends PdoAdapter
     }
 
     /**
-     * @param string $default Default
+     * @param string|null $default Default
      * @return int|string|null
      */
-    protected function parseDefault(string $default)
+    protected function parseDefault(?string $default)
     {
+        if ($default === null) {
+            return null;
+        }
         $result = preg_replace(["/\('(.*)'\)/", "/\(\((.*)\)\)/", "/\((.*)\)/"], '$1', $default);
 
         if (strtoupper($result) === 'NULL') {

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1045,7 +1045,7 @@ ORDER BY T.[name], I.[index_id];";
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?float $limit = null): array
+    public function getSqlType($type, ?int $limit = null): array
     {
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -38,7 +38,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function getAdapterType()
+    public function getAdapterType(): string
     {
         return 'TablePrefixAdapter';
     }
@@ -46,7 +46,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function hasTable($tableName)
+    public function hasTable(string $tableName): bool
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
 
@@ -56,7 +56,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = [])
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
     {
         $adapterTable = new Table(
             $this->getAdapterTableName($table->getName()),
@@ -71,7 +71,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function changePrimaryKey(Table $table, $newColumns)
+    public function changePrimaryKey(Table $table, $newColumns): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -91,7 +91,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function changeComment(Table $table, $newComment)
+    public function changeComment(Table $table, ?string $newComment): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -111,7 +111,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function renameTable($tableName, $newTableName)
+    public function renameTable(string $tableName, string $newTableName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -129,7 +129,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropTable($tableName)
+    public function dropTable(string $tableName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -142,7 +142,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function truncateTable($tableName)
+    public function truncateTable(string $tableName): void
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
         parent::truncateTable($adapterTableName);
@@ -151,7 +151,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function getColumns($tableName)
+    public function getColumns(string $tableName): array
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
 
@@ -161,7 +161,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function hasColumn($tableName, $columnName)
+    public function hasColumn(string $tableName, string $columnName): bool
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
 
@@ -174,7 +174,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addColumn(Table $table, Column $column)
+    public function addColumn(Table $table, Column $column): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -191,7 +191,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function renameColumn($tableName, $columnName, $newColumnName)
+    public function renameColumn(string $tableName, string $columnName, string $newColumnName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -207,7 +207,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function changeColumn($tableName, $columnName, Column $newColumn)
+    public function changeColumn(string $tableName, string $columnName, Column $newColumn): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -223,7 +223,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropColumn($tableName, $columnName)
+    public function dropColumn(string $tableName, string $columnName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -236,7 +236,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function hasIndex($tableName, $columns)
+    public function hasIndex(string $tableName, $columns): bool
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
 
@@ -246,7 +246,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function hasIndexByName($tableName, $indexName)
+    public function hasIndexByName(string $tableName, string $indexName): bool
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
 
@@ -259,7 +259,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addIndex(Table $table, Index $index)
+    public function addIndex(Table $table, Index $index): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -275,7 +275,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropIndex($tableName, $columns)
+    public function dropIndex(string $tableName, $columns): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -291,7 +291,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropIndexByName($tableName, $indexName)
+    public function dropIndexByName(string $tableName, string $indexName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -304,7 +304,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function hasPrimaryKey($tableName, $columns, $constraint = null)
+    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
 
@@ -314,7 +314,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function hasForeignKey($tableName, $columns, $constraint = null)
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
 
@@ -327,7 +327,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addForeignKey(Table $table, ForeignKey $foreignKey)
+    public function addForeignKey(Table $table, ForeignKey $foreignKey): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -344,7 +344,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropForeignKey($tableName, $columns, $constraint = null)
+    public function dropForeignKey(string $tableName, array $columns, ?string $constraint = null): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -357,7 +357,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function insert(Table $table, $row)
+    public function insert(Table $table, array $row): void
     {
         $adapterTableName = $this->getAdapterTableName($table->getName());
         $adapterTable = new Table($adapterTableName, $table->getOptions());
@@ -367,7 +367,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function bulkinsert(Table $table, $rows)
+    public function bulkinsert(Table $table, array $rows): void
     {
         $adapterTableName = $this->getAdapterTableName($table->getName());
         $adapterTable = new Table($adapterTableName, $table->getOptions());
@@ -379,7 +379,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      *
      * @return string
      */
-    public function getPrefix()
+    public function getPrefix(): string
     {
         return (string)$this->getOption('table_prefix');
     }
@@ -389,7 +389,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      *
      * @return string
      */
-    public function getSuffix()
+    public function getSuffix(): string
     {
         return (string)$this->getOption('table_suffix');
     }
@@ -400,7 +400,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @param string $tableName Table name
      * @return string
      */
-    public function getAdapterTableName($tableName)
+    public function getAdapterTableName(string $tableName): string
     {
         return $this->getPrefix() . $tableName . $this->getSuffix();
     }
@@ -411,7 +411,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function executeActions(Table $table, array $actions)
+    public function executeActions(Table $table, array $actions): void
     {
         $adapterTableName = $this->getAdapterTableName($table->getName());
         $adapterTable = new Table($adapterTableName, $table->getOptions());
@@ -419,14 +419,17 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
         foreach ($actions as $k => $action) {
             switch (true) {
                 case $action instanceof AddColumn:
+                    /** @var \Phinx\Db\Action\AddColumn $action */
                     $actions[$k] = new AddColumn($adapterTable, $action->getColumn());
                     break;
 
                 case $action instanceof AddIndex:
+                    /** @var \Phinx\Db\Action\AddIndex $action */
                     $actions[$k] = new AddIndex($adapterTable, $action->getIndex());
                     break;
 
                 case $action instanceof AddForeignKey:
+                    /** @var \Phinx\Db\Action\AddForeignKey $action */
                     $foreignKey = clone $action->getForeignKey();
                     $refTable = $foreignKey->getReferencedTable();
                     $refTableName = $this->getAdapterTableName($refTable->getName());
@@ -435,38 +438,47 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
                     break;
 
                 case $action instanceof ChangeColumn:
+                    /** @var \Phinx\Db\Action\ChangeColumn $action */
                     $actions[$k] = new ChangeColumn($adapterTable, $action->getColumnName(), $action->getColumn());
                     break;
 
                 case $action instanceof DropForeignKey:
+                    /** @var \Phinx\Db\Action\DropForeignKey $action */
                     $actions[$k] = new DropForeignKey($adapterTable, $action->getForeignKey());
                     break;
 
                 case $action instanceof DropIndex:
+                    /** @var \Phinx\Db\Action\DropIndex $action */
                     $actions[$k] = new DropIndex($adapterTable, $action->getIndex());
                     break;
 
                 case $action instanceof DropTable:
+                    /** @var \Phinx\Db\Action\DropTable $action */
                     $actions[$k] = new DropTable($adapterTable);
                     break;
 
                 case $action instanceof RemoveColumn:
+                    /** @var \Phinx\Db\Action\RemoveColumn $action */
                     $actions[$k] = new RemoveColumn($adapterTable, $action->getColumn());
                     break;
 
                 case $action instanceof RenameColumn:
+                    /** @var \Phinx\Db\Action\RenameColumn $action */
                     $actions[$k] = new RenameColumn($adapterTable, $action->getColumn(), $action->getNewName());
                     break;
 
                 case $action instanceof RenameTable:
+                    /** @var \Phinx\Db\Action\RenameTable $action */
                     $actions[$k] = new RenameTable($adapterTable, $action->getNewName());
                     break;
 
                 case $action instanceof ChangePrimaryKey:
+                    /** @var \Phinx\Db\Action\ChangePrimaryKey $action */
                     $actions[$k] = new ChangePrimaryKey($adapterTable, $action->getNewColumns());
                     break;
 
                 case $action instanceof ChangeComment:
+                    /** @var \Phinx\Db\Action\ChangeComment $action */
                     $actions[$k] = new ChangeComment($adapterTable, $action->getNewComment());
                     break;
 

--- a/src/Phinx/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Phinx/Db/Adapter/TimedOutputAdapter.php
@@ -22,7 +22,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function getAdapterType()
+    public function getAdapterType(): string
     {
         return $this->getAdapter()->getAdapterType();
     }
@@ -32,7 +32,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      *
      * @return callable A function that is to be called when the command finishes
      */
-    public function startCommandTimer()
+    public function startCommandTimer(): callable
     {
         $started = microtime(true);
 
@@ -51,7 +51,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @param array $args Command Args
      * @return void
      */
-    public function writeCommand($command, $args = [])
+    public function writeCommand(string $command, array $args = []): void
     {
         if (OutputInterface::VERBOSITY_VERBOSE > $this->getOutput()->getVerbosity()) {
             return;
@@ -84,7 +84,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function insert(Table $table, $row)
+    public function insert(Table $table, array $row): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('insert', [$table->getName()]);
@@ -95,7 +95,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function bulkinsert(Table $table, $rows)
+    public function bulkinsert(Table $table, array $rows): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('bulkinsert', [$table->getName()]);
@@ -106,7 +106,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = [])
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('createTable', [$table->getName()]);
@@ -120,7 +120,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function changePrimaryKey(Table $table, $newColumns)
+    public function changePrimaryKey(Table $table, $newColumns): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -138,7 +138,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function changeComment(Table $table, $newComment)
+    public function changeComment(Table $table, ?string $newComment): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -156,7 +156,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function renameTable($tableName, $newTableName)
+    public function renameTable(string $tableName, string $newTableName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -174,7 +174,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropTable($tableName)
+    public function dropTable(string $tableName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -189,7 +189,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function truncateTable($tableName)
+    public function truncateTable(string $tableName): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('truncateTable', [$tableName]);
@@ -203,7 +203,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addColumn(Table $table, Column $column)
+    public function addColumn(Table $table, Column $column): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -228,7 +228,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function renameColumn($tableName, $columnName, $newColumnName)
+    public function renameColumn(string $tableName, string $columnName, string $newColumnName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -246,7 +246,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function changeColumn($tableName, $columnName, Column $newColumn)
+    public function changeColumn(string $tableName, string $columnName, Column $newColumn): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -264,7 +264,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropColumn($tableName, $columnName)
+    public function dropColumn(string $tableName, string $columnName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -282,7 +282,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addIndex(Table $table, Index $index)
+    public function addIndex(Table $table, Index $index): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -300,7 +300,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropIndex($tableName, $columns)
+    public function dropIndex(string $tableName, $columns): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -318,7 +318,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropIndexByName($tableName, $indexName)
+    public function dropIndexByName(string $tableName, string $indexName): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -336,7 +336,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addForeignKey(Table $table, ForeignKey $foreignKey)
+    public function addForeignKey(Table $table, ForeignKey $foreignKey): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -354,7 +354,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function dropForeignKey($tableName, $columns, $constraint = null)
+    public function dropForeignKey(string $tableName, array $columns, ?string $constraint = null): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -369,7 +369,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function createDatabase($name, $options = [])
+    public function createDatabase(string $name, array $options = []): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('createDatabase', [$name]);
@@ -380,7 +380,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function dropDatabase($name)
+    public function dropDatabase(string $name): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('dropDatabase', [$name]);
@@ -391,7 +391,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function createSchema($name = 'public')
+    public function createSchema(string $name = 'public'): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('createSchema', [$name]);
@@ -402,7 +402,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function dropSchema($name)
+    public function dropSchema(string $name): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('dropSchema', [$name]);
@@ -413,7 +413,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function executeActions(Table $table, array $actions)
+    public function executeActions(Table $table, array $actions): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand(sprintf('Altering table %s', $table->getName()));

--- a/src/Phinx/Db/Adapter/WrapperInterface.php
+++ b/src/Phinx/Db/Adapter/WrapperInterface.php
@@ -27,7 +27,7 @@ interface WrapperInterface
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Adapter
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function setAdapter(AdapterInterface $adapter);
+    public function setAdapter(AdapterInterface $adapter): AdapterInterface;
 
     /**
      * Gets the database adapter.
@@ -35,5 +35,5 @@ interface WrapperInterface
      * @throws \RuntimeException if the adapter has not been set
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function getAdapter();
+    public function getAdapter(): AdapterInterface;
 }

--- a/src/Phinx/Db/Plan/AlterTable.php
+++ b/src/Phinx/Db/Plan/AlterTable.php
@@ -45,7 +45,7 @@ class AlterTable
      * @param \Phinx\Db\Action\Action $action The action to add
      * @return void
      */
-    public function addAction(Action $action)
+    public function addAction(Action $action): void
     {
         $this->actions[] = $action;
     }
@@ -55,7 +55,7 @@ class AlterTable
      *
      * @return \Phinx\Db\Table\Table
      */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->table;
     }
@@ -65,7 +65,7 @@ class AlterTable
      *
      * @return \Phinx\Db\Action\Action[]
      */
-    public function getActions()
+    public function getActions(): array
     {
         return $this->actions;
     }

--- a/src/Phinx/Db/Plan/Intent.php
+++ b/src/Phinx/Db/Plan/Intent.php
@@ -27,7 +27,7 @@ class Intent
      * @param \Phinx\Db\Action\Action $action The action to add
      * @return void
      */
-    public function addAction(Action $action)
+    public function addAction(Action $action): void
     {
         $this->actions[] = $action;
     }
@@ -37,7 +37,7 @@ class Intent
      *
      * @return \Phinx\Db\Action\Action[]
      */
-    public function getActions()
+    public function getActions(): array
     {
         return $this->actions;
     }
@@ -48,7 +48,7 @@ class Intent
      * @param \Phinx\Db\Plan\Intent $another The other intent to merge in
      * @return void
      */
-    public function merge(Intent $another)
+    public function merge(Intent $another): void
     {
         $this->actions = array_merge($this->actions, $another->getActions());
     }

--- a/src/Phinx/Db/Plan/NewTable.php
+++ b/src/Phinx/Db/Plan/NewTable.php
@@ -53,7 +53,7 @@ class NewTable
      * @param \Phinx\Db\Table\Column $column The column description
      * @return void
      */
-    public function addColumn(Column $column)
+    public function addColumn(Column $column): void
     {
         $this->columns[] = $column;
     }
@@ -64,7 +64,7 @@ class NewTable
      * @param \Phinx\Db\Table\Index $index The index description
      * @return void
      */
-    public function addIndex(Index $index)
+    public function addIndex(Index $index): void
     {
         $this->indexes[] = $index;
     }
@@ -74,7 +74,7 @@ class NewTable
      *
      * @return \Phinx\Db\Table\Table
      */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->table;
     }
@@ -84,7 +84,7 @@ class NewTable
      *
      * @return \Phinx\Db\Table\Column[]
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -94,7 +94,7 @@ class NewTable
      *
      * @return \Phinx\Db\Table\Index[]
      */
-    public function getIndexes()
+    public function getIndexes(): array
     {
         return $this->indexes;
     }

--- a/src/Phinx/Db/Plan/Plan.php
+++ b/src/Phinx/Db/Plan/Plan.php
@@ -92,7 +92,7 @@ class Plan
      * @param \Phinx\Db\Action\Action[] $actions The actions to use for the plan
      * @return void
      */
-    protected function createPlan($actions)
+    protected function createPlan(array $actions): void
     {
         $this->gatherCreates($actions);
         $this->gatherUpdates($actions);
@@ -107,7 +107,7 @@ class Plan
      *
      * @return \Phinx\Db\Plan\AlterTable[][]
      */
-    protected function updatesSequence()
+    protected function updatesSequence(): array
     {
         return [
             $this->tableUpdates,
@@ -123,7 +123,7 @@ class Plan
      *
      * @return \Phinx\Db\Plan\AlterTable[][]
      */
-    protected function inverseUpdatesSequence()
+    protected function inverseUpdatesSequence(): array
     {
         return [
             $this->constraints,
@@ -140,7 +140,7 @@ class Plan
      * @param \Phinx\Db\Adapter\AdapterInterface $executor The executor object for the plan
      * @return void
      */
-    public function execute(AdapterInterface $executor)
+    public function execute(AdapterInterface $executor): void
     {
         foreach ($this->tableCreates as $newTable) {
             $executor->createTable($newTable->getTable(), $newTable->getColumns(), $newTable->getIndexes());
@@ -159,7 +159,7 @@ class Plan
      * @param \Phinx\Db\Adapter\AdapterInterface $executor The executor object for the plan
      * @return void
      */
-    public function executeInverse(AdapterInterface $executor)
+    public function executeInverse(AdapterInterface $executor): void
     {
         foreach ($this->inverseUpdatesSequence() as $updates) {
             foreach ($updates as $update) {
@@ -177,7 +177,7 @@ class Plan
      *
      * @return void
      */
-    protected function resolveConflicts()
+    protected function resolveConflicts(): void
     {
         foreach ($this->tableMoves as $alterTable) {
             foreach ($alterTable->getActions() as $action) {
@@ -251,7 +251,7 @@ class Plan
      * @param \Phinx\Db\Plan\AlterTable[] $actions The actions to transform
      * @return \Phinx\Db\Plan\AlterTable[] The list of actions without actions for the given table
      */
-    protected function forgetTable(Table $table, $actions)
+    protected function forgetTable(Table $table, array $actions): array
     {
         $result = [];
         foreach ($actions as $action) {
@@ -273,7 +273,7 @@ class Plan
      * @return \Phinx\Db\Plan\AlterTable The updated AlterTable object. This function
      * has the side effect of changing the `$this->indexes` property.
      */
-    protected function remapContraintAndIndexConflicts(AlterTable $alter)
+    protected function remapContraintAndIndexConflicts(AlterTable $alter): AlterTable
     {
         $newAlter = new AlterTable($alter->getTable());
 
@@ -303,7 +303,7 @@ class Plan
      * @return array A tuple containing the list of actions without actions for dropping the index
      * and a list of drop index actions that were removed.
      */
-    protected function forgetDropIndex(Table $table, array $columns, array $actions)
+    protected function forgetDropIndex(Table $table, array $columns, array $actions): array
     {
         $dropIndexActions = new ArrayObject();
         $indexes = array_map(function ($alter) use ($table, $columns, $dropIndexActions) {
@@ -335,7 +335,7 @@ class Plan
      * @return array A tuple containing the list of actions without actions for removing the column
      * and a list of remove column actions that were removed.
      */
-    protected function forgetRemoveColumn(Table $table, array $columns, array $actions)
+    protected function forgetRemoveColumn(Table $table, array $columns, array $actions): array
     {
         $removeColumnActions = new ArrayObject();
         $indexes = array_map(function ($alter) use ($table, $columns, $removeColumnActions) {
@@ -364,7 +364,7 @@ class Plan
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
      * @return void
      */
-    protected function gatherCreates($actions)
+    protected function gatherCreates(array $actions): void
     {
         foreach ($actions as $action) {
             if ($action instanceof CreateTable) {
@@ -396,7 +396,7 @@ class Plan
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
      * @return void
      */
-    protected function gatherUpdates($actions)
+    protected function gatherUpdates(array $actions): void
     {
         foreach ($actions as $action) {
             if (
@@ -432,7 +432,7 @@ class Plan
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
      * @return void
      */
-    protected function gatherTableMoves($actions)
+    protected function gatherTableMoves(array $actions): void
     {
         foreach ($actions as $action) {
             if (
@@ -460,7 +460,7 @@ class Plan
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
      * @return void
      */
-    protected function gatherIndexes($actions)
+    protected function gatherIndexes(array $actions): void
     {
         foreach ($actions as $action) {
             if (!($action instanceof AddIndex) && !($action instanceof DropIndex)) {
@@ -486,7 +486,7 @@ class Plan
      * @param \Phinx\Db\Action\Action[] $actions The actions to parse
      * @return void
      */
-    protected function gatherConstraints($actions)
+    protected function gatherConstraints(array $actions): void
     {
         foreach ($actions as $action) {
             if (!($action instanceof AddForeignKey || $action instanceof DropForeignKey)) {

--- a/src/Phinx/Db/Plan/Solver/ActionSplitter.php
+++ b/src/Phinx/Db/Plan/Solver/ActionSplitter.php
@@ -52,7 +52,7 @@ class ActionSplitter
      * which is the dual of $conflictClass. For example `AddColumn` and `DropColumn` are duals.
      * @param callable $conflictFilter The collection of actions to inspect
      */
-    public function __construct($conflictClass, $conflictClassDual, callable $conflictFilter)
+    public function __construct(string $conflictClass, string $conflictClassDual, callable $conflictFilter)
     {
         $this->conflictClass = $conflictClass;
         $this->conflictClassDual = $conflictClassDual;
@@ -67,7 +67,7 @@ class ActionSplitter
      * @return \Phinx\Db\Plan\AlterTable[] A list of AlterTable that can be executed without
      * this type of conflict
      */
-    public function __invoke(AlterTable $alter)
+    public function __invoke(AlterTable $alter): array
     {
         $conflictActions = array_filter($alter->getActions(), function ($action) {
             return $action instanceof $this->conflictClass;

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -58,7 +58,7 @@ class Table
      * @param array $options Options
      * @param \Phinx\Db\Adapter\AdapterInterface|null $adapter Database Adapter
      */
-    public function __construct($name, $options = [], ?AdapterInterface $adapter = null)
+    public function __construct(string $name, array $options = [], ?AdapterInterface $adapter = null)
     {
         $this->table = new TableValue($name, $options);
         $this->actions = new Intent();
@@ -71,9 +71,9 @@ class Table
     /**
      * Gets the table name.
      *
-     * @return string|null
+     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->table->getName();
     }
@@ -83,7 +83,7 @@ class Table
      *
      * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->table->getOptions();
     }
@@ -93,7 +93,7 @@ class Table
      *
      * @return \Phinx\Db\Table\Table
      */
-    public function getTable()
+    public function getTable(): TableValue
     {
         return $this->table;
     }
@@ -115,9 +115,9 @@ class Table
      * Gets the database adapter.
      *
      * @throws \RuntimeException
-     * @return \Phinx\Db\Adapter\AdapterInterface|null
+     * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function getAdapter()
+    public function getAdapter(): AdapterInterface
     {
         if (!$this->adapter) {
             throw new RuntimeException('There is no database adapter set yet, cannot proceed');
@@ -131,7 +131,7 @@ class Table
      *
      * @return bool
      */
-    public function hasPendingActions()
+    public function hasPendingActions(): bool
     {
         return count($this->actions->getActions()) > 0 || count($this->data) > 0;
     }
@@ -141,7 +141,7 @@ class Table
      *
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         return $this->getAdapter()->hasTable($this->getName());
     }
@@ -164,7 +164,7 @@ class Table
      * @param string $newTableName New Table Name
      * @return $this
      */
-    public function rename($newTableName)
+    public function rename(string $newTableName)
     {
         $this->actions->addAction(new RenameTable($this->table, $newTableName));
 
@@ -191,7 +191,7 @@ class Table
      * @param string|null $constraint Constraint names
      * @return bool
      */
-    public function hasPrimaryKey($columns, $constraint = null)
+    public function hasPrimaryKey($columns, ?string $constraint = null): bool
     {
         return $this->getAdapter()->hasPrimaryKey($this->getName(), $columns, $constraint);
     }
@@ -202,7 +202,7 @@ class Table
      * @param string|null $comment New comment string, or null to drop the comment
      * @return $this
      */
-    public function changeComment($comment)
+    public function changeComment(?string $comment)
     {
         $this->actions->addAction(new ChangeComment($this->table, $comment));
 
@@ -214,7 +214,7 @@ class Table
      *
      * @return \Phinx\Db\Table\Column[]
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->getAdapter()->getColumns($this->getName());
     }
@@ -225,7 +225,7 @@ class Table
      * @param string $name Column name
      * @return \Phinx\Db\Table\Column|null
      */
-    public function getColumn($name)
+    public function getColumn(string $name): ?Column
     {
         $columns = array_filter(
             $this->getColumns(),
@@ -243,7 +243,7 @@ class Table
      * @param array $data Data
      * @return $this
      */
-    public function setData($data)
+    public function setData(array $data)
     {
         $this->data = $data;
 
@@ -255,7 +255,7 @@ class Table
      *
      * @return array
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->data;
     }
@@ -265,7 +265,7 @@ class Table
      *
      * @return void
      */
-    public function resetData()
+    public function resetData(): void
     {
         $this->setData([]);
     }
@@ -275,7 +275,7 @@ class Table
      *
      * @return void
      */
-    public function reset()
+    public function reset(): void
     {
         $this->actions = new Intent();
         $this->resetData();
@@ -295,7 +295,7 @@ class Table
      * @throws \InvalidArgumentException
      * @return $this
      */
-    public function addColumn($columnName, $type = null, $options = [])
+    public function addColumn($columnName, $type = null, array $options = [])
     {
         if ($columnName instanceof Column) {
             $action = new AddColumn($this->table, $columnName);
@@ -323,7 +323,7 @@ class Table
      * @param string $columnName Column Name
      * @return $this
      */
-    public function removeColumn($columnName)
+    public function removeColumn(string $columnName)
     {
         $action = RemoveColumn::build($this->table, $columnName);
         $this->actions->addAction($action);
@@ -338,7 +338,7 @@ class Table
      * @param string $newName New Column Name
      * @return $this
      */
-    public function renameColumn($oldName, $newName)
+    public function renameColumn(string $oldName, string $newName)
     {
         $action = RenameColumn::build($this->table, $oldName, $newName);
         $this->actions->addAction($action);
@@ -354,7 +354,7 @@ class Table
      * @param array $options Options
      * @return $this
      */
-    public function changeColumn($columnName, $newColumnType, array $options = [])
+    public function changeColumn(string $columnName, $newColumnType, array $options = [])
     {
         if ($newColumnType instanceof Column) {
             $action = new ChangeColumn($this->table, $columnName, $newColumnType);
@@ -372,7 +372,7 @@ class Table
      * @param string $columnName Column Name
      * @return bool
      */
-    public function hasColumn($columnName)
+    public function hasColumn(string $columnName): bool
     {
         return $this->getAdapter()->hasColumn($this->getName(), $columnName);
     }
@@ -414,7 +414,7 @@ class Table
      * @param string $name Index name
      * @return $this
      */
-    public function removeIndexByName($name)
+    public function removeIndexByName(string $name)
     {
         $action = DropIndex::buildFromName($this->table, $name);
         $this->actions->addAction($action);
@@ -428,7 +428,7 @@ class Table
      * @param string|string[] $columns Columns
      * @return bool
      */
-    public function hasIndex($columns)
+    public function hasIndex($columns): bool
     {
         return $this->getAdapter()->hasIndex($this->getName(), $columns);
     }
@@ -439,7 +439,7 @@ class Table
      * @param string $indexName Index name
      * @return bool
      */
-    public function hasIndexByName($indexName)
+    public function hasIndexByName($indexName): bool
     {
         return $this->getAdapter()->hasIndexByName($this->getName(), $indexName);
     }
@@ -456,7 +456,7 @@ class Table
      * @param array $options Options
      * @return $this
      */
-    public function addForeignKey($columns, $referencedTable, $referencedColumns = ['id'], $options = [])
+    public function addForeignKey($columns, $referencedTable, $referencedColumns = ['id'], array $options = [])
     {
         $action = AddForeignKey::build($this->table, $columns, $referencedTable, $referencedColumns, $options);
         $this->actions->addAction($action);
@@ -477,7 +477,7 @@ class Table
      * @param array $options Options
      * @return $this
      */
-    public function addForeignKeyWithName($name, $columns, $referencedTable, $referencedColumns = ['id'], $options = [])
+    public function addForeignKeyWithName(string $name, $columns, $referencedTable, $referencedColumns = ['id'], array $options = [])
     {
         $action = AddForeignKey::build(
             $this->table,
@@ -499,7 +499,7 @@ class Table
      * @param string|null $constraint Constraint names
      * @return $this
      */
-    public function dropForeignKey($columns, $constraint = null)
+    public function dropForeignKey($columns, ?string $constraint = null)
     {
         $action = DropForeignKey::build($this->table, $columns, $constraint);
         $this->actions->addAction($action);
@@ -514,7 +514,7 @@ class Table
      * @param string|null $constraint Constraint names
      * @return bool
      */
-    public function hasForeignKey($columns, $constraint = null)
+    public function hasForeignKey($columns, ?string $constraint = null): bool
     {
         return $this->getAdapter()->hasForeignKey($this->getName(), $columns, $constraint);
     }
@@ -527,7 +527,7 @@ class Table
      * @param bool $withTimezone Whether to set the timezone option on the added columns
      * @return $this
      */
-    public function addTimestamps($createdAt = 'created_at', $updatedAt = 'updated_at', $withTimezone = false)
+    public function addTimestamps($createdAt = 'created_at', $updatedAt = 'updated_at', bool $withTimezone = false)
     {
         $createdAt = $createdAt ?? 'created_at';
         $updatedAt = $updatedAt ?? 'updated_at';
@@ -560,8 +560,8 @@ class Table
      * Alias that always sets $withTimezone to true
      *
      * @see addTimestamps
-     * @param string|null $createdAt Alternate name for the created_at column
-     * @param string|null $updatedAt Alternate name for the updated_at column
+     * @param string|false|null $createdAt Alternate name for the created_at column
+     * @param string|false|null $updatedAt Alternate name for the updated_at column
      * @return $this
      */
     public function addTimestampsWithTimezone($createdAt = null, $updatedAt = null)
@@ -582,7 +582,7 @@ class Table
      *              or array("col1" => "value1", "col2" => "anotherValue1")
      * @return $this
      */
-    public function insert($data)
+    public function insert(array $data)
     {
         // handle array of array situations
         $keys = array_keys($data);
@@ -607,7 +607,7 @@ class Table
      *
      * @return void
      */
-    public function create()
+    public function create(): void
     {
         $this->executeActions(false);
         $this->saveData();
@@ -619,7 +619,7 @@ class Table
      *
      * @return void
      */
-    public function update()
+    public function update(): void
     {
         $this->executeActions(true);
         $this->saveData();
@@ -631,7 +631,7 @@ class Table
      *
      * @return void
      */
-    public function saveData()
+    public function saveData(): void
     {
         $rows = $this->getData();
         if (empty($rows)) {
@@ -665,7 +665,7 @@ class Table
      *
      * @return void
      */
-    public function truncate()
+    public function truncate(): void
     {
         $this->getAdapter()->truncateTable($this->getName());
     }
@@ -677,7 +677,7 @@ class Table
      *
      * @return void
      */
-    public function save()
+    public function save(): void
     {
         if ($this->exists()) {
             $this->update(); // update the table
@@ -692,7 +692,7 @@ class Table
      * @param bool $exists Whether or not the table existed prior to executing this method
      * @return void
      */
-    protected function executeActions($exists)
+    protected function executeActions(bool $exists): void
     {
         // Renaming a table is tricky, specially when running a reversible migration
         // down. We will just assume the table already exists if the user commands a

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -144,9 +144,9 @@ class Column
     protected $srid;
 
     /**
-     * @var array
+     * @var array|null
      */
-    protected $values;
+    protected $values = null;
 
     /**
      * Sets the column name.
@@ -606,9 +606,9 @@ class Column
     /**
      * Gets field values
      *
-     * @return array
+     * @return array|null
      */
-    public function getValues(): array
+    public function getValues(): ?array
     {
         return $this->values;
     }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -64,9 +64,9 @@ class Column
     protected $type;
 
     /**
-     * @var int
+     * @var int|null
      */
-    protected $limit;
+    protected $limit = null;
 
     /**
      * @var bool
@@ -96,7 +96,7 @@ class Column
     /**
      * @var int
      */
-    protected $scale;
+    protected $scale = null;
 
     /**
      * @var string
@@ -109,9 +109,9 @@ class Column
     protected $update;
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $comment;
+    protected $comment = null;
 
     /**
      * @var bool
@@ -197,10 +197,10 @@ class Column
     /**
      * Sets the column limit.
      *
-     * @param int $limit Limit
+     * @param int|null $limit Limit
      * @return $this
      */
-    public function setLimit(int $limit)
+    public function setLimit(?int $limit)
     {
         $this->limit = $limit;
 
@@ -212,7 +212,7 @@ class Column
      *
      * @return int
      */
-    public function getLimit(): int
+    public function getLimit(): ?int
     {
         return $this->limit;
     }
@@ -358,10 +358,10 @@ class Column
      * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
      * and the column could store value from -999.99 to 999.99.
      *
-     * @param int $precision Number precision
+     * @param int|null $precision Number precision
      * @return $this
      */
-    public function setPrecision(int $precision)
+    public function setPrecision(?int $precision)
     {
         $this->setLimit($precision);
 
@@ -376,7 +376,7 @@ class Column
      *
      * @return int
      */
-    public function getPrecision(): int
+    public function getPrecision(): ?int
     {
         return $this->limit;
     }
@@ -433,10 +433,10 @@ class Column
      * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
      * and the column could store value from -999.99 to 999.99.
      *
-     * @param int $scale Number scale
+     * @param int|null $scale Number scale
      * @return $this
      */
-    public function setScale(int $scale)
+    public function setScale(?int $scale)
     {
         $this->scale = $scale;
 
@@ -451,7 +451,7 @@ class Column
      *
      * @return int
      */
-    public function getScale(): int
+    public function getScale(): ?int
     {
         return $this->scale;
     }
@@ -477,10 +477,10 @@ class Column
     /**
      * Sets the column comment.
      *
-     * @param string $comment Comment
+     * @param string|null $comment Comment
      * @return $this
      */
-    public function setComment(string $comment)
+    public function setComment(?string $comment)
     {
         $this->comment = $comment;
 
@@ -492,7 +492,7 @@ class Column
      *
      * @return string
      */
-    public function getComment(): string
+    public function getComment(): ?string
     {
         return $this->comment;
     }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -66,7 +66,7 @@ class Column
     /**
      * @var float|null
      */
-    protected $limit = null;
+    protected $limit;
 
     /**
      * @var bool
@@ -76,7 +76,7 @@ class Column
     /**
      * @var mixed
      */
-    protected $default = null;
+    protected $default;
 
     /**
      * @var bool
@@ -86,32 +86,32 @@ class Column
     /**
      * @var int|null
      */
-    protected $seed = null;
+    protected $seed;
 
     /**
      * @var int|null
      */
-    protected $increment = null;
+    protected $increment;
 
     /**
      * @var int|null
      */
-    protected $scale = null;
+    protected $scale;
 
     /**
      * @var string|null
      */
-    protected $after = null;
+    protected $after;
 
     /**
      * @var string|null
      */
-    protected $update = null;
+    protected $update;
 
     /**
      * @var string|null
      */
-    protected $comment = null;
+    protected $comment;
 
     /**
      * @var bool
@@ -131,22 +131,22 @@ class Column
     /**
      * @var string|null
      */
-    protected $collation = null;
+    protected $collation;
 
     /**
      * @var string|null
      */
-    protected $encoding = null;
+    protected $encoding;
 
     /**
      * @var int|null
      */
-    protected $srid = null;
+    protected $srid;
 
     /**
      * @var array|null
      */
-    protected $values = null;
+    protected $values;
 
     /**
      * Sets the column name.

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -154,7 +154,7 @@ class Column
      * @param string $name Name
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): Column
     {
         $this->name = $name;
 
@@ -166,7 +166,7 @@ class Column
      *
      * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -177,7 +177,7 @@ class Column
      * @param string|\Phinx\Util\Literal $type Column type
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): Column
     {
         $this->type = $type;
 
@@ -200,7 +200,7 @@ class Column
      * @param int $limit Limit
      * @return $this
      */
-    public function setLimit($limit)
+    public function setLimit(int $limit): Column
     {
         $this->limit = $limit;
 
@@ -212,7 +212,7 @@ class Column
      *
      * @return int
      */
-    public function getLimit()
+    public function getLimit(): int
     {
         return $this->limit;
     }
@@ -223,7 +223,7 @@ class Column
      * @param bool $null Null
      * @return $this
      */
-    public function setNull($null)
+    public function setNull(bool $null): Column
     {
         $this->null = (bool)$null;
 
@@ -235,7 +235,7 @@ class Column
      *
      * @return bool
      */
-    public function getNull()
+    public function getNull(): bool
     {
         return $this->null;
     }
@@ -245,7 +245,7 @@ class Column
      *
      * @return bool
      */
-    public function isNull()
+    public function isNull(): bool
     {
         return $this->getNull();
     }
@@ -256,7 +256,7 @@ class Column
      * @param mixed $default Default
      * @return $this
      */
-    public function setDefault($default)
+    public function setDefault($default): Column
     {
         $this->default = $default;
 
@@ -279,7 +279,7 @@ class Column
      * @param bool $identity Identity
      * @return $this
      */
-    public function setIdentity($identity)
+    public function setIdentity(bool $identity): Column
     {
         $this->identity = $identity;
 
@@ -291,7 +291,7 @@ class Column
      *
      * @return bool
      */
-    public function getIdentity()
+    public function getIdentity(): bool
     {
         return $this->identity;
     }
@@ -301,7 +301,7 @@ class Column
      *
      * @return bool
      */
-    public function isIdentity()
+    public function isIdentity(): bool
     {
         return $this->getIdentity();
     }
@@ -312,7 +312,7 @@ class Column
      * @param string $after After
      * @return $this
      */
-    public function setAfter($after)
+    public function setAfter(string $after): Column
     {
         $this->after = $after;
 
@@ -324,7 +324,7 @@ class Column
      *
      * @return string
      */
-    public function getAfter()
+    public function getAfter(): string
     {
         return $this->after;
     }
@@ -335,7 +335,7 @@ class Column
      * @param string $update On Update function
      * @return $this
      */
-    public function setUpdate($update)
+    public function setUpdate(string $update): Column
     {
         $this->update = $update;
 
@@ -347,7 +347,7 @@ class Column
      *
      * @return string
      */
-    public function getUpdate()
+    public function getUpdate(): string
     {
         return $this->update;
     }
@@ -361,7 +361,7 @@ class Column
      * @param int $precision Number precision
      * @return $this
      */
-    public function setPrecision($precision)
+    public function setPrecision(int $precision): Column
     {
         $this->setLimit($precision);
 
@@ -376,7 +376,7 @@ class Column
      *
      * @return int
      */
-    public function getPrecision()
+    public function getPrecision(): int
     {
         return $this->limit;
     }
@@ -386,7 +386,7 @@ class Column
      *
      * @return int
      */
-    public function getSeed()
+    public function getSeed(): int
     {
         return $this->seed;
     }
@@ -396,7 +396,7 @@ class Column
      *
      * @return int
      */
-    public function getIncrement()
+    public function getIncrement(): int
     {
         return $this->increment;
     }
@@ -407,7 +407,7 @@ class Column
      * @param int $seed Number seed
      * @return $this
      */
-    public function setSeed($seed)
+    public function setSeed(int $seed): Column
     {
         $this->seed = $seed;
 
@@ -420,7 +420,7 @@ class Column
      * @param int $increment Number increment
      * @return $this
      */
-    public function setIncrement($increment)
+    public function setIncrement(int $increment): Column
     {
         $this->increment = $increment;
 
@@ -436,7 +436,7 @@ class Column
      * @param int $scale Number scale
      * @return $this
      */
-    public function setScale($scale)
+    public function setScale(int $scale): Column
     {
         $this->scale = $scale;
 
@@ -451,7 +451,7 @@ class Column
      *
      * @return int
      */
-    public function getScale()
+    public function getScale(): int
     {
         return $this->scale;
     }
@@ -466,7 +466,7 @@ class Column
      * @param int $scale Number scale
      * @return $this
      */
-    public function setPrecisionAndScale($precision, $scale)
+    public function setPrecisionAndScale(int $precision, int $scale): Column
     {
         $this->setLimit($precision);
         $this->scale = $scale;
@@ -480,7 +480,7 @@ class Column
      * @param string $comment Comment
      * @return $this
      */
-    public function setComment($comment)
+    public function setComment(string $comment): Column
     {
         $this->comment = $comment;
 
@@ -492,7 +492,7 @@ class Column
      *
      * @return string
      */
-    public function getComment()
+    public function getComment(): string
     {
         return $this->comment;
     }
@@ -503,7 +503,7 @@ class Column
      * @param bool $signed Signed
      * @return $this
      */
-    public function setSigned($signed)
+    public function setSigned(bool $signed): Column
     {
         $this->signed = (bool)$signed;
 
@@ -515,7 +515,7 @@ class Column
      *
      * @return bool
      */
-    public function getSigned()
+    public function getSigned(): bool
     {
         return $this->signed;
     }
@@ -525,7 +525,7 @@ class Column
      *
      * @return bool
      */
-    public function isSigned()
+    public function isSigned(): bool
     {
         return $this->getSigned();
     }
@@ -537,7 +537,7 @@ class Column
      * @param bool $timezone Timezone
      * @return $this
      */
-    public function setTimezone($timezone)
+    public function setTimezone(bool $timezone): Column
     {
         $this->timezone = (bool)$timezone;
 
@@ -549,7 +549,7 @@ class Column
      *
      * @return bool
      */
-    public function getTimezone()
+    public function getTimezone(): bool
     {
         return $this->timezone;
     }
@@ -559,7 +559,7 @@ class Column
      *
      * @return bool
      */
-    public function isTimezone()
+    public function isTimezone(): bool
     {
         return $this->getTimezone();
     }
@@ -570,7 +570,7 @@ class Column
      * @param array $properties Properties
      * @return $this
      */
-    public function setProperties($properties)
+    public function setProperties(array $properties): Column
     {
         $this->properties = $properties;
 
@@ -582,7 +582,7 @@ class Column
      *
      * @return array
      */
-    public function getProperties()
+    public function getProperties(): array
     {
         return $this->properties;
     }
@@ -593,7 +593,7 @@ class Column
      * @param string[]|string $values Value(s)
      * @return $this
      */
-    public function setValues($values)
+    public function setValues($values): Column
     {
         if (!is_array($values)) {
             $values = preg_split('/,\s*/', $values);
@@ -608,7 +608,7 @@ class Column
      *
      * @return array
      */
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }
@@ -619,7 +619,7 @@ class Column
      * @param string $collation Collation
      * @return $this
      */
-    public function setCollation($collation)
+    public function setCollation(string $collation): Column
     {
         $this->collation = $collation;
 
@@ -631,7 +631,7 @@ class Column
      *
      * @return string
      */
-    public function getCollation()
+    public function getCollation(): string
     {
         return $this->collation;
     }
@@ -642,7 +642,7 @@ class Column
      * @param string $encoding Encoding
      * @return $this
      */
-    public function setEncoding($encoding)
+    public function setEncoding(string $encoding): Column
     {
         $this->encoding = $encoding;
 
@@ -654,7 +654,7 @@ class Column
      *
      * @return string
      */
-    public function getEncoding()
+    public function getEncoding(): string
     {
         return $this->encoding;
     }
@@ -663,9 +663,9 @@ class Column
      * Sets the column SRID.
      *
      * @param int $srid SRID
-     * @return \Phinx\Db\Table\Column
+     * @return $this
      */
-    public function setSrid($srid)
+    public function setSrid(int $srid): Column
     {
         $this->srid = $srid;
 
@@ -677,7 +677,7 @@ class Column
      *
      * @return int|null
      */
-    public function getSrid()
+    public function getSrid(): ?int
     {
         return $this->srid;
     }
@@ -687,7 +687,7 @@ class Column
      *
      * @return array
      */
-    protected function getValidOptions()
+    protected function getValidOptions(): array
     {
         return [
             'limit',
@@ -715,7 +715,7 @@ class Column
      *
      * @return array
      */
-    protected function getAliasedOptions()
+    protected function getAliasedOptions(): array
     {
         return [
             'length' => 'limit',
@@ -730,7 +730,7 @@ class Column
      * @throws \RuntimeException
      * @return $this
      */
-    public function setOptions($options)
+    public function setOptions(array $options): Column
     {
         $validOptions = $this->getValidOptions();
         $aliasOptions = $this->getAliasedOptions();

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -74,7 +74,7 @@ class Column
     protected $null = true;
 
     /**
-     * @var mixed|null
+     * @var mixed
      */
     protected $default = null;
 
@@ -266,7 +266,7 @@ class Column
     /**
      * Gets the default column value.
      *
-     * @return mixed|null
+     * @return mixed
      */
     public function getDefault()
     {

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -76,7 +76,7 @@ class Column
     /**
      * @var mixed|null
      */
-    protected $default;
+    protected $default = null;
 
     /**
      * @var bool
@@ -84,29 +84,29 @@ class Column
     protected $identity = false;
 
     /**
-     * @var int
+     * @var int|null
      */
-    protected $seed;
+    protected $seed = null;
 
     /**
-     * @var int
+     * @var int|null
      */
-    protected $increment;
+    protected $increment = null;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $scale = null;
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $after;
+    protected $after = null;
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $update;
+    protected $update = null;
 
     /**
      * @var string|null
@@ -129,19 +129,19 @@ class Column
     protected $properties = [];
 
     /**
-     * @var string|string
+     * @var string|null
      */
-    protected $collation;
+    protected $collation = null;
 
     /**
-     * @var string|string
+     * @var string|null
      */
     protected $encoding = null;
 
     /**
      * @var int|null
      */
-    protected $srid;
+    protected $srid = null;
 
     /**
      * @var array|null
@@ -197,10 +197,10 @@ class Column
     /**
      * Sets the column limit.
      *
-     * @param int|null $limit Limit
+     * @param int $limit Limit
      * @return $this
      */
-    public function setLimit(?int $limit)
+    public function setLimit(int $limit)
     {
         $this->limit = $limit;
 
@@ -210,7 +210,7 @@ class Column
     /**
      * Gets the column limit.
      *
-     * @return int
+     * @return int|null
      */
     public function getLimit(): ?int
     {
@@ -266,7 +266,7 @@ class Column
     /**
      * Gets the default column value.
      *
-     * @return mixed
+     * @return mixed|null
      */
     public function getDefault()
     {
@@ -322,9 +322,9 @@ class Column
     /**
      * Returns the name of the column to add this column after.
      *
-     * @return string
+     * @return string|null
      */
-    public function getAfter(): string
+    public function getAfter(): ?string
     {
         return $this->after;
     }
@@ -345,9 +345,9 @@ class Column
     /**
      * Returns the value of the ON UPDATE column function.
      *
-     * @return string
+     * @return string|null
      */
-    public function getUpdate(): string
+    public function getUpdate(): ?string
     {
         return $this->update;
     }
@@ -358,10 +358,10 @@ class Column
      * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
      * and the column could store value from -999.99 to 999.99.
      *
-     * @param int|null $precision Number precision
+     * @param int $precision Number precision
      * @return $this
      */
-    public function setPrecision(?int $precision)
+    public function setPrecision(int $precision)
     {
         $this->setLimit($precision);
 
@@ -382,21 +382,24 @@ class Column
     }
 
     /**
-     * Gets the column identity seed.
+     * Sets the column identity increment.
      *
-     * @return int
+     * @param int $increment Number increment
+     * @return $this
      */
-    public function getSeed(): int
+    public function setIncrement(int $increment)
     {
-        return $this->seed;
+        $this->increment = $increment;
+
+        return $this;
     }
 
     /**
      * Gets the column identity increment.
      *
-     * @return int
+     * @return int|null
      */
-    public function getIncrement(): int
+    public function getIncrement(): ?int
     {
         return $this->increment;
     }
@@ -415,16 +418,13 @@ class Column
     }
 
     /**
-     * Sets the column identity increment.
+     * Gets the column identity seed.
      *
-     * @param int $increment Number increment
-     * @return $this
+     * @return int
      */
-    public function setIncrement(int $increment)
+    public function getSeed(): ?int
     {
-        $this->increment = $increment;
-
-        return $this;
+        return $this->seed;
     }
 
     /**
@@ -436,7 +436,7 @@ class Column
      * @param int|null $scale Number scale
      * @return $this
      */
-    public function setScale(?int $scale)
+    public function setScale(int $scale)
     {
         $this->scale = $scale;
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -66,7 +66,7 @@ class Column
     protected $type;
 
     /**
-     * @var float|null
+     * @var int|null
      */
     protected $limit;
 
@@ -199,10 +199,10 @@ class Column
     /**
      * Sets the column limit.
      *
-     * @param float|null $limit Limit
+     * @param int|null $limit Limit
      * @return $this
      */
-    public function setLimit(?float $limit)
+    public function setLimit(?int $limit)
     {
         $this->limit = $limit;
 
@@ -212,9 +212,9 @@ class Column
     /**
      * Gets the column limit.
      *
-     * @return float|null
+     * @return int|null
      */
-    public function getLimit(): ?float
+    public function getLimit(): ?int
     {
         return $this->limit;
     }
@@ -360,10 +360,10 @@ class Column
      * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
      * and the column could store value from -999.99 to 999.99.
      *
-     * @param float|null $precision Number precision
+     * @param int|null $precision Number precision
      * @return $this
      */
-    public function setPrecision(?float $precision)
+    public function setPrecision(?int $precision)
     {
         $this->setLimit($precision);
 
@@ -376,9 +376,9 @@ class Column
      * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
      * and the column could store value from -999.99 to 999.99.
      *
-     * @return float
+     * @return int|null
      */
-    public function getPrecision(): ?float
+    public function getPrecision(): ?int
     {
         return $this->limit;
     }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -129,14 +129,14 @@ class Column
     protected $properties = [];
 
     /**
-     * @var string
+     * @var string|string
      */
     protected $collation;
 
     /**
-     * @var string
+     * @var string|string
      */
-    protected $encoding;
+    protected $encoding = null;
 
     /**
      * @var int|null
@@ -629,9 +629,9 @@ class Column
     /**
      * Gets the column collation.
      *
-     * @return string
+     * @return string|null
      */
-    public function getCollation(): string
+    public function getCollation(): ?string
     {
         return $this->collation;
     }
@@ -652,9 +652,9 @@ class Column
     /**
      * Gets the column character set.
      *
-     * @return string
+     * @return string|null
      */
-    public function getEncoding(): string
+    public function getEncoding(): ?string
     {
         return $this->encoding;
     }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -197,10 +197,10 @@ class Column
     /**
      * Sets the column limit.
      *
-     * @param int $limit Limit
+     * @param int|null $limit Limit
      * @return $this
      */
-    public function setLimit(int $limit)
+    public function setLimit(?int $limit)
     {
         $this->limit = $limit;
 
@@ -358,10 +358,10 @@ class Column
      * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
      * and the column could store value from -999.99 to 999.99.
      *
-     * @param int $precision Number precision
+     * @param int|null $precision Number precision
      * @return $this
      */
-    public function setPrecision(int $precision)
+    public function setPrecision(?int $precision)
     {
         $this->setLimit($precision);
 
@@ -436,7 +436,7 @@ class Column
      * @param int|null $scale Number scale
      * @return $this
      */
-    public function setScale(int $scale)
+    public function setScale(?int $scale)
     {
         $this->scale = $scale;
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -64,7 +64,7 @@ class Column
     protected $type;
 
     /**
-     * @var int|null
+     * @var float|null
      */
     protected $limit = null;
 
@@ -197,10 +197,10 @@ class Column
     /**
      * Sets the column limit.
      *
-     * @param int|null $limit Limit
+     * @param float|null $limit Limit
      * @return $this
      */
-    public function setLimit(?int $limit)
+    public function setLimit(?float $limit)
     {
         $this->limit = $limit;
 
@@ -210,9 +210,9 @@ class Column
     /**
      * Gets the column limit.
      *
-     * @return int|null
+     * @return float|null
      */
-    public function getLimit(): ?int
+    public function getLimit(): ?float
     {
         return $this->limit;
     }
@@ -358,10 +358,10 @@ class Column
      * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
      * and the column could store value from -999.99 to 999.99.
      *
-     * @param int|null $precision Number precision
+     * @param float|null $precision Number precision
      * @return $this
      */
-    public function setPrecision(?int $precision)
+    public function setPrecision(?float $precision)
     {
         $this->setLimit($precision);
 
@@ -374,9 +374,9 @@ class Column
      * For example `DECIMAL(5,2)`, 5 is the precision and 2 is the scale,
      * and the column could store value from -999.99 to 999.99.
      *
-     * @return int
+     * @return float
      */
-    public function getPrecision(): ?int
+    public function getPrecision(): ?float
     {
         return $this->limit;
     }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -154,7 +154,7 @@ class Column
      * @param string $name Name
      * @return $this
      */
-    public function setName(string $name): Column
+    public function setName(string $name)
     {
         $this->name = $name;
 
@@ -177,7 +177,7 @@ class Column
      * @param string|\Phinx\Util\Literal $type Column type
      * @return $this
      */
-    public function setType($type): Column
+    public function setType($type)
     {
         $this->type = $type;
 
@@ -200,7 +200,7 @@ class Column
      * @param int $limit Limit
      * @return $this
      */
-    public function setLimit(int $limit): Column
+    public function setLimit(int $limit)
     {
         $this->limit = $limit;
 
@@ -223,7 +223,7 @@ class Column
      * @param bool $null Null
      * @return $this
      */
-    public function setNull(bool $null): Column
+    public function setNull(bool $null)
     {
         $this->null = (bool)$null;
 
@@ -256,7 +256,7 @@ class Column
      * @param mixed $default Default
      * @return $this
      */
-    public function setDefault($default): Column
+    public function setDefault($default)
     {
         $this->default = $default;
 
@@ -279,7 +279,7 @@ class Column
      * @param bool $identity Identity
      * @return $this
      */
-    public function setIdentity(bool $identity): Column
+    public function setIdentity(bool $identity)
     {
         $this->identity = $identity;
 
@@ -312,7 +312,7 @@ class Column
      * @param string $after After
      * @return $this
      */
-    public function setAfter(string $after): Column
+    public function setAfter(string $after)
     {
         $this->after = $after;
 
@@ -335,7 +335,7 @@ class Column
      * @param string $update On Update function
      * @return $this
      */
-    public function setUpdate(string $update): Column
+    public function setUpdate(string $update)
     {
         $this->update = $update;
 
@@ -361,7 +361,7 @@ class Column
      * @param int $precision Number precision
      * @return $this
      */
-    public function setPrecision(int $precision): Column
+    public function setPrecision(int $precision)
     {
         $this->setLimit($precision);
 
@@ -407,7 +407,7 @@ class Column
      * @param int $seed Number seed
      * @return $this
      */
-    public function setSeed(int $seed): Column
+    public function setSeed(int $seed)
     {
         $this->seed = $seed;
 
@@ -420,7 +420,7 @@ class Column
      * @param int $increment Number increment
      * @return $this
      */
-    public function setIncrement(int $increment): Column
+    public function setIncrement(int $increment)
     {
         $this->increment = $increment;
 
@@ -436,7 +436,7 @@ class Column
      * @param int $scale Number scale
      * @return $this
      */
-    public function setScale(int $scale): Column
+    public function setScale(int $scale)
     {
         $this->scale = $scale;
 
@@ -466,7 +466,7 @@ class Column
      * @param int $scale Number scale
      * @return $this
      */
-    public function setPrecisionAndScale(int $precision, int $scale): Column
+    public function setPrecisionAndScale(int $precision, int $scale)
     {
         $this->setLimit($precision);
         $this->scale = $scale;
@@ -480,7 +480,7 @@ class Column
      * @param string $comment Comment
      * @return $this
      */
-    public function setComment(string $comment): Column
+    public function setComment(string $comment)
     {
         $this->comment = $comment;
 
@@ -503,7 +503,7 @@ class Column
      * @param bool $signed Signed
      * @return $this
      */
-    public function setSigned(bool $signed): Column
+    public function setSigned(bool $signed)
     {
         $this->signed = (bool)$signed;
 
@@ -537,7 +537,7 @@ class Column
      * @param bool $timezone Timezone
      * @return $this
      */
-    public function setTimezone(bool $timezone): Column
+    public function setTimezone(bool $timezone)
     {
         $this->timezone = (bool)$timezone;
 
@@ -570,7 +570,7 @@ class Column
      * @param array $properties Properties
      * @return $this
      */
-    public function setProperties(array $properties): Column
+    public function setProperties(array $properties)
     {
         $this->properties = $properties;
 
@@ -593,7 +593,7 @@ class Column
      * @param string[]|string $values Value(s)
      * @return $this
      */
-    public function setValues($values): Column
+    public function setValues($values)
     {
         if (!is_array($values)) {
             $values = preg_split('/,\s*/', $values);
@@ -619,7 +619,7 @@ class Column
      * @param string $collation Collation
      * @return $this
      */
-    public function setCollation(string $collation): Column
+    public function setCollation(string $collation)
     {
         $this->collation = $collation;
 
@@ -642,7 +642,7 @@ class Column
      * @param string $encoding Encoding
      * @return $this
      */
-    public function setEncoding(string $encoding): Column
+    public function setEncoding(string $encoding)
     {
         $this->encoding = $encoding;
 
@@ -665,7 +665,7 @@ class Column
      * @param int $srid SRID
      * @return $this
      */
-    public function setSrid(int $srid): Column
+    public function setSrid(int $srid)
     {
         $this->srid = $srid;
 
@@ -730,7 +730,7 @@ class Column
      * @throws \RuntimeException
      * @return $this
      */
-    public function setOptions(array $options): Column
+    public function setOptions(array $options)
     {
         $validOptions = $this->getValidOptions();
         $aliasOptions = $this->getAliasedOptions();

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -53,7 +53,7 @@ class ForeignKey
      * @param string[]|string $columns Columns
      * @return $this
      */
-    public function setColumns($columns)
+    public function setColumns($columns): ForeignKey
     {
         $this->columns = is_string($columns) ? [$columns] : $columns;
 
@@ -65,7 +65,7 @@ class ForeignKey
      *
      * @return string[]
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -76,7 +76,7 @@ class ForeignKey
      * @param \Phinx\Db\Table\Table $table The table this KEY is pointing to
      * @return $this
      */
-    public function setReferencedTable(Table $table)
+    public function setReferencedTable(Table $table): ForeignKey
     {
         $this->referencedTable = $table;
 
@@ -88,7 +88,7 @@ class ForeignKey
      *
      * @return \Phinx\Db\Table\Table
      */
-    public function getReferencedTable()
+    public function getReferencedTable(): Table
     {
         return $this->referencedTable;
     }
@@ -99,7 +99,7 @@ class ForeignKey
      * @param string[] $referencedColumns Referenced columns
      * @return $this
      */
-    public function setReferencedColumns(array $referencedColumns)
+    public function setReferencedColumns(array $referencedColumns): ForeignKey
     {
         $this->referencedColumns = $referencedColumns;
 
@@ -111,7 +111,7 @@ class ForeignKey
      *
      * @return string[]
      */
-    public function getReferencedColumns()
+    public function getReferencedColumns(): array
     {
         return $this->referencedColumns;
     }
@@ -122,7 +122,7 @@ class ForeignKey
      * @param string $onDelete On Delete
      * @return $this
      */
-    public function setOnDelete($onDelete)
+    public function setOnDelete(string $onDelete): ForeignKey
     {
         $this->onDelete = $this->normalizeAction($onDelete);
 
@@ -134,7 +134,7 @@ class ForeignKey
      *
      * @return string
      */
-    public function getOnDelete()
+    public function getOnDelete(): string
     {
         return $this->onDelete;
     }
@@ -144,7 +144,7 @@ class ForeignKey
      *
      * @return string
      */
-    public function getOnUpdate()
+    public function getOnUpdate(): string
     {
         return $this->onUpdate;
     }
@@ -155,7 +155,7 @@ class ForeignKey
      * @param string $onUpdate On Update
      * @return $this
      */
-    public function setOnUpdate($onUpdate)
+    public function setOnUpdate(string $onUpdate): ForeignKey
     {
         $this->onUpdate = $this->normalizeAction($onUpdate);
 
@@ -168,7 +168,7 @@ class ForeignKey
      * @param string $constraint Constraint
      * @return $this
      */
-    public function setConstraint($constraint)
+    public function setConstraint(string $constraint): ForeignKey
     {
         $this->constraint = $constraint;
 
@@ -180,7 +180,7 @@ class ForeignKey
      *
      * @return string|null
      */
-    public function getConstraint()
+    public function getConstraint(): ?string
     {
         return $this->constraint;
     }
@@ -192,7 +192,7 @@ class ForeignKey
      * @throws \RuntimeException
      * @return $this
      */
-    public function setOptions($options)
+    public function setOptions(array $options): ForeignKey
     {
         // Valid Options
         $validOptions = ['delete', 'update', 'constraint'];
@@ -222,7 +222,7 @@ class ForeignKey
      * @throws \InvalidArgumentException
      * @return string
      */
-    protected function normalizeAction($action)
+    protected function normalizeAction(string $action): string
     {
         $constantName = 'static::' . str_replace(' ', '_', strtoupper(trim($action)));
         if (!defined($constantName)) {

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -53,7 +53,7 @@ class ForeignKey
      * @param string[]|string $columns Columns
      * @return $this
      */
-    public function setColumns($columns): ForeignKey
+    public function setColumns($columns)
     {
         $this->columns = is_string($columns) ? [$columns] : $columns;
 
@@ -76,7 +76,7 @@ class ForeignKey
      * @param \Phinx\Db\Table\Table $table The table this KEY is pointing to
      * @return $this
      */
-    public function setReferencedTable(Table $table): ForeignKey
+    public function setReferencedTable(Table $table)
     {
         $this->referencedTable = $table;
 
@@ -99,7 +99,7 @@ class ForeignKey
      * @param string[] $referencedColumns Referenced columns
      * @return $this
      */
-    public function setReferencedColumns(array $referencedColumns): ForeignKey
+    public function setReferencedColumns(array $referencedColumns)
     {
         $this->referencedColumns = $referencedColumns;
 
@@ -122,7 +122,7 @@ class ForeignKey
      * @param string $onDelete On Delete
      * @return $this
      */
-    public function setOnDelete(string $onDelete): ForeignKey
+    public function setOnDelete(string $onDelete)
     {
         $this->onDelete = $this->normalizeAction($onDelete);
 
@@ -155,7 +155,7 @@ class ForeignKey
      * @param string $onUpdate On Update
      * @return $this
      */
-    public function setOnUpdate(string $onUpdate): ForeignKey
+    public function setOnUpdate(string $onUpdate)
     {
         $this->onUpdate = $this->normalizeAction($onUpdate);
 
@@ -168,7 +168,7 @@ class ForeignKey
      * @param string $constraint Constraint
      * @return $this
      */
-    public function setConstraint(string $constraint): ForeignKey
+    public function setConstraint(string $constraint)
     {
         $this->constraint = $constraint;
 
@@ -192,7 +192,7 @@ class ForeignKey
      * @throws \RuntimeException
      * @return $this
      */
-    public function setOptions(array $options): ForeignKey
+    public function setOptions(array $options)
     {
         // Valid Options
         $validOptions = ['delete', 'update', 'constraint'];

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -35,17 +35,17 @@ class ForeignKey
     /**
      * @var string|null
      */
-    protected $onDelete = null;
+    protected $onDelete;
 
     /**
      * @var string|null
      */
-    protected $onUpdate = null;
+    protected $onUpdate;
 
     /**
      * @var string|null
      */
-    protected $constraint = null;
+    protected $constraint;
 
     /**
      * Sets the foreign key columns.

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -33,19 +33,19 @@ class ForeignKey
     protected $referencedColumns = [];
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $onDelete;
-
-    /**
-     * @var string
-     */
-    protected $onUpdate;
+    protected $onDelete = null;
 
     /**
      * @var string|null
      */
-    protected $constraint;
+    protected $onUpdate = null;
+
+    /**
+     * @var string|null
+     */
+    protected $constraint = null;
 
     /**
      * Sets the foreign key columns.
@@ -132,9 +132,9 @@ class ForeignKey
     /**
      * Gets ON DELETE action for the foreign key.
      *
-     * @return string
+     * @return string|null
      */
-    public function getOnDelete(): string
+    public function getOnDelete(): ?string
     {
         return $this->onDelete;
     }
@@ -142,9 +142,9 @@ class ForeignKey
     /**
      * Gets ON UPDATE action for the foreign key.
      *
-     * @return string
+     * @return string|null
      */
-    public function getOnUpdate(): string
+    public function getOnUpdate(): ?string
     {
         return $this->onUpdate;
     }

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -27,7 +27,7 @@ class Index
     public const FULLTEXT = 'fulltext';
 
     /**
-     * @var string[]
+     * @var string[]|null
      */
     protected $columns;
 
@@ -72,9 +72,9 @@ class Index
     /**
      * Gets the index columns.
      *
-     * @return string[]
+     * @return string[]|null
      */
-    public function getColumns(): array
+    public function getColumns(): ?array
     {
         return $this->columns;
     }

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -59,12 +59,12 @@ class Index
     /**
      * Sets the index columns.
      *
-     * @param string[] $columns Columns
+     * @param string|string[] $columns Columns
      * @return $this
      */
-    public function setColumns($columns)
+    public function setColumns($columns): Index
     {
-        $this->columns = $columns;
+        $this->columns = is_string($columns) ? [$columns] : $columns;
 
         return $this;
     }
@@ -74,7 +74,7 @@ class Index
      *
      * @return string[]
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -85,7 +85,7 @@ class Index
      * @param string $type Type
      * @return $this
      */
-    public function setType($type)
+    public function setType(string $type): Index
     {
         $this->type = $type;
 
@@ -97,7 +97,7 @@ class Index
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -108,7 +108,7 @@ class Index
      * @param string $name Name
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): Index
     {
         $this->name = $name;
 
@@ -120,7 +120,7 @@ class Index
      *
      * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -131,7 +131,7 @@ class Index
      * @param int|array $limit limit value or array of limit value
      * @return $this
      */
-    public function setLimit($limit)
+    public function setLimit($limit): Index
     {
         $this->limit = $limit;
 
@@ -154,7 +154,7 @@ class Index
      * @param string[] $order column name sort order key value pair
      * @return $this
      */
-    public function setOrder($order)
+    public function setOrder(array $order): Index
     {
         $this->order = $order;
 
@@ -166,7 +166,7 @@ class Index
      *
      * @return string[]
      */
-    public function getOrder()
+    public function getOrder(): array
     {
         return $this->order;
     }
@@ -177,7 +177,7 @@ class Index
      * @param string[] $includedColumns Columns
      * @return $this
      */
-    public function setInclude($includedColumns)
+    public function setInclude(array $includedColumns): Index
     {
         $this->includedColumns = $includedColumns;
 
@@ -189,7 +189,7 @@ class Index
      *
      * @return string[]
      */
-    public function getInclude()
+    public function getInclude(): array
     {
         return $this->includedColumns;
     }
@@ -201,7 +201,7 @@ class Index
      * @throws \RuntimeException
      * @return $this
      */
-    public function setOptions($options)
+    public function setOptions(array $options): Index
     {
         // Valid Options
         $validOptions = ['type', 'unique', 'name', 'limit', 'order', 'include'];

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -62,7 +62,7 @@ class Index
      * @param string|string[] $columns Columns
      * @return $this
      */
-    public function setColumns($columns): Index
+    public function setColumns($columns)
     {
         $this->columns = is_string($columns) ? [$columns] : $columns;
 
@@ -85,7 +85,7 @@ class Index
      * @param string $type Type
      * @return $this
      */
-    public function setType(string $type): Index
+    public function setType(string $type)
     {
         $this->type = $type;
 
@@ -108,7 +108,7 @@ class Index
      * @param string $name Name
      * @return $this
      */
-    public function setName(string $name): Index
+    public function setName(string $name)
     {
         $this->name = $name;
 
@@ -131,7 +131,7 @@ class Index
      * @param int|array $limit limit value or array of limit value
      * @return $this
      */
-    public function setLimit($limit): Index
+    public function setLimit($limit)
     {
         $this->limit = $limit;
 
@@ -154,7 +154,7 @@ class Index
      * @param string[] $order column name sort order key value pair
      * @return $this
      */
-    public function setOrder(array $order): Index
+    public function setOrder(array $order)
     {
         $this->order = $order;
 
@@ -177,7 +177,7 @@ class Index
      * @param string[] $includedColumns Columns
      * @return $this
      */
-    public function setInclude(array $includedColumns): Index
+    public function setInclude(array $includedColumns)
     {
         $this->includedColumns = $includedColumns;
 
@@ -201,7 +201,7 @@ class Index
      * @throws \RuntimeException
      * @return $this
      */
-    public function setOptions(array $options): Index
+    public function setOptions(array $options)
     {
         // Valid Options
         $validOptions = ['type', 'unique', 'name', 'limit', 'order', 'include'];

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -39,22 +39,22 @@ class Index
     /**
      * @var string|null
      */
-    protected $name = null;
+    protected $name;
 
     /**
      * @var int|array|null
      */
-    protected $limit = null;
+    protected $limit;
 
     /**
      * @var string[]|null
      */
-    protected $order = null;
+    protected $order;
 
     /**
      * @var string[]|null
      */
-    protected $includedColumns = null;
+    protected $includedColumns;
 
     /**
      * Sets the index columns.

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -39,22 +39,22 @@ class Index
     /**
      * @var string|null
      */
-    protected $name;
+    protected $name = null;
 
     /**
      * @var int|array|null
      */
-    protected $limit;
+    protected $limit = null;
 
     /**
-     * @var string[]
+     * @var string[]|null
      */
-    protected $order;
+    protected $order = null;
 
     /**
-     * @var string[]
+     * @var string[]|null
      */
-    protected $includedColumns;
+    protected $includedColumns = null;
 
     /**
      * Sets the index columns.
@@ -141,7 +141,7 @@ class Index
     /**
      * Gets the index limit.
      *
-     * @return int|array
+     * @return int|array|null
      */
     public function getLimit()
     {
@@ -164,9 +164,9 @@ class Index
     /**
      * Gets the index columns sort order.
      *
-     * @return string[]
+     * @return string[]|null
      */
-    public function getOrder(): array
+    public function getOrder(): ?array
     {
         return $this->order;
     }
@@ -187,9 +187,9 @@ class Index
     /**
      * Gets the index included columns.
      *
-     * @return string[]
+     * @return string[]|null
      */
-    public function getInclude(): array
+    public function getInclude(): ?array
     {
         return $this->includedColumns;
     }

--- a/src/Phinx/Db/Table/Table.php
+++ b/src/Phinx/Db/Table/Table.php
@@ -42,7 +42,7 @@ class Table
      * @param string $name The name of the table
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): Table
     {
         $this->name = $name;
 
@@ -54,7 +54,7 @@ class Table
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -64,7 +64,7 @@ class Table
      *
      * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
@@ -73,10 +73,12 @@ class Table
      * Sets the table options
      *
      * @param array $options The options for the table creation
-     * @return void
+     * @return $this
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): Table
     {
         $this->options = $options;
+
+        return $this;
     }
 }

--- a/src/Phinx/Db/Table/Table.php
+++ b/src/Phinx/Db/Table/Table.php
@@ -42,7 +42,7 @@ class Table
      * @param string $name The name of the table
      * @return $this
      */
-    public function setName(string $name): Table
+    public function setName(string $name)
     {
         $this->name = $name;
 
@@ -75,7 +75,7 @@ class Table
      * @param array $options The options for the table creation
      * @return $this
      */
-    public function setOptions(array $options): Table
+    public function setOptions(array $options)
     {
         $this->options = $options;
 

--- a/src/Phinx/Db/Util/AlterInstructions.php
+++ b/src/Phinx/Db/Util/AlterInstructions.php
@@ -41,7 +41,7 @@ class AlterInstructions
      * @param string $part The SQL snipped to add as part of the ALTER instruction
      * @return void
      */
-    public function addAlter($part)
+    public function addAlter(string $part): void
     {
         $this->alterParts[] = $part;
     }
@@ -57,7 +57,7 @@ class AlterInstructions
      * @param string|callable $sql The SQL to run after, or a callable to execute
      * @return void
      */
-    public function addPostStep($sql)
+    public function addPostStep($sql): void
     {
         $this->postSteps[] = $sql;
     }
@@ -67,7 +67,7 @@ class AlterInstructions
      *
      * @return string[]
      */
-    public function getAlterParts()
+    public function getAlterParts(): array
     {
         return $this->alterParts;
     }
@@ -77,7 +77,7 @@ class AlterInstructions
      *
      * @return (string|callable)[]
      */
-    public function getPostSteps()
+    public function getPostSteps(): array
     {
         return $this->postSteps;
     }
@@ -88,7 +88,7 @@ class AlterInstructions
      * @param \Phinx\Db\Util\AlterInstructions $other The other collection of instructions to merge in
      * @return void
      */
-    public function merge(AlterInstructions $other)
+    public function merge(AlterInstructions $other): void
     {
         $this->alterParts = array_merge($this->alterParts, $other->getAlterParts());
         $this->postSteps = array_merge($this->postSteps, $other->getPostSteps());
@@ -101,7 +101,7 @@ class AlterInstructions
      * @param callable $executor The function to be used to execute all instructions
      * @return void
      */
-    public function execute($alterTemplate, callable $executor)
+    public function execute(string $alterTemplate, callable $executor): void
     {
         if ($this->alterParts) {
             $alter = sprintf($alterTemplate, implode(', ', $this->alterParts));

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -70,7 +70,7 @@ abstract class AbstractMigration implements MigrationInterface
      * @param \Symfony\Component\Console\Input\InputInterface|null $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output
      */
-    final public function __construct($environment, $version, ?InputInterface $input = null, ?OutputInterface $output = null)
+    final public function __construct(string $environment, int $version, ?InputInterface $input = null, ?OutputInterface $output = null)
     {
         $this->environment = $environment;
         $this->version = $version;
@@ -87,7 +87,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function setAdapter(AdapterInterface $adapter)
+    public function setAdapter(AdapterInterface $adapter): MigrationInterface
     {
         $this->adapter = $adapter;
 
@@ -97,7 +97,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getAdapter()
+    public function getAdapter(): AdapterInterface
     {
         return $this->adapter;
     }
@@ -105,7 +105,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function setInput(InputInterface $input)
+    public function setInput(InputInterface $input): MigrationInterface
     {
         $this->input = $input;
 
@@ -115,7 +115,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getInput()
+    public function getInput(): InputInterface
     {
         return $this->input;
     }
@@ -123,7 +123,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function setOutput(OutputInterface $output)
+    public function setOutput(OutputInterface $output): MigrationInterface
     {
         $this->output = $output;
 
@@ -133,7 +133,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->output;
     }
@@ -141,7 +141,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getName()
+    public function getName(): string
     {
         return static::class;
     }
@@ -149,7 +149,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getEnvironment()
+    public function getEnvironment(): string
     {
         return $this->environment;
     }
@@ -157,7 +157,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function setVersion($version)
+    public function setVersion($version): MigrationInterface
     {
         $this->version = $version;
 
@@ -167,7 +167,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getVersion()
+    public function getVersion(): int
     {
         return $this->version;
     }
@@ -175,7 +175,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function setMigratingUp($isMigratingUp)
+    public function setMigratingUp(bool $isMigratingUp): MigrationInterface
     {
         $this->isMigratingUp = $isMigratingUp;
 
@@ -185,7 +185,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function isMigratingUp()
+    public function isMigratingUp(): bool
     {
         return $this->isMigratingUp;
     }
@@ -193,7 +193,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function execute($sql, array $params = [])
+    public function execute(string $sql, array $params = []): int
     {
         return $this->getAdapter()->execute($sql, $params);
     }
@@ -201,7 +201,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function query($sql, array $params = [])
+    public function query(string $sql, array $params = [])
     {
         return $this->getAdapter()->query($sql, $params);
     }
@@ -209,7 +209,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): \Cake\Database\Query
     {
         return $this->getAdapter()->getQueryBuilder();
     }
@@ -217,7 +217,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function fetchRow($sql)
+    public function fetchRow(string $sql)
     {
         return $this->getAdapter()->fetchRow($sql);
     }
@@ -225,7 +225,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function fetchAll($sql)
+    public function fetchAll(string $sql): array
     {
         return $this->getAdapter()->fetchAll($sql);
     }
@@ -233,7 +233,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function createDatabase($name, $options)
+    public function createDatabase(string $name, array $options): void
     {
         $this->getAdapter()->createDatabase($name, $options);
     }
@@ -241,7 +241,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function dropDatabase($name)
+    public function dropDatabase(string $name): void
     {
         $this->getAdapter()->dropDatabase($name);
     }
@@ -249,7 +249,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function createSchema($name)
+    public function createSchema(string $name): void
     {
         $this->getAdapter()->createSchema($name);
     }
@@ -257,7 +257,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function dropSchema($name)
+    public function dropSchema(string $name): void
     {
         $this->getAdapter()->dropSchema($name);
     }
@@ -265,7 +265,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function hasTable($tableName)
+    public function hasTable(string $tableName): bool
     {
         return $this->getAdapter()->hasTable($tableName);
     }
@@ -273,7 +273,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function table($tableName, $options = [])
+    public function table(string $tableName, array $options = []): Table
     {
         $table = new Table($tableName, $options, $this->getAdapter());
         $this->tables[] = $table;
@@ -290,7 +290,7 @@ abstract class AbstractMigration implements MigrationInterface
      *
      * @return void
      */
-    public function preFlightCheck()
+    public function preFlightCheck(): void
     {
         if (method_exists($this, MigrationInterface::CHANGE)) {
             if (
@@ -312,7 +312,7 @@ abstract class AbstractMigration implements MigrationInterface
      * @throws \RuntimeException
      * @return void
      */
-    public function postFlightCheck()
+    public function postFlightCheck(): void
     {
         foreach ($this->tables as $table) {
             if ($table->hasPendingActions()) {
@@ -330,7 +330,7 @@ abstract class AbstractMigration implements MigrationInterface
      *
      * @return bool
      */
-    public function shouldExecute()
+    public function shouldExecute(): bool
     {
         return true;
     }

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -36,19 +36,19 @@ abstract class AbstractMigration implements MigrationInterface
     protected $version;
 
     /**
-     * @var \Phinx\Db\Adapter\AdapterInterface
+     * @var \Phinx\Db\Adapter\AdapterInterface|null
      */
-    protected $adapter;
+    protected $adapter = null;
 
     /**
-     * @var \Symfony\Component\Console\Output\OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface|null
      */
-    protected $output;
+    protected $output = null;
 
     /**
-     * @var \Symfony\Component\Console\Input\InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input;
+    protected $input = null;
 
     /**
      * Whether this migration is being applied or reverted
@@ -97,7 +97,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getAdapter(): AdapterInterface
+    public function getAdapter(): ?AdapterInterface
     {
         return $this->adapter;
     }
@@ -115,7 +115,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getInput(): InputInterface
+    public function getInput(): ?InputInterface
     {
         return $this->input;
     }
@@ -133,7 +133,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getOutput(): OutputInterface
+    public function getOutput(): ?OutputInterface
     {
         return $this->output;
     }

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -7,6 +7,7 @@
 
 namespace Phinx\Migration;
 
+use Cake\Database\Query;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
 use RuntimeException;
@@ -38,17 +39,17 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @var \Phinx\Db\Adapter\AdapterInterface|null
      */
-    protected $adapter = null;
+    protected $adapter;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface|null
      */
-    protected $output = null;
+    protected $output;
 
     /**
      * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input = null;
+    protected $input;
 
     /**
      * Whether this migration is being applied or reverted
@@ -209,7 +210,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getQueryBuilder(): \Cake\Database\Query
+    public function getQueryBuilder(): Query
     {
         return $this->getAdapter()->getQueryBuilder();
     }

--- a/src/Phinx/Migration/AbstractTemplateCreation.php
+++ b/src/Phinx/Migration/AbstractTemplateCreation.php
@@ -39,7 +39,7 @@ abstract class AbstractTemplateCreation implements CreationInterface
     /**
      * @inheritDoc
      */
-    public function getInput()
+    public function getInput(): InputInterface
     {
         return $this->input;
     }
@@ -47,7 +47,7 @@ abstract class AbstractTemplateCreation implements CreationInterface
     /**
      * @inheritDoc
      */
-    public function setInput(InputInterface $input)
+    public function setInput(InputInterface $input): CreationInterface
     {
         $this->input = $input;
 
@@ -57,7 +57,7 @@ abstract class AbstractTemplateCreation implements CreationInterface
     /**
      * @inheritDoc
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->output;
     }
@@ -65,7 +65,7 @@ abstract class AbstractTemplateCreation implements CreationInterface
     /**
      * @inheritDoc
      */
-    public function setOutput(OutputInterface $output)
+    public function setOutput(OutputInterface $output): CreationInterface
     {
         $this->output = $output;
 

--- a/src/Phinx/Migration/CreationInterface.php
+++ b/src/Phinx/Migration/CreationInterface.php
@@ -25,25 +25,25 @@ interface CreationInterface
 
     /**
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     * @return \Phinx\Migration\CreationInterface
+     * @return $this
      */
-    public function setInput(InputInterface $input);
+    public function setInput(InputInterface $input): CreationInterface;
 
     /**
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return \Phinx\Migration\CreationInterface
+     * @return $this
      */
-    public function setOutput(OutputInterface $output);
+    public function setOutput(OutputInterface $output): CreationInterface;
 
     /**
      * @return \Symfony\Component\Console\Input\InputInterface
      */
-    public function getInput();
+    public function getInput(): InputInterface;
 
     /**
      * @return \Symfony\Component\Console\Output\OutputInterface
      */
-    public function getOutput();
+    public function getOutput(): OutputInterface;
 
     /**
      * Get the migration template.
@@ -52,7 +52,7 @@ interface CreationInterface
      *
      * @return string The content of the template for Phinx to amend.
      */
-    public function getMigrationTemplate();
+    public function getMigrationTemplate(): string;
 
     /**
      * Post Migration Creation.
@@ -65,5 +65,5 @@ interface CreationInterface
      * @param string $baseClassName The name of the base class.
      * @return void
      */
-    public function postMigrationCreation($migrationFilename, $className, $baseClassName);
+    public function postMigrationCreation(string $migrationFilename, string $className, string $baseClassName): void;
 }

--- a/src/Phinx/Migration/CreationInterface.php
+++ b/src/Phinx/Migration/CreationInterface.php
@@ -27,13 +27,13 @@ interface CreationInterface
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @return $this
      */
-    public function setInput(InputInterface $input): CreationInterface;
+    public function setInput(InputInterface $input);
 
     /**
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return $this
      */
-    public function setOutput(OutputInterface $output): CreationInterface;
+    public function setOutput(OutputInterface $output);
 
     /**
      * @return \Symfony\Component\Console\Input\InputInterface

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -49,14 +49,14 @@ class Manager
     protected $environments = [];
 
     /**
-     * @var \Phinx\Migration\AbstractMigration[]|null
+     * @var \Phinx\Migration\MigrationInterface[]
      */
-    protected $migrations;
+    protected $migrations = [];
 
     /**
-     * @var \Phinx\Seed\AbstractSeed[]|null
+     * @var \Phinx\Seed\SeedInterface[]
      */
-    protected $seeds;
+    protected $seeds = [];
 
     /**
      * @var \Psr\Container\ContainerInterface
@@ -83,7 +83,7 @@ class Manager
      * @throws \RuntimeException
      * @return array array indicating if there are any missing or down migrations
      */
-    public function printStatus($environment, $format = null)
+    public function printStatus(string $environment, ?string $format = null): array
     {
         $output = $this->getOutput();
         $hasDownMigration = false;
@@ -252,7 +252,7 @@ class Manager
      * @param int $maxNameLength The maximum migration name length.
      * @return void
      */
-    protected function printMissingVersion($version, $maxNameLength)
+    protected function printMissingVersion(array $version, int $maxNameLength): void
     {
         $this->getOutput()->writeln(sprintf(
             '     <error>up</error>  %14.0f  %19s  %19s  <comment>%s</comment>  <error>** MISSING MIGRATION FILE **</error>',
@@ -276,7 +276,7 @@ class Manager
      *                               migration
      * @return void
      */
-    public function migrateToDateTime($environment, DateTime $dateTime, $fake = false)
+    public function migrateToDateTime(string $environment, DateTime $dateTime, bool $fake = false): void
     {
         $versions = array_keys($this->getMigrations($environment));
         $dateString = $dateTime->format('YmdHis');
@@ -300,7 +300,7 @@ class Manager
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function migrate($environment, $version = null, $fake = false)
+    public function migrate(string $environment, ?int $version = null, bool $fake = false): void
     {
         $migrations = $this->getMigrations($environment);
         $env = $this->getEnvironment($environment);
@@ -362,7 +362,7 @@ class Manager
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function executeMigration($name, MigrationInterface $migration, $direction = MigrationInterface::UP, $fake = false)
+    public function executeMigration(string $name, MigrationInterface $migration, string $direction = MigrationInterface::UP, bool $fake = false): void
     {
         $this->getOutput()->writeln('');
 
@@ -394,7 +394,7 @@ class Manager
      * @param \Phinx\Seed\SeedInterface $seed Seed
      * @return void
      */
-    public function executeSeed($name, SeedInterface $seed)
+    public function executeSeed(string $name, SeedInterface $seed): void
     {
         $this->getOutput()->writeln('');
 
@@ -427,7 +427,7 @@ class Manager
      * @param string|null $duration Duration the migration took the be executed
      * @return void
      */
-    protected function printMigrationStatus(MigrationInterface $migration, $status, $duration = null)
+    protected function printMigrationStatus(MigrationInterface $migration, string $status, ?string $duration = null): void
     {
         $this->printStatusOutput(
             $migration->getVersion() . ' ' . $migration->getName(),
@@ -444,7 +444,7 @@ class Manager
      * @param string|null $duration Duration the seed took the be executed
      * @return void
      */
-    protected function printSeedStatus(SeedInterface $seed, $status, $duration = null)
+    protected function printSeedStatus(SeedInterface $seed, string $status, ?string $duration = null): void
     {
         $this->printStatusOutput(
             $seed->getName(),
@@ -461,7 +461,7 @@ class Manager
      * @param string|null $duration Duration the migration or seed took the be executed
      * @return void
      */
-    protected function printStatusOutput($name, $status, $duration = null)
+    protected function printStatusOutput(string $name, string $status, ?string $duration = null): void
     {
         $this->getOutput()->writeln(
             ' ==' .
@@ -480,7 +480,7 @@ class Manager
      * @param bool $fake Flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function rollback($environment, $target = null, $force = false, $targetMustMatchVersion = true, $fake = false)
+    public function rollback(string $environment, $target = null, bool $force = false, bool $targetMustMatchVersion = true, bool $fake = false): void
     {
         // note that the migrations are indexed by name (aka creation time) in ascending order
         $migrations = $this->getMigrations($environment);
@@ -591,7 +591,7 @@ class Manager
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function seed($environment, $seed = null)
+    public function seed(string $environment, ?string $seed = null): void
     {
         $seeds = $this->getSeeds();
 
@@ -618,7 +618,7 @@ class Manager
      * @param \Phinx\Migration\Manager\Environment[] $environments Environments
      * @return $this
      */
-    public function setEnvironments($environments = [])
+    public function setEnvironments(array $environments = [])
     {
         $this->environments = $environments;
 
@@ -632,7 +632,7 @@ class Manager
      * @throws \InvalidArgumentException
      * @return \Phinx\Migration\Manager\Environment
      */
-    public function getEnvironment($name)
+    public function getEnvironment(string $name): Environment
     {
         if (isset($this->environments[$name])) {
             return $this->environments[$name];
@@ -663,11 +663,13 @@ class Manager
      * Sets the user defined PSR-11 container
      *
      * @param \Psr\Container\ContainerInterface $container Container
-     * @return void
+     * @return $this
      */
     public function setContainer(ContainerInterface $container)
     {
         $this->container = $container;
+
+        return $this;
     }
 
     /**
@@ -688,7 +690,7 @@ class Manager
      *
      * @return \Symfony\Component\Console\Input\InputInterface
      */
-    public function getInput()
+    public function getInput(): InputInterface
     {
         return $this->input;
     }
@@ -711,7 +713,7 @@ class Manager
      *
      * @return \Symfony\Component\Console\Output\OutputInterface
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->output;
     }
@@ -735,9 +737,9 @@ class Manager
      *
      * @param string $environment Environment
      * @throws \InvalidArgumentException
-     * @return \Phinx\Migration\AbstractMigration[]
+     * @return \Phinx\Migration\MigrationInterface[]
      */
-    public function getMigrations($environment)
+    public function getMigrations(string $environment): array
     {
         if ($this->migrations === null) {
             $phpFiles = $this->getMigrationFiles();
@@ -840,7 +842,7 @@ class Manager
      *
      * @return string[]
      */
-    protected function getMigrationFiles()
+    protected function getMigrationFiles(): array
     {
         return Util::getFiles($this->getConfig()->getMigrationPaths());
     }
@@ -848,7 +850,7 @@ class Manager
     /**
      * Sets the database seeders.
      *
-     * @param \Phinx\Seed\AbstractSeed[] $seeds Seeders
+     * @param \Phinx\Seed\SeedInterface[] $seeds Seeders
      * @return $this
      */
     public function setSeeds(array $seeds)
@@ -861,10 +863,10 @@ class Manager
     /**
      * Get seed dependencies instances from seed dependency array
      *
-     * @param \Phinx\Seed\AbstractSeed $seed Seed
-     * @return \Phinx\Seed\AbstractSeed[]
+     * @param \Phinx\Seed\SeedInterface $seed Seed
+     * @return \Phinx\Seed\SeedInterface[]
      */
-    protected function getSeedDependenciesInstances(AbstractSeed $seed)
+    protected function getSeedDependenciesInstances(SeedInterface $seed): array
     {
         $dependenciesInstances = [];
         $dependencies = $seed->getDependencies();
@@ -884,10 +886,10 @@ class Manager
     /**
      * Order seeds by dependencies
      *
-     * @param \Phinx\Seed\AbstractSeed[] $seeds Seeds
-     * @return \Phinx\Seed\AbstractSeed[]
+     * @param \Phinx\Seed\SeedInterface[] $seeds Seeds
+     * @return \Phinx\Seed\SeedInterface[]
      */
-    protected function orderSeedsByDependencies(array $seeds)
+    protected function orderSeedsByDependencies(array $seeds): array
     {
         $orderedSeeds = [];
         foreach ($seeds as $seed) {
@@ -908,16 +910,16 @@ class Manager
      * Gets an array of database seeders.
      *
      * @throws \InvalidArgumentException
-     * @return \Phinx\Seed\AbstractSeed[]
+     * @return \Phinx\Seed\SeedInterface[]
      */
-    public function getSeeds()
+    public function getSeeds(): array
     {
         if ($this->seeds === null) {
             $phpFiles = $this->getSeedFiles();
 
             // filter the files to only get the ones that match our naming scheme
             $fileNames = [];
-            /** @var \Phinx\Seed\AbstractSeed[] $seeds */
+            /** @var \Phinx\Seed\SeedInterface[] $seeds */
             $seeds = [];
 
             foreach ($phpFiles as $filePath) {
@@ -982,7 +984,7 @@ class Manager
      *
      * @return string[]
      */
-    protected function getSeedFiles()
+    protected function getSeedFiles(): array
     {
         return Util::getFiles($this->getConfig()->getSeedPaths());
     }
@@ -1005,7 +1007,7 @@ class Manager
      *
      * @return \Phinx\Config\ConfigInterface
      */
-    public function getConfig()
+    public function getConfig(): ConfigInterface
     {
         return $this->config;
     }
@@ -1017,7 +1019,7 @@ class Manager
      * @param int|null $version Version
      * @return void
      */
-    public function toggleBreakpoint($environment, $version)
+    public function toggleBreakpoint(string $environment, ?int $version): void
     {
         $this->markBreakpoint($environment, $version, self::BREAKPOINT_TOGGLE);
     }
@@ -1030,7 +1032,7 @@ class Manager
      * @param int $mark The state of the breakpoint as defined by self::BREAKPOINT_xxxx constants.
      * @return void
      */
-    protected function markBreakpoint($environment, $version, $mark)
+    protected function markBreakpoint(string $environment, ?int $version, int $mark): void
     {
         $migrations = $this->getMigrations($environment);
         $this->getMigrations($environment);
@@ -1086,7 +1088,7 @@ class Manager
      * @param string $environment The required environment
      * @return void
      */
-    public function removeBreakpoints($environment)
+    public function removeBreakpoints(string $environment): void
     {
         $this->getOutput()->writeln(sprintf(
             ' %d breakpoints cleared.',
@@ -1101,7 +1103,7 @@ class Manager
      * @param int|null $version The version of the target migration
      * @return void
      */
-    public function setBreakpoint($environment, $version)
+    public function setBreakpoint(string $environment, ?int $version): void
     {
         $this->markBreakpoint($environment, $version, self::BREAKPOINT_SET);
     }
@@ -1113,7 +1115,7 @@ class Manager
      * @param int|null $version The version of the target migration
      * @return void
      */
-    public function unsetBreakpoint($environment, $version)
+    public function unsetBreakpoint(string $environment, ?int $version): void
     {
         $this->markBreakpoint($environment, $version, self::BREAKPOINT_UNSET);
     }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -51,12 +51,12 @@ class Manager
     /**
      * @var \Phinx\Migration\MigrationInterface[]
      */
-    protected $migrations = [];
+    protected $migrations;
 
     /**
      * @var \Phinx\Seed\SeedInterface[]
      */
-    protected $seeds = [];
+    protected $seeds;
 
     /**
      * @var \Psr\Container\ContainerInterface
@@ -1035,7 +1035,6 @@ class Manager
     protected function markBreakpoint(string $environment, ?int $version, int $mark): void
     {
         $migrations = $this->getMigrations($environment);
-        $this->getMigrations($environment);
         $env = $this->getEnvironment($environment);
         $versions = $env->getVersionLog();
 

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -29,14 +29,14 @@ class Environment
     protected $options;
 
     /**
-     * @var \Symfony\Component\Console\Input\InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input;
+    protected $input = null;
 
     /**
-     * @var \Symfony\Component\Console\Output\OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface|null
      */
-    protected $output;
+    protected $output = null;
 
     /**
      * @var int
@@ -214,9 +214,9 @@ class Environment
     /**
      * Gets the console input.
      *
-     * @return \Symfony\Component\Console\Input\InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface|null
      */
-    public function getInput(): InputInterface
+    public function getInput(): ?InputInterface
     {
         return $this->input;
     }
@@ -237,9 +237,9 @@ class Environment
     /**
      * Gets the console output.
      *
-     * @return \Symfony\Component\Console\Output\OutputInterface
+     * @return \Symfony\Component\Console\Output\OutputInterface|null
      */
-    public function getOutput(): OutputInterface
+    public function getOutput(): ?OutputInterface
     {
         return $this->output;
     }

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -57,7 +57,7 @@ class Environment
      * @param string $name Environment Name
      * @param array $options Options
      */
-    public function __construct($name, $options)
+    public function __construct(string $name, array $options)
     {
         $this->name = $name;
         $this->options = $options;
@@ -71,7 +71,7 @@ class Environment
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function executeMigration(MigrationInterface $migration, $direction = MigrationInterface::UP, $fake = false)
+    public function executeMigration(MigrationInterface $migration, string $direction = MigrationInterface::UP, bool $fake = false): void
     {
         $direction = $direction === MigrationInterface::UP ? MigrationInterface::UP : MigrationInterface::DOWN;
         $migration->setMigratingUp($direction === MigrationInterface::UP);
@@ -129,7 +129,7 @@ class Environment
      * @param \Phinx\Seed\SeedInterface $seed Seed
      * @return void
      */
-    public function executeSeed(SeedInterface $seed)
+    public function executeSeed(SeedInterface $seed): void
     {
         $seed->setAdapter($this->getAdapter());
         if (method_exists($seed, SeedInterface::INIT)) {
@@ -158,7 +158,7 @@ class Environment
      * @param string $name Environment Name
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
 
@@ -170,7 +170,7 @@ class Environment
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -181,7 +181,7 @@ class Environment
      * @param array $options Environment Options
      * @return $this
      */
-    public function setOptions($options)
+    public function setOptions(array $options)
     {
         $this->options = $options;
 
@@ -193,7 +193,7 @@ class Environment
      *
      * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
@@ -216,7 +216,7 @@ class Environment
      *
      * @return \Symfony\Component\Console\Input\InputInterface
      */
-    public function getInput()
+    public function getInput(): InputInterface
     {
         return $this->input;
     }
@@ -239,7 +239,7 @@ class Environment
      *
      * @return \Symfony\Component\Console\Output\OutputInterface
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->output;
     }
@@ -249,7 +249,7 @@ class Environment
      *
      * @return array
      */
-    public function getVersions()
+    public function getVersions(): array
     {
         return $this->getAdapter()->getVersions();
     }
@@ -260,7 +260,7 @@ class Environment
      *
      * @return array
      */
-    public function getVersionLog()
+    public function getVersionLog(): array
     {
         return $this->getAdapter()->getVersionLog();
     }
@@ -271,7 +271,7 @@ class Environment
      * @param int $version Environment Version
      * @return $this
      */
-    public function setCurrentVersion($version)
+    public function setCurrentVersion(int $version)
     {
         $this->currentVersion = $version;
 
@@ -283,7 +283,7 @@ class Environment
      *
      * @return int
      */
-    public function getCurrentVersion()
+    public function getCurrentVersion(): int
     {
         // We don't cache this code as the current version is pretty volatile.
         // that means they're no point in a setter then?
@@ -319,7 +319,7 @@ class Environment
      * @throws \RuntimeException
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function getAdapter()
+    public function getAdapter(): AdapterInterface
     {
         if (isset($this->adapter)) {
             return $this->adapter;
@@ -391,7 +391,7 @@ class Environment
      *
      * @return string
      */
-    public function getSchemaTableName()
+    public function getSchemaTableName(): string
     {
         return $this->schemaTableName;
     }

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -31,12 +31,12 @@ class Environment
     /**
      * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input = null;
+    protected $input;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface|null
      */
-    protected $output = null;
+    protected $output;
 
     /**
      * @var int

--- a/src/Phinx/Migration/Migration.template.php.dist
+++ b/src/Phinx/Migration/Migration.template.php.dist
@@ -16,7 +16,7 @@ final class $className extends $baseClassName
      * Remember to call "create()" or "update()" and NOT "save()" when working
      * with the Table class.
      */
-    public function change(): void
+    public function change()
     {
 
     }

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -49,9 +49,9 @@ interface MigrationInterface
     /**
      * Gets the database adapter.
      *
-     * @return \Phinx\Db\Adapter\AdapterInterface
+     * @return \Phinx\Db\Adapter\AdapterInterface|null
      */
-    public function getAdapter(): AdapterInterface;
+    public function getAdapter(): ?AdapterInterface;
 
     /**
      * Sets the input object to be used in migration object
@@ -64,9 +64,9 @@ interface MigrationInterface
     /**
      * Gets the input object to be used in migration object
      *
-     * @return \Symfony\Component\Console\Input\InputInterface
+     * @return \Symfony\Component\Console\Input\InputInterface|null
      */
-    public function getInput(): InputInterface;
+    public function getInput(): ?InputInterface;
 
     /**
      * Sets the output object to be used in migration object
@@ -79,9 +79,9 @@ interface MigrationInterface
     /**
      * Gets the output object to be used in migration object
      *
-     * @return \Symfony\Component\Console\Output\OutputInterface
+     * @return \Symfony\Component\Console\Output\OutputInterface|null
      */
-    public function getOutput(): OutputInterface;
+    public function getOutput(): ?OutputInterface;
 
     /**
      * Gets the name.

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -7,6 +7,7 @@
 
 namespace Phinx\Migration;
 
+use Cake\Database\Query;
 use Phinx\Db\Adapter\AdapterInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -44,7 +45,7 @@ interface MigrationInterface
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
      * @return $this
      */
-    public function setAdapter(AdapterInterface $adapter): MigrationInterface;
+    public function setAdapter(AdapterInterface $adapter);
 
     /**
      * Gets the database adapter.
@@ -59,7 +60,7 @@ interface MigrationInterface
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @return $this
      */
-    public function setInput(InputInterface $input): MigrationInterface;
+    public function setInput(InputInterface $input);
 
     /**
      * Gets the input object to be used in migration object
@@ -74,7 +75,7 @@ interface MigrationInterface
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return $this
      */
-    public function setOutput(OutputInterface $output): MigrationInterface;
+    public function setOutput(OutputInterface $output);
 
     /**
      * Gets the output object to be used in migration object
@@ -118,7 +119,7 @@ interface MigrationInterface
      * @param bool $isMigratingUp True if the migration is being applied
      * @return $this
      */
-    public function setMigratingUp(bool $isMigratingUp): MigrationInterface;
+    public function setMigratingUp(bool $isMigratingUp);
 
     /**
      * Gets whether this migration is being applied or reverted.
@@ -161,7 +162,7 @@ interface MigrationInterface
      * @see https://api.cakephp.org/3.6/class-Cake.Database.Query.html
      * @return \Cake\Database\Query
      */
-    public function getQueryBuilder(): \Cake\Database\Query;
+    public function getQueryBuilder(): Query;
 
     /**
      * Executes a query and returns only one row as an array.

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -42,83 +42,83 @@ interface MigrationInterface
      * Sets the database adapter.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
-     * @return \Phinx\Migration\MigrationInterface
+     * @return $this
      */
-    public function setAdapter(AdapterInterface $adapter);
+    public function setAdapter(AdapterInterface $adapter): MigrationInterface;
 
     /**
      * Gets the database adapter.
      *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function getAdapter();
+    public function getAdapter(): AdapterInterface;
 
     /**
      * Sets the input object to be used in migration object
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     * @return \Phinx\Migration\MigrationInterface
+     * @return $this
      */
-    public function setInput(InputInterface $input);
+    public function setInput(InputInterface $input): MigrationInterface;
 
     /**
      * Gets the input object to be used in migration object
      *
      * @return \Symfony\Component\Console\Input\InputInterface
      */
-    public function getInput();
+    public function getInput(): InputInterface;
 
     /**
      * Sets the output object to be used in migration object
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return \Phinx\Migration\MigrationInterface
+     * @return $this
      */
-    public function setOutput(OutputInterface $output);
+    public function setOutput(OutputInterface $output): MigrationInterface;
 
     /**
      * Gets the output object to be used in migration object
      *
      * @return \Symfony\Component\Console\Output\OutputInterface
      */
-    public function getOutput();
+    public function getOutput(): OutputInterface;
 
     /**
      * Gets the name.
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Gets the detected environment
      *
      * @return string
      */
-    public function getEnvironment();
+    public function getEnvironment(): string;
 
     /**
      * Sets the migration version number.
      *
      * @param int $version Version
-     * @return \Phinx\Migration\MigrationInterface
+     * @return $this
      */
-    public function setVersion($version);
+    public function setVersion(int $version);
 
     /**
      * Gets the migration version number.
      *
      * @return int
      */
-    public function getVersion();
+    public function getVersion(): int;
 
     /**
      * Sets whether this migration is being applied or reverted
      *
      * @param bool $isMigratingUp True if the migration is being applied
-     * @return \Phinx\Migration\MigrationInterface
+     * @return $this
      */
-    public function setMigratingUp($isMigratingUp);
+    public function setMigratingUp(bool $isMigratingUp): MigrationInterface;
 
     /**
      * Gets whether this migration is being applied or reverted.
@@ -126,7 +126,7 @@ interface MigrationInterface
      *
      * @return bool
      */
-    public function isMigratingUp();
+    public function isMigratingUp(): bool;
 
     /**
      * Executes a SQL statement and returns the number of affected rows.
@@ -135,7 +135,7 @@ interface MigrationInterface
      * @param array $params parameters to use for prepared query
      * @return int
      */
-    public function execute($sql, array $params = []);
+    public function execute(string $sql, array $params = []): int;
 
     /**
      * Executes a SQL statement.
@@ -149,7 +149,7 @@ interface MigrationInterface
      * @param array $params parameters to use for prepared query
      * @return mixed
      */
-    public function query($sql, array $params = []);
+    public function query(string $sql, array $params = []);
 
     /**
      * Returns a new Query object that can be used to build complex SELECT, UPDATE, INSERT or DELETE
@@ -161,7 +161,7 @@ interface MigrationInterface
      * @see https://api.cakephp.org/3.6/class-Cake.Database.Query.html
      * @return \Cake\Database\Query
      */
-    public function getQueryBuilder();
+    public function getQueryBuilder(): \Cake\Database\Query;
 
     /**
      * Executes a query and returns only one row as an array.
@@ -169,7 +169,7 @@ interface MigrationInterface
      * @param string $sql SQL
      * @return array|false
      */
-    public function fetchRow($sql);
+    public function fetchRow(string $sql);
 
     /**
      * Executes a query and returns an array of rows.
@@ -177,7 +177,7 @@ interface MigrationInterface
      * @param string $sql SQL
      * @return array
      */
-    public function fetchAll($sql);
+    public function fetchAll(string $sql): array;
 
     /**
      * Create a new database.
@@ -186,7 +186,7 @@ interface MigrationInterface
      * @param array $options Options
      * @return void
      */
-    public function createDatabase($name, $options);
+    public function createDatabase(string $name, array $options): void;
 
     /**
      * Drop a database.
@@ -194,7 +194,7 @@ interface MigrationInterface
      * @param string $name Database Name
      * @return void
      */
-    public function dropDatabase($name);
+    public function dropDatabase(string $name): void;
 
     /**
      * Creates schema.
@@ -205,7 +205,7 @@ interface MigrationInterface
      * @return void
      * @throws \BadMethodCallException
      */
-    public function createSchema($name);
+    public function createSchema(string $name): void;
 
     /**
      * Drops schema.
@@ -216,7 +216,7 @@ interface MigrationInterface
      * @return void
      * @throws \BadMethodCallException
      */
-    public function dropSchema($name);
+    public function dropSchema(string $name): void;
 
     /**
      * Checks to see if a table exists.
@@ -224,7 +224,7 @@ interface MigrationInterface
      * @param string $tableName Table name
      * @return bool
      */
-    public function hasTable($tableName);
+    public function hasTable(string $tableName): bool;
 
     /**
      * Returns an instance of the <code>\Table</code> class.
@@ -235,7 +235,7 @@ interface MigrationInterface
      * @param array $options Options
      * @return \Phinx\Db\Table
      */
-    public function table($tableName, $options);
+    public function table(string $tableName, array $options);
 
     /**
      * Perform checks on the migration, printing a warning
@@ -243,7 +243,7 @@ interface MigrationInterface
      *
      * @return void
      */
-    public function preFlightCheck();
+    public function preFlightCheck(): void;
 
     /**
      * Perform checks on the migration after completion
@@ -252,7 +252,7 @@ interface MigrationInterface
      *
      * @return void
      */
-    public function postFlightCheck();
+    public function postFlightCheck(): void;
 
     /**
      * Checks to see if the migration should be executed.
@@ -263,5 +263,5 @@ interface MigrationInterface
      *
      * @return bool
      */
-    public function shouldExecute();
+    public function shouldExecute(): bool;
 }

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -54,9 +54,7 @@ abstract class AbstractSeed implements SeedInterface
     }
 
     /**
-     * Return seeds dependencies.
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getDependencies(): array
     {

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -49,7 +49,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function run()
+    public function run(): void
     {
     }
 
@@ -58,7 +58,7 @@ abstract class AbstractSeed implements SeedInterface
      *
      * @return array
      */
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return [];
     }
@@ -66,7 +66,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function setAdapter(AdapterInterface $adapter)
+    public function setAdapter(AdapterInterface $adapter): SeedInterface
     {
         $this->adapter = $adapter;
 
@@ -76,7 +76,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function getAdapter()
+    public function getAdapter(): AdapterInterface
     {
         return $this->adapter;
     }
@@ -84,7 +84,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function setInput(InputInterface $input)
+    public function setInput(InputInterface $input): SeedInterface
     {
         $this->input = $input;
 
@@ -94,7 +94,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function getInput()
+    public function getInput(): InputInterface
     {
         return $this->input;
     }
@@ -102,7 +102,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function setOutput(OutputInterface $output)
+    public function setOutput(OutputInterface $output): SeedInterface
     {
         $this->output = $output;
 
@@ -112,7 +112,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->output;
     }
@@ -120,7 +120,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function getName()
+    public function getName(): string
     {
         return static::class;
     }
@@ -128,7 +128,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function execute($sql, array $params = [])
+    public function execute(string $sql, array $params = [])
     {
         return $this->getAdapter()->execute($sql, $params);
     }
@@ -136,7 +136,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function query($sql, array $params = [])
+    public function query(string $sql, array $params = [])
     {
         return $this->getAdapter()->query($sql, $params);
     }
@@ -144,7 +144,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function fetchRow($sql)
+    public function fetchRow(string $sql)
     {
         return $this->getAdapter()->fetchRow($sql);
     }
@@ -152,7 +152,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function fetchAll($sql)
+    public function fetchAll(string $sql): array
     {
         return $this->getAdapter()->fetchAll($sql);
     }
@@ -160,7 +160,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function insert($table, $data)
+    public function insert(string $table, array $data): void
     {
         // convert to table object
         if (is_string($table)) {
@@ -172,7 +172,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function hasTable($tableName)
+    public function hasTable(string $tableName): bool
     {
         return $this->getAdapter()->hasTable($tableName);
     }
@@ -180,7 +180,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function table($tableName, $options = [])
+    public function table(string $tableName, array $options = []): Table
     {
         return new Table($tableName, $options, $this->getAdapter());
     }
@@ -194,7 +194,7 @@ abstract class AbstractSeed implements SeedInterface
      *
      * @return bool
      */
-    public function shouldExecute()
+    public function shouldExecute(): bool
     {
         return true;
     }

--- a/src/Phinx/Seed/Seed.template.php.dist
+++ b/src/Phinx/Seed/Seed.template.php.dist
@@ -13,7 +13,7 @@ class $className extends $baseClassName
      * More information on writing seeders is available here:
      * https://book.cakephp.org/phinx/0/en/seeding.html
      */
-    public function run()
+    public function run(): void
     {
 
     }

--- a/src/Phinx/Seed/Seed.template.php.dist
+++ b/src/Phinx/Seed/Seed.template.php.dist
@@ -13,7 +13,7 @@ class $className extends $baseClassName
      * More information on writing seeders is available here:
      * https://book.cakephp.org/phinx/0/en/seeding.html
      */
-    public function run(): void
+    public function run()
     {
 
     }

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -36,10 +36,17 @@ interface SeedInterface
     public function run(): void;
 
     /**
+     * Return seeds dependencies.
+     *
+     * @return array
+     */
+    public function getDependencies(): array;
+
+    /**
      * Sets the database adapter.
      *
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
-     * @return \Phinx\Seed\SeedInterface
+     * @return $this
      */
     public function setAdapter(AdapterInterface $adapter): SeedInterface;
 
@@ -54,7 +61,7 @@ interface SeedInterface
      * Sets the input object to be used in migration object
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     * @return \Phinx\Seed\SeedInterface
+     * @return $this
      */
     public function setInput(InputInterface $input): SeedInterface;
 
@@ -69,7 +76,7 @@ interface SeedInterface
      * Sets the output object to be used in migration object
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return \Phinx\Seed\SeedInterface
+     * @return $this
      */
     public function setOutput(OutputInterface $output): SeedInterface;
 

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -48,7 +48,7 @@ interface SeedInterface
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
      * @return $this
      */
-    public function setAdapter(AdapterInterface $adapter): SeedInterface;
+    public function setAdapter(AdapterInterface $adapter);
 
     /**
      * Gets the database adapter.
@@ -63,7 +63,7 @@ interface SeedInterface
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @return $this
      */
-    public function setInput(InputInterface $input): SeedInterface;
+    public function setInput(InputInterface $input);
 
     /**
      * Gets the input object to be used in migration object
@@ -78,7 +78,7 @@ interface SeedInterface
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return $this
      */
-    public function setOutput(OutputInterface $output): SeedInterface;
+    public function setOutput(OutputInterface $output);
 
     /**
      * Gets the output object to be used in migration object

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -33,7 +33,7 @@ interface SeedInterface
      *
      * @return void
      */
-    public function run();
+    public function run(): void;
 
     /**
      * Sets the database adapter.
@@ -41,14 +41,14 @@ interface SeedInterface
      * @param \Phinx\Db\Adapter\AdapterInterface $adapter Database Adapter
      * @return \Phinx\Seed\SeedInterface
      */
-    public function setAdapter(AdapterInterface $adapter);
+    public function setAdapter(AdapterInterface $adapter): SeedInterface;
 
     /**
      * Gets the database adapter.
      *
      * @return \Phinx\Db\Adapter\AdapterInterface
      */
-    public function getAdapter();
+    public function getAdapter(): AdapterInterface;
 
     /**
      * Sets the input object to be used in migration object
@@ -56,14 +56,14 @@ interface SeedInterface
      * @param \Symfony\Component\Console\Input\InputInterface $input Input
      * @return \Phinx\Seed\SeedInterface
      */
-    public function setInput(InputInterface $input);
+    public function setInput(InputInterface $input): SeedInterface;
 
     /**
      * Gets the input object to be used in migration object
      *
      * @return \Symfony\Component\Console\Input\InputInterface
      */
-    public function getInput();
+    public function getInput(): InputInterface;
 
     /**
      * Sets the output object to be used in migration object
@@ -71,21 +71,21 @@ interface SeedInterface
      * @param \Symfony\Component\Console\Output\OutputInterface $output Output
      * @return \Phinx\Seed\SeedInterface
      */
-    public function setOutput(OutputInterface $output);
+    public function setOutput(OutputInterface $output): SeedInterface;
 
     /**
      * Gets the output object to be used in migration object
      *
      * @return \Symfony\Component\Console\Output\OutputInterface
      */
-    public function getOutput();
+    public function getOutput(): OutputInterface;
 
     /**
      * Gets the name.
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Executes a SQL statement and returns the number of affected rows.
@@ -94,7 +94,7 @@ interface SeedInterface
      * @param array $params parameters to use for prepared query
      * @return int
      */
-    public function execute($sql, array $params = []);
+    public function execute(string $sql, array $params = []);
 
     /**
      * Executes a SQL statement.
@@ -108,7 +108,7 @@ interface SeedInterface
      * @param array $params parameters to use for prepared query
      * @return mixed
      */
-    public function query($sql, array $params = []);
+    public function query(string $sql, array $params = []);
 
     /**
      * Executes a query and returns only one row as an array.
@@ -116,7 +116,7 @@ interface SeedInterface
      * @param string $sql SQL
      * @return array|false
      */
-    public function fetchRow($sql);
+    public function fetchRow(string $sql);
 
     /**
      * Executes a query and returns an array of rows.
@@ -124,7 +124,7 @@ interface SeedInterface
      * @param string $sql SQL
      * @return array
      */
-    public function fetchAll($sql);
+    public function fetchAll(string $sql): array;
 
     /**
      * Insert data into a table.
@@ -133,7 +133,7 @@ interface SeedInterface
      * @param array $data Data
      * @return void
      */
-    public function insert($tableName, $data);
+    public function insert(string $tableName, array $data): void;
 
     /**
      * Checks to see if a table exists.
@@ -141,7 +141,7 @@ interface SeedInterface
      * @param string $tableName Table name
      * @return bool
      */
-    public function hasTable($tableName);
+    public function hasTable(string $tableName): bool;
 
     /**
      * Returns an instance of the <code>\Table</code> class.
@@ -152,7 +152,7 @@ interface SeedInterface
      * @param array $options Options
      * @return \Phinx\Db\Table
      */
-    public function table($tableName, $options);
+    public function table(string $tableName, array $options): \Phinx\Db\Table;
 
     /**
      * Checks to see if the seed should be executed.
@@ -163,5 +163,5 @@ interface SeedInterface
      *
      * @return bool
      */
-    public function shouldExecute();
+    public function shouldExecute(): bool;
 }

--- a/src/Phinx/Util/Expression.php
+++ b/src/Phinx/Util/Expression.php
@@ -17,7 +17,7 @@ class Expression
     /**
      * @param string $value The expression
      */
-    public function __construct($value)
+    public function __construct(string $value)
     {
         $this->value = $value;
     }
@@ -25,7 +25,7 @@ class Expression
     /**
      * @return string Returns the expression
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->value;
     }
@@ -34,7 +34,7 @@ class Expression
      * @param string $value The expression
      * @return self
      */
-    public static function from($value)
+    public static function from(string $value): Expression
     {
         return new self($value);
     }

--- a/src/Phinx/Util/Literal.php
+++ b/src/Phinx/Util/Literal.php
@@ -17,7 +17,7 @@ class Literal
     /**
      * @param string $value The literal's value
      */
-    public function __construct($value)
+    public function __construct(string $value)
     {
         $this->value = $value;
     }
@@ -25,7 +25,7 @@ class Literal
     /**
      * @return string Returns the literal's value
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->value;
     }
@@ -34,7 +34,7 @@ class Literal
      * @param string $value The literal's value
      * @return self
      */
-    public static function from($value)
+    public static function from(string $value): Literal
     {
         return new self($value);
     }

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -45,7 +45,7 @@ class Util
      *
      * @return string
      */
-    public static function getCurrentTimestamp()
+    public static function getCurrentTimestamp(): string
     {
         $dt = new DateTime('now', new DateTimeZone('UTC'));
 
@@ -58,7 +58,7 @@ class Util
      * @param string $path Path
      * @return string[]
      */
-    public static function getExistingMigrationClassNames($path)
+    public static function getExistingMigrationClassNames(string $path): array
     {
         $classNames = [];
 
@@ -85,7 +85,7 @@ class Util
      * @param string $fileName File Name
      * @return string
      */
-    public static function getVersionFromFileName($fileName)
+    public static function getVersionFromFileName(string $fileName): string
     {
         $matches = [];
         preg_match('/^[0-9]+/', basename($fileName), $matches);
@@ -101,7 +101,7 @@ class Util
      * @param string $className Class Name
      * @return string
      */
-    public static function mapClassNameToFileName($className)
+    public static function mapClassNameToFileName(string $className): string
     {
         $snake = function ($matches) {
             return '_' . strtolower($matches[0]);
@@ -147,7 +147,7 @@ class Util
      * @param string $path Path
      * @return bool
      */
-    public static function isUniqueMigrationClassName($className, $path)
+    public static function isUniqueMigrationClassName(string $className, string $path): bool
     {
         $existingClassNames = static::getExistingMigrationClassNames($path);
 
@@ -165,7 +165,7 @@ class Util
      * @param string $className Class Name
      * @return bool
      */
-    public static function isValidPhinxClassName($className)
+    public static function isValidPhinxClassName(string $className): bool
     {
         return (bool)preg_match(static::CLASS_NAME_PATTERN, $className);
     }
@@ -188,7 +188,7 @@ class Util
      * @param string $fileName File Name
      * @return bool
      */
-    public static function isValidSeedFileName($fileName)
+    public static function isValidSeedFileName(string $fileName): bool
     {
         return (bool)preg_match(static::SEED_FILE_NAME_PATTERN, $fileName);
     }
@@ -199,7 +199,7 @@ class Util
      * @param string[] $paths Paths
      * @return string[]
      */
-    public static function globAll(array $paths)
+    public static function globAll(array $paths): array
     {
         $result = [];
 
@@ -216,7 +216,7 @@ class Util
      * @param string $path Path
      * @return string[]
      */
-    public static function glob($path)
+    public static function glob(string $path): array
     {
         return glob($path, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
     }
@@ -231,7 +231,7 @@ class Util
      * @throws \Exception
      * @return string
      */
-    public static function loadPhpFile($filename, ?InputInterface $input = null, ?OutputInterface $output = null, $context = null)
+    public static function loadPhpFile(string $filename, ?InputInterface $input = null, ?OutputInterface $output = null, $context = null): string
     {
         $filePath = realpath($filename);
         if (!file_exists($filePath)) {
@@ -263,7 +263,7 @@ class Util
      * @param string|string[] $paths Path or array of paths to get .php files.
      * @return string[]
      */
-    public static function getFiles($paths)
+    public static function getFiles($paths): array
     {
         $files = static::globAll(array_map(function ($path) {
             return $path . DIRECTORY_SEPARATOR . '*.php';
@@ -283,7 +283,7 @@ class Util
      * @param string $path Path to remove cwd prefix from
      * @return string
      */
-    public static function relativePath($path)
+    public static function relativePath(string $path): string
     {
         $realpath = realpath($path);
         if ($realpath !== false) {

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -49,7 +49,7 @@ class TextWrapper
      *
      * @return \Phinx\Console\PhinxApplication
      */
-    public function getApp()
+    public function getApp(): PhinxApplication
     {
         return $this->app;
     }
@@ -59,7 +59,7 @@ class TextWrapper
      *
      * @return int
      */
-    public function getExitCode()
+    public function getExitCode(): int
     {
         return $this->exitCode;
     }
@@ -70,7 +70,7 @@ class TextWrapper
      * @param string|null $env environment name (optional)
      * @return string
      */
-    public function getStatus($env = null)
+    public function getStatus(?string $env = null): string
     {
         $command = ['status'];
         if ($env ?: $this->hasOption('environment')) {
@@ -96,7 +96,7 @@ class TextWrapper
      * @param string|null $target target version (optional)
      * @return string
      */
-    public function getMigrate($env = null, $target = null)
+    public function getMigrate(?string $env = null, ?string $target = null): string
     {
         $command = ['migrate'];
         if ($env ?: $this->hasOption('environment')) {
@@ -123,7 +123,7 @@ class TextWrapper
      * @param string[]|string|null $seed Array of seed names or seed name
      * @return string
      */
-    public function getSeed($env = null, $target = null, $seed = null)
+    public function getSeed(?string $env = null, ?string $target = null, $seed = null): string
     {
         $command = ['seed:run'];
         if ($env ?: $this->hasOption('environment')) {
@@ -153,7 +153,7 @@ class TextWrapper
      * @param mixed $target Target version, or 0 (zero) fully revert (optional)
      * @return string
      */
-    public function getRollback($env = null, $target = null)
+    public function getRollback(?string $env = null, $target = null): string
     {
         $command = ['rollback'];
         if ($env ?: $this->hasOption('environment')) {
@@ -180,7 +180,7 @@ class TextWrapper
      * @param string $key Key
      * @return bool
      */
-    protected function hasOption($key)
+    protected function hasOption(string $key): bool
     {
         return isset($this->options[$key]);
     }
@@ -191,7 +191,7 @@ class TextWrapper
      * @param string $key Key
      * @return string|null
      */
-    protected function getOption($key)
+    protected function getOption(string $key): ?string
     {
         if (!isset($this->options[$key])) {
             return null;
@@ -207,7 +207,7 @@ class TextWrapper
      * @param string $value Value
      * @return $this
      */
-    public function setOption($key, $value)
+    public function setOption(string $key, string $value): TextWrapper
     {
         $this->options[$key] = $value;
 
@@ -220,7 +220,7 @@ class TextWrapper
      * @param array $command Command
      * @return string
      */
-    protected function executeRun(array $command)
+    protected function executeRun(array $command): string
     {
         // Output will be written to a temporary stream, so that it can be
         // collected after running the command.

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -207,7 +207,7 @@ class TextWrapper
      * @param string $value Value
      * @return $this
      */
-    public function setOption(string $key, string $value): TextWrapper
+    public function setOption(string $key, string $value)
     {
         $this->options[$key] = $value;
 

--- a/tests/Phinx/Config/AbstractConfigTest.php
+++ b/tests/Phinx/Config/AbstractConfigTest.php
@@ -16,12 +16,12 @@ abstract class AbstractConfigTest extends TestCase
     /**
      * @var string
      */
-    protected $migrationPath = null;
+    protected $migrationPath;
 
     /**
      * @var string
      */
-    protected $seedPath = null;
+    protected $seedPath;
 
     /**
      * Returns a sample configuration array for use with the unit tests.

--- a/tests/Phinx/Config/Command/VoidCommand.php
+++ b/tests/Phinx/Config/Command/VoidCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 class VoidCommand extends AbstractCommand
 {
-    public function locateConfigFile(InputInterface $input)
+    public function locateConfigFile(InputInterface $input): string
     {
         return parent::locateConfigFile($input);
     }

--- a/tests/Phinx/Console/Command/TemplateGenerators/NullGenerator.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/NullGenerator.php
@@ -12,9 +12,10 @@ class NullGenerator extends AbstractTemplateCreation
      *
      * @return string The content of the template for Phinx to amend.
      */
-    public function getMigrationTemplate()
+    public function getMigrationTemplate(): string
     {
         // Implement getMigrationTemplate() method.
+        return '';
     }
 
     /**
@@ -28,7 +29,7 @@ class NullGenerator extends AbstractTemplateCreation
      * @param string $baseClassName The name of the base class.
      * @return void
      */
-    public function postMigrationCreation($migrationFilename, $className, $baseClassName)
+    public function postMigrationCreation(string $migrationFilename, string $className, string $baseClassName): void
     {
         // Implement postMigrationCreation() method.
     }

--- a/tests/Phinx/Console/Command/TemplateGenerators/SimpleGenerator.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/SimpleGenerator.php
@@ -12,7 +12,7 @@ class SimpleGenerator extends AbstractTemplateCreation
      *
      * @return string The content of the template for Phinx to amend.
      */
-    public function getMigrationTemplate()
+    public function getMigrationTemplate(): string
     {
         return 'useClassName $useClassName / className $className / version $version / baseClassName $baseClassName';
     }
@@ -28,7 +28,7 @@ class SimpleGenerator extends AbstractTemplateCreation
      * @param string $baseClassName The name of the base class.
      * @return void
      */
-    public function postMigrationCreation($migrationFilename, $className, $baseClassName)
+    public function postMigrationCreation(string $migrationFilename, string $className, string $baseClassName): void
     {
     }
 }

--- a/tests/Phinx/Console/Output/RawBufferedOutput.php
+++ b/tests/Phinx/Console/Output/RawBufferedOutput.php
@@ -13,7 +13,7 @@ class RawBufferedOutput extends \Symfony\Component\Console\Output\BufferedOutput
      * @param int $options
      * @return void
      */
-    public function writeln($messages, $options = self::OUTPUT_RAW)
+    public function writeln($messages, int $options = self::OUTPUT_RAW): void
     {
         $this->write($messages, true, $options);
     }

--- a/tests/Phinx/Console/Output/RawBufferedOutput.php
+++ b/tests/Phinx/Console/Output/RawBufferedOutput.php
@@ -13,7 +13,7 @@ class RawBufferedOutput extends \Symfony\Component\Console\Output\BufferedOutput
      * @param int $options
      * @return void
      */
-    public function writeln($messages, int $options = self::OUTPUT_RAW): void
+    public function writeln($messages, $options = self::OUTPUT_RAW)
     {
         $this->write($messages, true, $options);
     }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -466,7 +466,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasTable('ntable'));
         $this->assertTrue($this->adapter->hasColumn('ntable', 'id'));
         $column_definitions = $this->adapter->getColumns('ntable');
-        $this->assertSame($this->usingMysql8() ? null : 4, $column_definitions[0]->getLimit());
+        $this->assertSame($this->usingMysql8() ? null : 4.0, $column_definitions[0]->getLimit());
     }
 
     public function testCreateTableWithSchema()
@@ -938,7 +938,7 @@ class MysqlAdapterTest extends TestCase
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
         $this->assertSame($expectedType, $sqlType['name']);
-        $this->assertSame($expectedLimit, $columns[1]->getLimit());
+        $this->assertSame((float)$expectedLimit, $columns[1]->getLimit());
     }
 
     public function varbinaryToBlobAutomaticConversionData()
@@ -965,7 +965,7 @@ class MysqlAdapterTest extends TestCase
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
         $this->assertSame($expectedType, $sqlType['name']);
-        $this->assertSame($expectedLimit, $columns[1]->getLimit());
+        $this->assertSame((float)$expectedLimit, $columns[1]->getLimit());
     }
 
     public function blobColumnsData()
@@ -1007,7 +1007,7 @@ class MysqlAdapterTest extends TestCase
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
         $this->assertSame($expectedType, $sqlType['name']);
-        $this->assertSame($expectedLimit, $columns[1]->getLimit());
+        $this->assertSame((float)$expectedLimit, $columns[1]->getLimit());
     }
 
     public function testBigIntegerColumn()
@@ -1058,7 +1058,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
-        $this->assertEquals($this->usingMysql8() ? 11 : $limit, $sqlType['limit']);
+        $this->assertEquals($this->usingMysql8() ? 11.0 : $limit, $sqlType['limit']);
     }
 
     public function testDatetimeColumn()

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -466,7 +466,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasTable('ntable'));
         $this->assertTrue($this->adapter->hasColumn('ntable', 'id'));
         $column_definitions = $this->adapter->getColumns('ntable');
-        $this->assertSame($this->usingMysql8() ? null : 4.0, $column_definitions[0]->getLimit());
+        $this->assertSame($this->usingMysql8() ? null : 4, $column_definitions[0]->getLimit());
     }
 
     public function testCreateTableWithSchema()

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -938,7 +938,7 @@ class MysqlAdapterTest extends TestCase
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
         $this->assertSame($expectedType, $sqlType['name']);
-        $this->assertSame((float)$expectedLimit, $columns[1]->getLimit());
+        $this->assertSame($expectedLimit, $columns[1]->getLimit());
     }
 
     public function varbinaryToBlobAutomaticConversionData()
@@ -965,7 +965,7 @@ class MysqlAdapterTest extends TestCase
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
         $this->assertSame($expectedType, $sqlType['name']);
-        $this->assertSame((float)$expectedLimit, $columns[1]->getLimit());
+        $this->assertSame($expectedLimit, $columns[1]->getLimit());
     }
 
     public function blobColumnsData()
@@ -1007,7 +1007,7 @@ class MysqlAdapterTest extends TestCase
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
         $this->assertSame($expectedType, $sqlType['name']);
-        $this->assertSame((float)$expectedLimit, $columns[1]->getLimit());
+        $this->assertSame($expectedLimit, $columns[1]->getLimit());
     }
 
     public function testBigIntegerColumn()
@@ -1058,7 +1058,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $columns = $table->getColumns();
         $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
-        $this->assertEquals($this->usingMysql8() ? 11.0 : $limit, $sqlType['limit']);
+        $this->assertEquals($this->usingMysql8() ? 11 : $limit, $sqlType['limit']);
     }
 
     public function testDatetimeColumn()

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -34,8 +34,6 @@ class PdoAdapterTest extends TestCase
 
     public function testOptionsSetConnection()
     {
-        $this->assertNull($this->adapter->getConnection());
-
         $connection = new PdoAdapterTestPDOMock();
         $this->adapter->setOptions(['connection' => $connection]);
 

--- a/tests/Phinx/Db/Mock/PdoAdapterTestPDOMockWithExecChecks.php
+++ b/tests/Phinx/Db/Mock/PdoAdapterTestPDOMockWithExecChecks.php
@@ -15,6 +15,8 @@ class PdoAdapterTestPDOMockWithExecChecks extends PdoAdapterTestPDOMock
     public function exec($sql)
     {
         $this->sql = $sql;
+
+        return 1;
     }
 
     public function prepare($sql, $options = [])

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -12,7 +12,7 @@ class ForeignKeyTest extends TestCase
     /**
      * @var ForeignKey
      */
-    private $fk = null;
+    private $fk;
 
     protected function setUp(): void
     {

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -125,7 +125,7 @@ class EnvironmentTest extends TestCase
             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->willReturn($adapterStub);
 
         $this->environment->setAdapter($adapterStub);
 
@@ -148,7 +148,7 @@ class EnvironmentTest extends TestCase
             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->willReturn($adapterStub);
 
         $this->environment->setAdapter($adapterStub);
 
@@ -200,7 +200,7 @@ class EnvironmentTest extends TestCase
             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->willReturn($adapterStub);
 
         $this->environment->setAdapter($adapterStub);
 
@@ -223,7 +223,7 @@ class EnvironmentTest extends TestCase
             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->willReturn($adapterStub);
 
         $this->environment->setAdapter($adapterStub);
 
@@ -255,7 +255,7 @@ class EnvironmentTest extends TestCase
             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
-                    ->will($this->returnArgument(0));
+                    ->willReturn($adapterStub);
 
         $this->environment->setAdapter($adapterStub);
 

--- a/tests/Phinx/Migration/_files/seeds/GSeeder.php
+++ b/tests/Phinx/Migration/_files/seeds/GSeeder.php
@@ -4,7 +4,7 @@ use Phinx\Seed\AbstractSeed;
 
 class GSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [

--- a/tests/Phinx/Migration/_files/seeds/PostSeeder.php
+++ b/tests/Phinx/Migration/_files/seeds/PostSeeder.php
@@ -4,7 +4,7 @@ use Phinx\Seed\AbstractSeed;
 
 class PostSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [
@@ -22,7 +22,7 @@ class PostSeeder extends AbstractSeed
               ->save();
     }
 
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return [
             'UserSeeder',

--- a/tests/Phinx/Migration/_files/seeds/UserSeeder.php
+++ b/tests/Phinx/Migration/_files/seeds/UserSeeder.php
@@ -4,7 +4,7 @@ use Phinx\Seed\AbstractSeed;
 
 class UserSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [

--- a/tests/Phinx/Migration/_files/seeds/UserSeederNotExecuted.php
+++ b/tests/Phinx/Migration/_files/seeds/UserSeederNotExecuted.php
@@ -5,7 +5,7 @@ use Phinx\Seed\AbstractSeed;
 
 class UserSeederNotExecuted extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [
@@ -23,7 +23,7 @@ class UserSeederNotExecuted extends AbstractSeed
               ->save();
     }
 
-    public function shouldExecute()
+    public function shouldExecute(): bool
     {
         return false;
     }

--- a/tests/Phinx/Migration/_files/should_execute/20201207205056_should_not_execute_migration.php
+++ b/tests/Phinx/Migration/_files/should_execute/20201207205056_should_not_execute_migration.php
@@ -11,7 +11,7 @@ class ShouldNotExecuteMigration extends AbstractMigration
         $this->table('info')->create();
     }
 
-    public function shouldExecute()
+    public function shouldExecute(): bool
     {
         return false;
     }

--- a/tests/Phinx/Migration/_files/should_execute/20201207205057_should_execute_migration.php
+++ b/tests/Phinx/Migration/_files/should_execute/20201207205057_should_execute_migration.php
@@ -11,7 +11,7 @@ class ShouldExecuteMigration extends AbstractMigration
         $this->table('info')->create();
     }
 
-    public function shouldExecute()
+    public function shouldExecute(): bool
     {
         return true;
     }

--- a/tests/Phinx/Migration/_files_baz/seeds/GSeeder.php
+++ b/tests/Phinx/Migration/_files_baz/seeds/GSeeder.php
@@ -6,7 +6,7 @@ use Phinx\Seed\AbstractSeed;
 
 class GSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [

--- a/tests/Phinx/Migration/_files_baz/seeds/PostSeeder.php
+++ b/tests/Phinx/Migration/_files_baz/seeds/PostSeeder.php
@@ -6,7 +6,7 @@ use Phinx\Seed\AbstractSeed;
 
 class PostSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [

--- a/tests/Phinx/Migration/_files_baz/seeds/UserSeeder.php
+++ b/tests/Phinx/Migration/_files_baz/seeds/UserSeeder.php
@@ -6,7 +6,7 @@ use Phinx\Seed\AbstractSeed;
 
 class UserSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [

--- a/tests/Phinx/Migration/_files_foo_bar/seeds/GSeeder.php
+++ b/tests/Phinx/Migration/_files_foo_bar/seeds/GSeeder.php
@@ -6,7 +6,7 @@ use Phinx\Seed\AbstractSeed;
 
 class GSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [

--- a/tests/Phinx/Migration/_files_foo_bar/seeds/PostSeeder.php
+++ b/tests/Phinx/Migration/_files_foo_bar/seeds/PostSeeder.php
@@ -6,7 +6,7 @@ use Phinx\Seed\AbstractSeed;
 
 class PostSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [

--- a/tests/Phinx/Migration/_files_foo_bar/seeds/UserSeeder.php
+++ b/tests/Phinx/Migration/_files_foo_bar/seeds/UserSeeder.php
@@ -6,7 +6,7 @@ use Phinx\Seed\AbstractSeed;
 
 class UserSeeder extends AbstractSeed
 {
-    public function run()
+    public function run(): void
     {
         $data = [
             [


### PR DESCRIPTION
This PR will add type hints to all possible places in the codebase. I debated on adding `declare(strict_types=1);` at the same time, but not sure if should be done at the same time, or separately. Putting this up in draft form to keep track of progress, and hopefully help ensure no one else spends time on doing this concurrently.