### PR TITLE
Add missing save call to renameColumn doc examples

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -1126,7 +1126,8 @@ To rename a column, access an instance of the Table object then call the
             public function up()
             {
                 $table = $this->table('users');
-                $table->renameColumn('bio', 'biography');
+                $table->renameColumn('bio', 'biography')
+                      ->save();
             }
 
             /**
@@ -1135,7 +1136,8 @@ To rename a column, access an instance of the Table object then call the
             public function down()
             {
                 $table = $this->table('users');
-                $table->renameColumn('biography', 'bio');
+                $table->renameColumn('biography', 'bio')
+                       ->save();
             }
         }
 


### PR DESCRIPTION
There is a `->save();` missing in the renameColumn block.