### PR TITLE
Add TrustServerCertificate to SqlServerAdapter

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -75,7 +75,7 @@ class SqlServerAdapter extends PdoAdapter
             if (!empty($options['port'])) {
                 $dsn .= ',' . $options['port'];
             }
-            $dsn .= ';database=' . $options['name'] . ';MultipleActiveResultSets=false';
+            $dsn .= ';database=' . $options['name'] . ';MultipleActiveResultSets=false;TrustServerCertificate=true';
 
             $driverOptions = [];
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -77,9 +77,12 @@ class SqlServerAdapter extends PdoAdapter
             }
             $dsn .= ';database=' . $options['name'] . ';MultipleActiveResultSets=false';
 
-            // option to turn on TrustServerCertificate
-            if (isset($options['trust_server_certificate'])) {
-                $dsn .= ';TrustServerCertificate=' . $options['trust_server_certificate'];
+            // option to add additional connection options
+            // https://docs.microsoft.com/en-us/sql/connect/php/connection-options?view=sql-server-ver15
+            if (isset($options['dsn_options'])) {
+                foreach ($options['dsn_options'] as $key => $option) {
+                    $dsn .= ';' . $key . '=' . $option;
+                }
             }
 
             $driverOptions = [];

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -75,7 +75,12 @@ class SqlServerAdapter extends PdoAdapter
             if (!empty($options['port'])) {
                 $dsn .= ',' . $options['port'];
             }
-            $dsn .= ';database=' . $options['name'] . ';MultipleActiveResultSets=false;TrustServerCertificate=true';
+            $dsn .= ';database=' . $options['name'] . ';MultipleActiveResultSets=false';
+
+            // option to turn on TrustServerCertificate
+            if (isset($options['trust_server_certificate'])) {
+                $dsn .= ';TrustServerCertificate=' . $options['trust_server_certificate'];
+            }
 
             $driverOptions = [];
 

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -50,6 +50,14 @@ class SqlServerAdapterTest extends TestCase
         $this->assertSame(\PDO::ERRMODE_EXCEPTION, $this->adapter->getConnection()->getAttribute(\PDO::ATTR_ERRMODE));
     }
 
+    public function testConnectionWithTrustServerCertificate()
+    {
+        $options = $this->adapter->getOptions();
+        $options['trust_server_certificate'] = 'true';
+        $this->adapter->setOptions($options);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
+    }
+
     public function testConnectionWithFetchMode()
     {
         $options = $this->adapter->getOptions();

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -50,10 +50,10 @@ class SqlServerAdapterTest extends TestCase
         $this->assertSame(\PDO::ERRMODE_EXCEPTION, $this->adapter->getConnection()->getAttribute(\PDO::ATTR_ERRMODE));
     }
 
-    public function testConnectionWithTrustServerCertificate()
+    public function testConnectionWithDsnOptions()
     {
         $options = $this->adapter->getOptions();
-        $options['trust_server_certificate'] = 'true';
+        $options['dsn_options'] = ['TrustServerCertificate' => 'true'];
         $this->adapter->setOptions($options);
         $this->assertInstanceOf('PDO', $this->adapter->getConnection());
     }


### PR DESCRIPTION
Fixes #2093

This PR adds _TrustServerCertificate=true_ to the connection string. This is needed for sqlserver 2017 and 2019. Tested that phinx works with sqlsrv 2019 after this fix.

@markstory 