### PR TITLE
Update MysqlAdapter.php

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -470,7 +470,8 @@ class MysqlAdapter extends PdoAdapter
     {
         $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName)));
         foreach ($rows as $column) {
-            if (strcasecmp($column['Field'], $columnName) === 0) {
+            $field = $column instanceof \stdClass ? $column->Field : $column['Field'];
+            if (strcasecmp($field, $columnName) === 0) {
                 return true;
             }
         }


### PR DESCRIPTION
When working with PDO in PDO :: ATTR_DEFAULT_FETCH_MODE => PDO :: FETCH_ASSOC mode, an error pops up. Cannot use an object of type stdClass as an array