### PR TITLE
Remove decimal from unsupported sqlite types list

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -94,7 +94,6 @@ class SQLiteAdapter extends PdoAdapter
     protected static $unsupportedColumnTypes = [
         self::PHINX_TYPE_BIT,
         self::PHINX_TYPE_CIDR,
-        self::PHINX_TYPE_DECIMAL,
         self::PHINX_TYPE_ENUM,
         self::PHINX_TYPE_FILESTREAM,
         self::PHINX_TYPE_GEOMETRY,


### PR DESCRIPTION
Fixes #2014 

Support for decimal was added in #1833, but was not removed from the internal static `$unsupportedColumnTypes` array. There is no effect on behavior as all places this list is used, the type is first checked to see if if exists in `$supportedColumnTypes` and then failing that would look in the former. Since decimal appeared in both, the fact it was in `$unsupportedColumnTypes` is totally ignored during code execution.