### PR TITLE
Clean up insert data doc example

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -284,15 +284,15 @@ insert methods in your migrations.
              */
             public function up()
             {
+                $table = $this->table('status');
+
                 // inserting only one row
                 $singleRow = [
                     'id'    => 1,
                     'name'  => 'In Progress'
                 ];
 
-                $table = $this->table('status');
-                $table->insert($singleRow);
-                $table->saveData();
+                $table->insert($singleRow)->saveData();
 
                 // inserting multiple rows
                 $rows = [
@@ -306,7 +306,7 @@ insert methods in your migrations.
                     ]
                 ];
 
-                $table('status')->insert($rows)->save();
+                $table->insert($rows)->saveData();
             }
 
             /**


### PR DESCRIPTION
#2041 changed the insert docs example to have invalid code. This fixes the example to what the intended change was (just referencing the variable `$table` instead of class method `$this->table`. I also reordered some of the other bits of code so that the example is a bit more symmetric in general between one row insertion and multiple row insertion.