### PR TITLE
Fix defaultName deprecation warning on symfony/console 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.0'
         coverage: none
 
     - name: Get composer cache directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           - php-version: '7.2'
             db-type: mysql
             prefer-lowest: prefer-lowest
+          - php-version: '8.0'
+            db-type: mysql
+            prefer-lowest: prefer-lowest
 
     steps:
     - name: Setup MySQL latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
           - php-version: '7.2'
             db-type: mysql
             prefer-lowest: prefer-lowest
-          - php-version: '8.0'
-            db-type: mysql
-            prefer-lowest: prefer-lowest
 
     steps:
     - name: Setup MySQL latest

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -8,10 +8,12 @@
 namespace Phinx\Console\Command;
 
 use InvalidArgumentException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'breakpoint')]
 class Breakpoint extends AbstractCommand
 {
     /**

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use Phinx\Config\NamespaceAwareInterface;
 use Phinx\Util\Util;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
+#[AsCommand(name: 'create')]
 class Create extends AbstractCommand
 {
     /**

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -9,11 +9,13 @@ namespace Phinx\Console\Command;
 
 use InvalidArgumentException;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'init')]
 class Init extends Command
 {
     protected const FILE_NAME = 'phinx';

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -8,9 +8,11 @@
 namespace Phinx\Console\Command;
 
 use Phinx\Util\Util;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'list:aliases')]
 class ListAliases extends AbstractCommand
 {
     /**

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -9,11 +9,13 @@ namespace Phinx\Console\Command;
 
 use DateTime;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+#[AsCommand(name: 'migrate')]
 class Migrate extends AbstractCommand
 {
     /**

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -9,10 +9,12 @@ namespace Phinx\Console\Command;
 
 use DateTime;
 use InvalidArgumentException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'rollback')]
 class Rollback extends AbstractCommand
 {
     /**

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use Phinx\Config\NamespaceAwareInterface;
 use Phinx\Util\Util;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
+#[AsCommand(name: 'seed:create')]
 class SeedCreate extends AbstractCommand
 {
     /**

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -7,10 +7,12 @@
 
 namespace Phinx\Console\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'seed:run')]
 class SeedRun extends AbstractCommand
 {
     /**

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -7,10 +7,12 @@
 
 namespace Phinx\Console\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'status')]
 class Status extends AbstractCommand
 {
     /**

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -10,13 +10,12 @@ namespace Phinx\Console\Command;
 use InvalidArgumentException;
 use Phinx\Migration\Manager\Environment;
 use Phinx\Util\Util;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * @author Leonid Kuzmin <lndkuzmin@gmail.com>
- */
+#[AsCommand(name: 'test')]
 class Test extends AbstractCommand
 {
     /**


### PR DESCRIPTION
Fixes #2104 

`symfony/console` has changed the mechanism in which command names should be declared, switching from using `$defaultName` static class parameter, to an attribute.

This deprecation was introduced in 6.1, but the `AsName` attribute has existed since 5.4. From my testing, it looks like this should work fine for users on older symfony versions with newer PHP versions, as the usage here was purely through [`ReflectionClass::getAttributes`](https://www.php.net/manual/en/reflectionclass.getattributes.php).