### PR TITLE
Add docs for MysqlAdapter::FIRST constant

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -1164,7 +1164,7 @@ where its value is the name of the column to position it after.
             }
         }
 
-This would create the new column ``city`` and have it be positioned after the ``email`` column. You
+This would create the new column ``city`` and position it after the ``email`` column. You
 can use the `\Phinx\Db\Adapter\MysqlAdapter\FIRST` constant to specify that the new column should
 created as the first column in that table.
 


### PR DESCRIPTION
Closes #1912 

This updates the docs for the `after` column option, adding that this is a MySQL only option, and also documenting the `MysqlAdapter::FIRST` constant to put the column first in the table.