### PR TITLE
Add baseline for phpstan to workaround analysis bug

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to function is_subclass_of\\(\\) with non\\-empty\\-string and 'Phinx\\\\\\\\Migration…' will always evaluate to false\\.$#"
+			count: 1
+			path: src/Phinx/Console/Command/Create.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+	- phpstan-baseline.neon
+
 parameters:
 	level: 6
 	treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
There's an open bug in phpstan that's triggering an error on usage of `is_subclass_of` (see https://github.com/phpstan/phpstan/issues/5369). While we wait for a fix, this PR adds a baseline file to ignore the reported error, so that the build will no longer fail.