### PR TITLE
Fix docs spell error

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -380,7 +380,7 @@ class Table
     /**
      * Add an index to a database table.
      *
-     * In $options you can specific unique = true/false or name (index name).
+     * In $options you can specify unique = true/false, and name (index name).
      *
      * @param string|array|\Phinx\Db\Table\Index $columns Table Column(s)
      * @param array $options Index Options


### PR DESCRIPTION
Replace `specific` with `specify`, and alter the sentence slightly to indicate that both options can be set simultaneously.