### PR TITLE
Do not set code when recasting PDOException

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -96,7 +96,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
             throw new InvalidArgumentException(sprintf(
                 'There was a problem connecting to the database: %s',
                 $e->getMessage()
-            ), $e->getCode(), $e);
+            ), 0, $e);
         }
 
         return $db;

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -94,7 +94,7 @@ class PostgresAdapter extends PdoAdapter
             } catch (PDOException $exception) {
                 throw new InvalidArgumentException(
                     sprintf('Schema does not exists: %s', $options['schema']),
-                    $exception->getCode(),
+                    0,
                     $exception
                 );
             }

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -152,7 +152,7 @@ class SqlServerAdapter extends PdoAdapter
             throw new InvalidArgumentException(sprintf(
                 'There was a problem connecting to the database: %s',
                 $exception->getMessage()
-            ));
+            ), 0, $exception);
         }
 
         $this->setConnection($db);


### PR DESCRIPTION
Fixes #2098 

The [`PDOException`](https://www.php.net/manual/en/class.pdoexception.php) class has the signature `int|string $code`, which makes it incompatible with most other stdlib exceptions that only allow `int $code`. While we could probably make a custom exception class or whatever for the recast, I don't think it's worth the hassle, and looking at the DB ecosystem, some amount of it also just drops the code in favor of just using `0` (e.g. `cakephp/Database` in [`Database/Driver`](https://github.com/cakephp/cakephp/blob/4aa99f805fb39b17ac7760e68fc1074bd826de0c/src/Database/Driver.php#L133) and have for years that I'm not sure people will really miss it.

The PDOException recast has been happening for the entire existence of this project that I'm somewhat risk adverse to remove the recast.