### PR TITLE
Fix fetching column null status on sqlite

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -644,7 +644,8 @@ PCRE_PATTERN;
             $default = $this->parseDefaultValue($columnInfo['dflt_value'], $type['name']);
 
             $column->setName($columnInfo['name'])
-                   ->setNull($columnInfo['notnull'] !== '1')
+                // SQLite on PHP 8.1 returns int for notnull, older versions return a string
+                   ->setNull((int)$columnInfo['notnull'] !== 1)
                    ->setDefault($default)
                    ->setType($type['name'])
                    ->setLimit($type['limit'])


### PR DESCRIPTION
On PHP 8.1, the version of sqlite that comes bundled with PHP now returns an integer value for the `notnull` column, which broke our check which assumes it's a string (such as on all older PHP versions).

This PR fixes it by applying an `(int)` cast before we compare the value of `notnull`.

The failing in PHP 8.1 mysql tests are fixed in #2021 