### PR TITLE
Add support for opening sqlite db with shared cache

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -157,7 +157,22 @@ class SQLiteAdapter extends PdoAdapter
 
             // use a memory database if the option was specified
             if (!empty($options['memory']) || $options['name'] === static::MEMORY) {
-                $dsn = 'sqlite:' . static::MEMORY;
+                $params = [];
+                if (!empty($options['cache'])) {
+                    $params[] = 'cache=' . $options['cache'];
+                }
+                if (!empty($options['mode'])) {
+                    $params[] = 'mode=' . $options['mode'];
+                }
+
+                if ($params) {
+                    if (PHP_VERSION_ID < 80100) {
+                        throw new RuntimeException('SQLite URI support requires PHP 8.1.');
+                    }
+                    $dsn = 'sqlite:file:' . static::MEMORY . '?' . implode('&', $params);
+                } else {
+                    $dsn = 'sqlite:' . static::MEMORY;
+                }
             } else {
                 $dsn = 'sqlite:' . $options['name'] . $this->suffix;
             }


### PR DESCRIPTION
this is useful when running phinx in the context of a cakephp testsuite via migrator
similar work has been done for cakephp here https://github.com/cakephp/cakephp/pull/16189
when merged cakephp/migrations can make use of these new options