### PR TITLE
Fix adding column to sqlite table created outside phinx

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -734,6 +734,21 @@ PCRE_PATTERN;
             }
         }
 
+        $columnsInfo = $this->getTableInfo($tableName);
+
+        foreach ($columnsInfo as $column) {
+            $columnName = $column['name'];
+            $columnNamePattern = "\"$columnName\"|`$columnName`|\\[$columnName\\]|$columnName";
+            $columnNamePattern = "#([\(,]+\\s*)($columnNamePattern)(\\s)#iU";
+
+            $sql = preg_replace($columnNamePattern, "$1`$columnName`$3", $sql);
+        }
+
+        $tableNamePattern = "\"$tableName\"|`$tableName`|\\[$tableName\\]|$tableName";
+        $tableNamePattern = "#^(CREATE TABLE)\s*($tableNamePattern)\s*(\()#Ui";
+
+        $sql = preg_replace($tableNamePattern, "$1 `$tableName` $3", $sql, 1);
+
         return $sql;
     }
 


### PR DESCRIPTION
This PR fixes adding columns to a table created outside of phinx and its create table syntax. When creating a table in SQLite, it saves the create sql statement directly and returns that exact copy when querying `sqlite_master` for the script. Phinx was setup to only expect the create statement that it would generate, while there's a number of ways to write that statement, with various places to put newlines, extra spaces, different quotation styles, etc. This PR adds a new normalization step when we fetch the create table syntax to make working with it consistent regardless of how the table was originally created.

Closes #2035 