### PR TITLE
improve tests for create command

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -99,12 +99,6 @@ class Create extends AbstractCommand
         }
 
         $paths = $this->getConfig()->getMigrationPaths();
-
-        // No paths? That's a problem.
-        if (empty($paths)) {
-            throw new Exception('No migration paths set in your Phinx configuration file.');
-        }
-
         $paths = Util::globAll($paths);
 
         if (empty($paths)) {
@@ -142,16 +136,6 @@ class Create extends AbstractCommand
 
         // get the migration path from the config
         $path = $this->getMigrationPath($input, $output);
-
-        if (!file_exists($path)) {
-            /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
-            $helper = $this->getHelper('question');
-            $question = $this->getCreateMigrationDirectoryQuestion();
-
-            if ($helper->ask($input, $output, $question)) {
-                mkdir($path, 0755, true);
-            }
-        }
 
         $this->verifyMigrationDirectory($path);
 


### PR DESCRIPTION
This PR will slightly improve the test coverage for the `Create` command.

You may also ask why I removed 2 sections related to path checking.
The reason behind that is the fact, that `getMigrationPaths()` already checks if the given (or default) path is present and valid.

If not it already throws an exception [here](https://github.com/cakephp/phinx/blob/master/src/Phinx/Console/Command/Create.php#L105) and therefore can never get to those other 2 checks.