### PR TITLE
Fix type error in MysqlAdapterTest::testGeometrySridSupport on PHP 8.1

### DIFF
--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2014,7 +2014,7 @@ INPUT;
         $rows = $this->adapter->fetchAll('SELECT ST_AsWKT(geom) as wkt, ST_SRID(geom) as srid FROM table1');
         $this->assertCount(1, $rows);
         $this->assertSame($geom, $rows[0]['wkt']);
-        $this->assertSame('4326', $rows[0]['srid']);
+        $this->assertSame(4326, (int)$rows[0]['srid']);
     }
 
     /**


### PR DESCRIPTION
On PHP 8.1, it seems like the `ST_SRID(geom)` function now properly returns an integer as opposed to a string. Given that `fetchAll` is a shallow wrapper around the `PDO::query` method, I do not think that this requires any adjustments on phinx itself for this.

The failing PHP 8.1 sqlite tests are fixed in #2020 