### PR TITLE
Fix SqlServerAdapter returning empty string instead of null for column default

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -477,16 +477,18 @@ class SqlServerAdapter extends PdoAdapter
     }
 
     /**
-     * @param string $default Default
+     * @param string|null $default Default
      * @return int|string|null
      */
     protected function parseDefault($default)
     {
+        // if a column is non-nullable and has no default, the default is null, otherwise
+        // it should be a string value that we parse below
         if ($default === null) {
-            $result = 'NULL';
-        } else {
-            $result = preg_replace(["/\('(.*)'\)/", "/\(\((.*)\)\)/", "/\((.*)\)/"], '$1', $default);
+            return null;
         }
+
+        $result = preg_replace(["/\('(.*)'\)/", "/\(\((.*)\)\)/", "/\((.*)\)/"], '$1', $default);
 
         if (strtoupper($result) === 'NULL') {
             $result = null;

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -482,7 +482,11 @@ class SqlServerAdapter extends PdoAdapter
      */
     protected function parseDefault($default)
     {
-        $result = preg_replace(["/\('(.*)'\)/", "/\(\((.*)\)\)/", "/\((.*)\)/"], '$1', $default);
+        if ($default === null) {
+            $result = 'NULL';
+        } else {
+            $result = preg_replace(["/\('(.*)'\)/", "/\(\((.*)\)\)/", "/\((.*)\)/"], '$1', $default);
+        }
 
         if (strtoupper($result) === 'NULL') {
             $result = null;

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -482,8 +482,9 @@ class SqlServerAdapter extends PdoAdapter
      */
     protected function parseDefault($default)
     {
-        // if a column is non-nullable and has no default, the default is null, otherwise
-        // it should be a string value that we parse below
+        // if a column is non-nullable and has no default, the value of column_default is null,
+        // otherwise it should be a string value that we parse below, including "(NULL)" which
+        // also stands for a null default
         if ($default === null) {
             return null;
         }

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -422,7 +422,7 @@ WHERE t.name='ntable'");
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table
-            ->addColumn('col', 'string', array('null' => false))
+            ->addColumn('col', 'string', ['null' => false])
             ->create();
 
         $columns = $this->adapter->getColumns('table1');

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -418,6 +418,21 @@ WHERE t.name='ntable'");
         }
     }
 
+    public function testAddColumnWithNotNullableNoDefault()
+    {
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table
+            ->addColumn('col', 'string', array('null' => false))
+            ->create();
+
+        $columns = $this->adapter->getColumns('table1');
+        $this->assertCount(2, $columns);
+        $this->assertArrayHasKey('id', $columns);
+        $this->assertArrayHasKey('col', $columns);
+        $this->assertFalse($columns['col']->isNull());
+        $this->assertNull($columns['col']->getDefault());
+    }
+
     public function testAddColumnWithDefaultBool()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);


### PR DESCRIPTION
The `SqlServerAdapter::parseDefault($default)` function returns `""` if `$default` is `null`
Because of the returned empty string, the column can not be **changed** to have an empty string as default value (no differnce detected)

Example for an existing column which has no effect:
```php
$this->table('tableName')->changeColumn('columnName', 'string', ['default' => '', 'null' => false])
```