### PR TITLE
Maintain indexes / triggers after altering sqlite tables

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -832,12 +832,23 @@ PCRE_PATTERN;
                 $state['selectColumns']
             );
 
+            $rows = $this->fetchAll(
+                sprintf(
+                    "SELECT * FROM sqlite_master WHERE `type` = 'index' OR `type` = 'trigger' AND tbl_name = %s",
+                    $this->quoteValue($tableName)
+                )
+            );
+
             $this->execute(sprintf('DROP TABLE %s', $this->quoteTableName($tableName)));
             $this->execute(sprintf(
                 'ALTER TABLE %s RENAME TO %s',
                 $this->quoteTableName($state['tmpTableName']),
                 $this->quoteTableName($tableName)
             ));
+
+            foreach ($rows as $row) {
+                $this->execute($row['sql']);
+            }
 
             return $state;
         });

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -834,7 +834,14 @@ PCRE_PATTERN;
 
             $rows = $this->fetchAll(
                 sprintf(
-                    "SELECT * FROM sqlite_master WHERE `type` = 'index' OR `type` = 'trigger' AND tbl_name = %s",
+                    "
+                        SELECT *
+                        FROM sqlite_master
+                        WHERE
+                            (`type` = 'index' OR `type` = 'trigger')
+                            AND tbl_name = %s
+                            AND sql IS NOT NULL
+                    ",
                     $this->quoteValue($tableName)
                 )
             );

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -600,6 +600,24 @@ class SQLiteAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
+    public function testChangeColumnWithIndex()
+    {
+        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addIndex(
+                'indexcol',
+                ['unique' => true]
+            )
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+
+        $table->changeColumn('indexcol', 'integer', ['null' => false])->update();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+    }
+
     public function testChangeColumnDefaultToZero()
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);


### PR DESCRIPTION
PR fixes a bug where altering sqlite tables that had indexes or triggers would drop the indexes or triggers. This was because indexes and triggers are not contained in the `CREATE TABLE` sql that we used to create a table copy the indexes and triggers would be get copied over, and so on dropping the original table it would delete the indexes and triggers, and the rename would not bring them back.

This PR adds new post steps of recreating the indexes and triggers after we rename the temporary table we created back to its original name.

Fixes #1290 