### PR TITLE
Fix renaming table not using prefix/suffix on new name

### DIFF
--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -459,7 +459,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
                     break;
 
                 case $action instanceof RenameTable:
-                    $actions[$k] = new RenameTable($adapterTable, $action->getNewName());
+                    $actions[$k] = new RenameTable($adapterTable, $this->getAdapterTableName($action->getNewName()));
                     break;
 
                 case $action instanceof ChangePrimaryKey:

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -393,7 +393,7 @@ class TablePrefixAdapterTest extends TestCase
             [new DropTable($table)],
             [RemoveColumn::build($table, 'acolumn')],
             [RenameColumn::build($table, 'acolumn', 'another')],
-            [new RenameTable($table, 'new_name')],
+            [new RenameTable($table, 'new_name'), true],
             [new ChangePrimaryKey($table, 'column1')],
             [new ChangeComment($table, 'comment1')],
         ];
@@ -412,10 +412,17 @@ class TablePrefixAdapterTest extends TestCase
                 $this->assertEquals('pre_my_test_suf', $newActions[0]->getTable()->getName());
 
                 if ($checkReferecedTable) {
-                    $this->assertEquals(
-                        'pre_another_table_suf',
-                        $newActions[0]->getForeignKey()->getReferencedTable()->getName()
-                    );
+                    if ($action instanceof AddForeignKey) {
+                        $this->assertEquals(
+                            'pre_another_table_suf',
+                            $newActions[0]->getForeignKey()->getReferencedTable()->getName()
+                        );
+                    } elseif ($action instanceof RenameTable) {
+                        $this->assertEquals(
+                            'pre_new_name_suf',
+                            $newActions[0]->getNewName()
+                        );
+                    }
                 }
             }));
 


### PR DESCRIPTION
Fixes #2018 

This PR fixes a bug where renaming a table would not apply the set prefix/suffix from the config.

If you had set the prefix/suffix in the config, and then attempted to do rename a table through `$this->table('foo')->rename('bar')->save();`, `foo` would have the prefix/suffix applied, but the new name would not.