### PR TITLE
TEXT WRAPPER: Refactor shorthand ternary & add tests

### DIFF
--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -73,7 +73,7 @@ class TextWrapper
     public function getStatus($env = null)
     {
         $command = ['status'];
-        if ($env ?: $this->hasOption('environment')) {
+        if ($this->hasEnvValue($env)) {
             $command += ['-e' => $env ?: $this->getOption('environment')];
         }
         if ($this->hasOption('configuration')) {
@@ -90,6 +90,15 @@ class TextWrapper
     }
 
     /**
+     * @param string|null $env environment name
+     * @return bool
+     */
+    private function hasEnvValue($env): bool
+    {
+        return $env || $this->hasOption('environment');
+    }
+
+    /**
      * Returns the output from running the "migrate" command.
      *
      * @param string|null $env environment name (optional)
@@ -99,7 +108,7 @@ class TextWrapper
     public function getMigrate($env = null, $target = null)
     {
         $command = ['migrate'];
-        if ($env ?: $this->hasOption('environment')) {
+        if ($this->hasEnvValue($env)) {
             $command += ['-e' => $env ?: $this->getOption('environment')];
         }
         if ($this->hasOption('configuration')) {
@@ -126,7 +135,7 @@ class TextWrapper
     public function getSeed($env = null, $target = null, $seed = null)
     {
         $command = ['seed:run'];
-        if ($env ?: $this->hasOption('environment')) {
+        if ($this->hasEnvValue($env)) {
             $command += ['-e' => $env ?: $this->getOption('environment')];
         }
         if ($this->hasOption('configuration')) {
@@ -156,7 +165,7 @@ class TextWrapper
     public function getRollback($env = null, $target = null)
     {
         $command = ['rollback'];
-        if ($env ?: $this->hasOption('environment')) {
+        if ($this->hasEnvValue($env)) {
             $command += ['-e' => $env ?: $this->getOption('environment')];
         }
         if ($this->hasOption('configuration')) {

--- a/tests/Phinx/Wrapper/TextWrapperTest.php
+++ b/tests/Phinx/Wrapper/TextWrapperTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phinx\Wrapper;
+
+use Phinx\Console\PhinxApplication;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+
+final class TextWrapperTest extends TestCase
+{
+    private const ANY_ENV_VALUE = 'something';
+
+    /**
+     * @dataProvider envValueProvider
+     * @param string|null $env
+     */
+    public function testEnvTruthinessValues($env, array $options, array $expectedCommand): void
+    {
+        $app = $this->createMock(PhinxApplication::class);
+        $app
+            ->expects($this->once())
+            ->method('doRun')
+            ->with(new ArrayInput($expectedCommand))
+            ->willReturn(0);
+
+        $wrapper = new TextWrapper($app, $options);
+
+        $wrapper->getStatus($env);
+    }
+
+    public function envValueProvider(): array
+    {
+        return [
+            'env-value-only' => [
+                self::ANY_ENV_VALUE,
+                [],
+                ['status', '-e' => self::ANY_ENV_VALUE],
+            ],
+            'options-env-value-only' => [
+                null,
+                ['environment' => self::ANY_ENV_VALUE],
+                ['status', '-e' => self::ANY_ENV_VALUE],
+            ],
+            'both-values' => [
+                self::ANY_ENV_VALUE,
+                ['environment' => self::ANY_ENV_VALUE . 'additional'],
+                ['status', '-e' => self::ANY_ENV_VALUE],
+            ],
+            'no-values' => [
+                null,
+                [],
+                ['status'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Currently, within the `TextWrapper::class`, in the methods `TextWrapper::getStatus()`, `TextWrapper::getMigrate()`, `TextWrapper::getSeed()`, `TextWrapper::getRollback()` the following expression: `if ($env ?: $this->hasOption('environment'))` is used.

If I am correct, that would mean that the inner short hand ternary would first have to evaluate before the outer if would evaluate its result. Hence there would be two evaluations of the value's truthiness. This pull request removes the use of the shorthand ternary and replaces it by a logical or.

The added tests should confirm that equivalent behavior is maintained (although tests are written for one method implementation).

In case there has been anything I overlooked please inform me, or if you have any additional requests please let me know!