### PR TITLE
Fix PHPUnit not throwing exception on deprecation notice

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,9 @@
 <phpunit
-        bootstrap="tests/phpunit-bootstrap.php"
-        colors="true"
-        columns="max"
+    bootstrap="tests/phpunit-bootstrap.php"
+    colors="true"
+    columns="max"
+    convertErrorsToExceptions="true"
+    convertDeprecationsToExceptions="true"
 >
 
     <!--


### PR DESCRIPTION
From the changelog of PHPUnit's latest release [9.5.10](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-9.5.md#9510---2021-09-25):

> PHPUnit no longer converts PHP deprecations to exceptions by default (configure convertDeprecationsToExceptions="true" to enable this)

This PR adds this setting, set to true, to the phpunit configuration as we relied on it for two tests for deprecated features.