### PR TITLE
Adding the mediumint type for the MySql adapter

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -56,6 +56,7 @@ interface AdapterInterface
     public const PHINX_TYPE_POLYGON = 'polygon';
 
     // only for mysql so far
+    public const PHINX_TYPE_MEDIUM_INTEGER = 'mediuminteger';
     public const PHINX_TYPE_ENUM = 'enum';
     public const PHINX_TYPE_SET = 'set';
     public const PHINX_TYPE_YEAR = 'year';

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -47,6 +47,7 @@ class MysqlAdapter extends PdoAdapter
         self::PHINX_TYPE_INTEGER => true,
         self::PHINX_TYPE_TINY_INTEGER => true,
         self::PHINX_TYPE_SMALL_INTEGER => true,
+        self::PHINX_TYPE_MEDIUM_INTEGER => true,
         self::PHINX_TYPE_BIG_INTEGER => true,
         self::PHINX_TYPE_FLOAT => true,
         self::PHINX_TYPE_DECIMAL => true,
@@ -1000,6 +1001,8 @@ class MysqlAdapter extends PdoAdapter
                 return ['name' => 'bit', 'limit' => $limit ?: 64];
             case static::PHINX_TYPE_SMALL_INTEGER:
                 return ['name' => 'smallint', 'limit' => $limit ?: 6];
+            case static::PHINX_TYPE_MEDIUM_INTEGER:
+                return ['name' => 'mediumint', 'limit' => $limit ?: 8];
             case static::PHINX_TYPE_TINY_INTEGER:
                 return ['name' => 'tinyint', 'limit' => $limit ?: 4];
             case static::PHINX_TYPE_INTEGER:
@@ -1015,6 +1018,7 @@ class MysqlAdapter extends PdoAdapter
                     $limits = [
                         'tinyint' => 4,
                         'smallint' => 6,
+                        'mediumint' => 8,
                         'int' => 11,
                         'bigint' => 20,
                     ];
@@ -1103,7 +1107,7 @@ class MysqlAdapter extends PdoAdapter
                 $limit = static::INT_SMALL;
                 break;
             case 'mediumint':
-                $type = static::PHINX_TYPE_INTEGER;
+                $type = static::PHINX_TYPE_MEDIUM_INTEGER;
                 $limit = static::INT_MEDIUM;
                 break;
             case 'int':

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -38,6 +38,7 @@ class MysqlAdapter extends PdoAdapter
         self::PHINX_TYPE_TINYBLOB,
         self::PHINX_TYPE_MEDIUMBLOB,
         self::PHINX_TYPE_LONGBLOB,
+        self::PHINX_TYPE_MEDIUM_INTEGER,
     ];
 
     /**

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -999,10 +999,12 @@ class MysqlAdapter extends PdoAdapter
                 return $this->getSqlType(static::PHINX_TYPE_BLOB, $limit ?: static::BLOB_LONG);
             case static::PHINX_TYPE_BIT:
                 return ['name' => 'bit', 'limit' => $limit ?: 64];
-            case static::PHINX_TYPE_SMALL_INTEGER:
-                return ['name' => 'smallint', 'limit' => $limit ?: 6];
+            case static::PHINX_TYPE_BIG_INTEGER:
+                return ['name' => 'bigint', 'limit' => $limit ?: 20];
             case static::PHINX_TYPE_MEDIUM_INTEGER:
                 return ['name' => 'mediumint', 'limit' => $limit ?: 8];
+            case static::PHINX_TYPE_SMALL_INTEGER:
+                return ['name' => 'smallint', 'limit' => $limit ?: 6];
             case static::PHINX_TYPE_TINY_INTEGER:
                 return ['name' => 'tinyint', 'limit' => $limit ?: 4];
             case static::PHINX_TYPE_INTEGER:
@@ -1037,8 +1039,6 @@ class MysqlAdapter extends PdoAdapter
                 }
 
                 return ['name' => 'int', 'limit' => $limit];
-            case static::PHINX_TYPE_BIG_INTEGER:
-                return ['name' => 'bigint', 'limit' => $limit ?: 20];
             case static::PHINX_TYPE_BOOLEAN:
                 return ['name' => 'tinyint', 'limit' => 1];
             case static::PHINX_TYPE_UUID:

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -33,6 +33,8 @@ class Column
     public const UUID = AdapterInterface::PHINX_TYPE_UUID;
     public const BINARYUUID = AdapterInterface::PHINX_TYPE_BINARYUUID;
     /** MySQL-only column type */
+    public const MEDIUMINTEGER = AdapterInterface::PHINX_TYPE_MEDIUM_INTEGER;
+    /** MySQL-only column type */
     public const ENUM = AdapterInterface::PHINX_TYPE_ENUM;
     /** MySQL-only column type */
     public const SET = AdapterInterface::PHINX_TYPE_STRING;

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2074,7 +2074,7 @@ INPUT;
             MYSQL_DB_CONFIG['name']
         ));
         $colDef = $rows[0];
-        $this->assertEquals('CURRENT_TIMESTAMP(3)', $colDef['COLUMN_DEFAULT']);
+        $this->assertEqualsIgnoringCase('CURRENT_TIMESTAMP(3)', $colDef['COLUMN_DEFAULT']);
     }
 
     public function pdoAttributeProvider()


### PR DESCRIPTION
This Pull requests solves issue #1996. Correctly adding the mediumint type to mysql. Together on this patch, one of the PHPUnit tests was changed to ignore case, due to differences between MySQL and MariaDB