### PR TITLE
Fix deprecation warning on Config::offsetGet function

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -507,6 +507,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @throws \InvalidArgumentException
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($id)
     {
         if (!array_key_exists($id, $this->values)) {


### PR DESCRIPTION
Fixes #2110 

Adds the `#[\ReturnTypeWillChange]` annotation to the `Config::offsetGet` function as to properly type it requires using the `mixed` keyword added in 8.1 and we still support 7.2+