### PR TITLE
Do not print information output with option --no-info

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -59,6 +59,11 @@ abstract class AbstractCommand extends Command
     protected $manager;
 
     /**
+     * @var int
+     */
+    protected $verbosityLevel = OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL;
+
+    /**
      * Exit code for when command executes successfully
      *
      * @var int
@@ -96,6 +101,7 @@ abstract class AbstractCommand extends Command
     {
         $this->addOption('--configuration', '-c', InputOption::VALUE_REQUIRED, 'The configuration file to load');
         $this->addOption('--parser', '-p', InputOption::VALUE_REQUIRED, 'Parser used to read the config file. Defaults to YAML');
+        $this->addOption('--no-info', null, InputOption::VALUE_NONE, 'Hides all debug information');
     }
 
     /**
@@ -107,6 +113,10 @@ abstract class AbstractCommand extends Command
      */
     public function bootstrap(InputInterface $input, OutputInterface $output)
     {
+        if ($input->hasParameterOption('--no-info')) {
+            $this->verbosityLevel = OutputInterface::VERBOSITY_VERBOSE;
+        }
+
         /** @var \Phinx\Config\ConfigInterface|null $config */
         $config = $this->getConfig();
         if (!$config) {
@@ -117,26 +127,26 @@ abstract class AbstractCommand extends Command
 
         $bootstrap = $this->getConfig()->getBootstrapFile();
         if ($bootstrap) {
-            $output->writeln('<info>using bootstrap</info> ' . Util::relativePath($bootstrap) . ' ');
+            $output->writeln('<info>using bootstrap</info> ' . Util::relativePath($bootstrap) . ' ', $this->verbosityLevel);
             Util::loadPhpFile($bootstrap, $input, $output, $this);
         }
 
         // report the paths
         $paths = $this->getConfig()->getMigrationPaths();
 
-        $output->writeln('<info>using migration paths</info> ');
+        $output->writeln('<info>using migration paths</info> ', $this->verbosityLevel);
 
         foreach (Util::globAll($paths) as $path) {
-            $output->writeln('<info> - ' . realpath($path) . '</info>');
+            $output->writeln('<info> - ' . realpath($path) . '</info>', $this->verbosityLevel);
         }
 
         try {
             $paths = $this->getConfig()->getSeedPaths();
 
-            $output->writeln('<info>using seed paths</info> ');
+            $output->writeln('<info>using seed paths</info> ', $this->verbosityLevel);
 
             foreach (Util::globAll($paths) as $path) {
-                $output->writeln('<info> - ' . realpath($path) . '</info>');
+                $output->writeln('<info> - ' . realpath($path) . '</info>', $this->verbosityLevel);
             }
         } catch (UnexpectedValueException $e) {
             // do nothing as seeds are optional
@@ -263,7 +273,7 @@ abstract class AbstractCommand extends Command
     protected function loadConfig(InputInterface $input, OutputInterface $output)
     {
         $configFilePath = $this->locateConfigFile($input);
-        $output->writeln('<info>using config file</info> ' . Util::relativePath($configFilePath));
+        $output->writeln('<info>using config file</info> ' . Util::relativePath($configFilePath), $this->verbosityLevel);
 
         $parser = $input->getOption('parser');
 
@@ -301,7 +311,7 @@ abstract class AbstractCommand extends Command
                 throw new InvalidArgumentException(sprintf('\'%s\' is not a valid parser.', $parser));
         }
 
-        $output->writeln('<info>using config parser</info> ' . $parser);
+        $output->writeln('<info>using config parser</info> ' . $parser, $this->verbosityLevel);
 
         $this->setConfig($config);
     }
@@ -317,6 +327,7 @@ abstract class AbstractCommand extends Command
     {
         if ($this->getManager() === null) {
             $manager = new Manager($this->getConfig(), $input, $output);
+            $manager->setVerbosityLevel($this->verbosityLevel);
             $container = $this->getConfig()->getContainer();
             if ($container !== null) {
                 $manager->setContainer($container);

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -68,9 +68,9 @@ EOT
 
         if ($environment === null) {
             $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
+            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
         } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
+            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
         }
 
         if (!$this->getConfig()->hasEnvironment($environment)) {

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -297,17 +297,17 @@ class Create extends AbstractCommand
             $creationClass->postMigrationCreation($filePath, $className, $this->getConfig()->getMigrationBaseClassName());
         }
 
-        $output->writeln('<info>using migration base class</info> ' . $classes['$useClassName']);
+        $output->writeln('<info>using migration base class</info> ' . $classes['$useClassName'], $this->verbosityLevel);
 
         if (!empty($altTemplate)) {
-            $output->writeln('<info>using alternative template</info> ' . $altTemplate);
+            $output->writeln('<info>using alternative template</info> ' . $altTemplate, $this->verbosityLevel);
         } elseif (!empty($creationClassName)) {
-            $output->writeln('<info>using template creation class</info> ' . $creationClassName);
+            $output->writeln('<info>using template creation class</info> ' . $creationClassName, $this->verbosityLevel);
         } else {
-            $output->writeln('<info>using default template</info>');
+            $output->writeln('<info>using default template</info>', $this->verbosityLevel);
         }
 
-        $output->writeln('<info>created</info> ' . Util::relativePath($filePath));
+        $output->writeln('<info>created</info> ' . Util::relativePath($filePath), $this->verbosityLevel);
 
         return self::CODE_SUCCESS;
     }

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -61,7 +61,8 @@ class ListAliases extends AbstractCommand
                         array_keys($aliases),
                         $aliases
                     )
-                )
+                ),
+                $this->verbosityLevel
             );
         } else {
             $output->writeln(

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -68,9 +68,9 @@ EOT
 
         if ($environment === null) {
             $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
+            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
         } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
+            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
         }
 
         if (!$this->getConfig()->hasEnvironment($environment)) {
@@ -81,15 +81,15 @@ EOT
 
         $envOptions = $this->getConfig()->getEnvironment($environment);
         if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
+            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter'], $this->verbosityLevel);
         }
 
         if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
+            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper'], $this->verbosityLevel);
         }
 
         if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name']);
+            $output->writeln('<info>using database</info> ' . $envOptions['name'], $this->verbosityLevel);
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
@@ -97,17 +97,17 @@ EOT
         }
 
         if (isset($envOptions['table_prefix'])) {
-            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix']);
+            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix'], $this->verbosityLevel);
         }
         if (isset($envOptions['table_suffix'])) {
-            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
+            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix'], $this->verbosityLevel);
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();
-        $output->writeln('<info>ordering by</info> ' . $versionOrder . ' time');
+        $output->writeln('<info>ordering by</info> ' . $versionOrder . ' time', $this->verbosityLevel);
 
         if ($fake) {
-            $output->writeln('<comment>warning</comment> performing fake migrations');
+            $output->writeln('<comment>warning</comment> performing fake migrations', $this->verbosityLevel);
         }
 
         try {
@@ -132,8 +132,8 @@ EOT
             return self::CODE_ERROR;
         }
 
-        $output->writeln('');
-        $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+        $output->writeln('', $this->verbosityLevel);
+        $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>', $this->verbosityLevel);
 
         return self::CODE_SUCCESS;
     }

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -79,9 +79,9 @@ EOT
 
         if ($environment === null) {
             $environment = $config->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
+            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
         } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
+            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
         }
 
         if (!$this->getConfig()->hasEnvironment($environment)) {
@@ -92,22 +92,22 @@ EOT
 
         $envOptions = $config->getEnvironment($environment);
         if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
+            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter'], $this->verbosityLevel);
         }
 
         if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
+            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper'], $this->verbosityLevel);
         }
 
         if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name']);
+            $output->writeln('<info>using database</info> ' . $envOptions['name'], $this->verbosityLevel);
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();
-        $output->writeln('<info>ordering by</info> ' . $versionOrder . ' time');
+        $output->writeln('<info>ordering by</info> ' . $versionOrder . ' time', $this->verbosityLevel);
 
         if ($fake) {
-            $output->writeln('<comment>warning</comment> performing fake rollbacks');
+            $output->writeln('<comment>warning</comment> performing fake rollbacks', $this->verbosityLevel);
         }
 
         // rollback the specified environment
@@ -123,8 +123,8 @@ EOT
         $this->getManager()->rollback($environment, $target, $force, $targetMustMatchVersion, $fake);
         $end = microtime(true);
 
-        $output->writeln('');
-        $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+        $output->writeln('', $this->verbosityLevel);
+        $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>', $this->verbosityLevel);
 
         return self::CODE_SUCCESS;
     }

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -197,8 +197,8 @@ class SeedCreate extends AbstractCommand
             ));
         }
 
-        $output->writeln('<info>using seed base class</info> ' . $classes['$useClassName']);
-        $output->writeln('<info>created</info> ' . Util::relativePath($filePath));
+        $output->writeln('<info>using seed base class</info> ' . $classes['$useClassName'], $this->verbosityLevel);
+        $output->writeln('<info>created</info> ' . Util::relativePath($filePath), $this->verbosityLevel);
 
         return self::CODE_SUCCESS;
     }

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -60,9 +60,9 @@ EOT
 
         if ($environment === null) {
             $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
+            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
         } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
+            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
         }
 
         if (!$this->getConfig()->hasEnvironment($environment)) {
@@ -73,15 +73,15 @@ EOT
 
         $envOptions = $this->getConfig()->getEnvironment($environment);
         if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
+            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter'], $this->verbosityLevel);
         }
 
         if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
+            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper'], $this->verbosityLevel);
         }
 
         if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name']);
+            $output->writeln('<info>using database</info> ' . $envOptions['name'], $this->verbosityLevel);
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
@@ -89,10 +89,10 @@ EOT
         }
 
         if (isset($envOptions['table_prefix'])) {
-            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix']);
+            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix'], $this->verbosityLevel);
         }
         if (isset($envOptions['table_suffix'])) {
-            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
+            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix'], $this->verbosityLevel);
         }
 
         $start = microtime(true);
@@ -109,8 +109,8 @@ EOT
 
         $end = microtime(true);
 
-        $output->writeln('');
-        $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+        $output->writeln('', $this->verbosityLevel);
+        $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>', $this->verbosityLevel);
 
         return self::CODE_SUCCESS;
     }

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -59,9 +59,9 @@ EOT
 
         if ($environment === null) {
             $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
+            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
         } else {
-            $output->writeln('<info>using environment</info> ' . $environment);
+            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
         }
 
         if (!$this->getConfig()->hasEnvironment($environment)) {
@@ -71,10 +71,10 @@ EOT
         }
 
         if ($format !== null) {
-            $output->writeln('<info>using format</info> ' . $format);
+            $output->writeln('<info>using format</info> ' . $format, $this->verbosityLevel);
         }
 
-        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder() . ' time');
+        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder() . ' time', $this->verbosityLevel);
 
         // print the status
         $result = $this->getManager()->printStatus($environment, $format);

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -82,7 +82,7 @@ EOT
                 ));
             }
 
-            $output->writeln(sprintf('<info>validating environment</info> %s', $envName));
+            $output->writeln(sprintf('<info>validating environment</info> %s', $envName), $this->verbosityLevel);
             $environment = new Environment(
                 $envName,
                 $this->getConfig()->getEnvironment($envName)
@@ -91,7 +91,7 @@ EOT
             $environment->getAdapter()->connect();
         }
 
-        $output->writeln('<info>success!</info>');
+        $output->writeln('<info>success!</info>', $this->verbosityLevel);
 
         return self::CODE_SUCCESS;
     }

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -60,9 +60,11 @@ class PhinxApplication extends Application
     {
         // always show the version information except when the user invokes the help
         // command as that already does it
-        if (($input->hasParameterOption(['--help', '-h']) !== false) || ($input->getFirstArgument() !== null && $input->getFirstArgument() !== 'list')) {
-            $output->writeln($this->getLongVersion());
-            $output->writeln('');
+        if ($input->hasParameterOption('--no-info') === false) {
+            if (($input->hasParameterOption(['--help', '-h']) !== false) || ($input->getFirstArgument() !== null && $input->getFirstArgument() !== 'list')) {
+                $output->writeln($this->getLongVersion());
+                $output->writeln('');
+            }
         }
 
         return parent::doRun($input, $output);

--- a/tests/Phinx/Console/Output/RawBufferedOutput.php
+++ b/tests/Phinx/Console/Output/RawBufferedOutput.php
@@ -13,8 +13,8 @@ class RawBufferedOutput extends \Symfony\Component\Console\Output\BufferedOutput
      * @param int $options
      * @return void
      */
-    public function writeln($messages, $options = self::OUTPUT_RAW)
+    public function writeln($messages, $options = 0)
     {
-        $this->write($messages, true, $options);
+        $this->write($messages, true, $options | self::OUTPUT_RAW);
     }
 }


### PR DESCRIPTION
Sort of fixes #1568

If use `--no-info` there would be no additional information. Especially useful for creating migration files with all migrations in one.

Output before:
```
Phinx by CakePHP - https://phinx.org.

using config file phinx.php
using config parser php
using migration paths 
 - /var/www/db/migrations
using seed paths 
 - /var/www/db/seeds
warning no environment specified, defaulting to: docker
using database ncc
ordering by creation time

 == 20211213143400 TestMig: migrating
START TRANSACTION;
CREATE TABLE `test_a` (`id` INT(11) NOT NULL AUTO_INCREMENT, `name` VARCHAR(255) NOT NULL, `value` VARCHAR(255) NOT NULL, `comment` VARCHAR(255) NOT NULL, PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
COMMIT;
INSERT INTO `phinx_migration_log` (`version`, `migration_name`, `start_time`, `end_time`, `breakpoint`) VALUES ('20211213143400', 'TestMig', '2021-12-13 15:36:02', '2021-12-13 15:36:02', 0);
 == 20211213143400 TestMig: migrated 0.0291s

 == 20211213143404 TestMig2: migrating
START TRANSACTION;
CREATE TABLE `test_b` (`id` INT(11) NOT NULL AUTO_INCREMENT, `name` VARCHAR(255) NOT NULL, `value` INT(11) NOT NULL, `comment` VARCHAR(255) NOT NULL, PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
COMMIT;
INSERT INTO `phinx_migration_log` (`version`, `migration_name`, `start_time`, `end_time`, `breakpoint`) VALUES ('20211213143404', 'TestMig2', '2021-12-13 15:36:02', '2021-12-13 15:36:02', 0);
 == 20211213143404 TestMig2: migrated 0.0008s

All Done. Took 0.0792s
```
After:
```
START TRANSACTION;
CREATE TABLE `test_a` (`id` INT(11) NOT NULL AUTO_INCREMENT, `name` VARCHAR(255) NOT NULL, `value` VARCHAR(255) NOT NULL, `comment` VARCHAR(255) NOT NULL, PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
COMMIT;
INSERT INTO `phinx_migration_log` (`version`, `migration_name`, `start_time`, `end_time`, `breakpoint`) VALUES ('20211213143400', 'TestMig', '2021-12-13 15:43:31', '2021-12-13 15:43:31', 0);
START TRANSACTION;
CREATE TABLE `test_b` (`id` INT(11) NOT NULL AUTO_INCREMENT, `name` VARCHAR(255) NOT NULL, `value` INT(11) NOT NULL, `comment` VARCHAR(255) NOT NULL, PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;
COMMIT;
INSERT INTO `phinx_migration_log` (`version`, `migration_name`, `start_time`, `end_time`, `breakpoint`) VALUES ('20211213143404', 'TestMig2', '2021-12-13 15:43:31', '2021-12-13 15:43:31', 0);
```