### PR TITLE
Remove PostgresAdapter::getDefaultValueDefinition method override

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1207,26 +1207,6 @@ class PostgresAdapter extends PdoAdapter
     }
 
     /**
-     * Get the defintion for a `DEFAULT` statement.
-     *
-     * @param mixed $default default value
-     * @param string|null $columnType column type added
-     * @return string
-     */
-    protected function getDefaultValueDefinition($default, ?string $columnType = null): string
-    {
-        if (is_string($default) && $default !== 'CURRENT_TIMESTAMP') {
-            $default = $this->getConnection()->quote($default);
-        } elseif (is_bool($default)) {
-            $default = $this->castToBool($default);
-        } elseif ($columnType === static::PHINX_TYPE_BOOLEAN) {
-            $default = $this->castToBool((bool)$default);
-        }
-
-        return isset($default) ? 'DEFAULT ' . $default : '';
-    }
-
-    /**
      * Gets the PostgreSQL Column Definition for a Column object.
      *
      * @param \Phinx\Db\Table\Column $column Column

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2182,11 +2182,11 @@ class PostgresAdapterTest extends TestCase
 
         if ($this->usingPostgres10()) {
             $expectedOutput = 'CREATE TABLE "public"."table1" ("id" INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY, "column1" CHARACTER VARYING (255) ' .
-                'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
+                'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL  DEFAULT \'test\', CONSTRAINT ' .
                 '"table1_pkey" PRIMARY KEY ("id"));';
         } else {
             $expectedOutput = 'CREATE TABLE "public"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) ' .
-                'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
+                'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL  DEFAULT \'test\', CONSTRAINT ' .
                 '"table1_pkey" PRIMARY KEY ("id"));';
         }
         $actualOutput = $consoleOutput->fetch();
@@ -2214,11 +2214,11 @@ class PostgresAdapterTest extends TestCase
 
         if ($this->usingPostgres10()) {
             $expectedOutput = 'CREATE TABLE "schema1"."table1" ("id" INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY, "column1" CHARACTER VARYING (255) ' .
-                'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
+                'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL  DEFAULT \'test\', CONSTRAINT ' .
                 '"table1_pkey" PRIMARY KEY ("id"));';
         } else {
             $expectedOutput = 'CREATE TABLE "schema1"."table1" ("id" SERIAL NOT NULL, "column1" CHARACTER VARYING (255) ' .
-                'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL DEFAULT \'test\', CONSTRAINT ' .
+                'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL  DEFAULT \'test\', CONSTRAINT ' .
                 '"table1_pkey" PRIMARY KEY ("id"));';
         }
         $actualOutput = $consoleOutput->fetch();


### PR DESCRIPTION
The `PostgresAdapter::getDefaultValueDefinition` function definition is nearly identical to the `PdoAdapter::getDefaultValueDefinition`, with the only difference being in missing the if statement around `Literal`:

https://github.com/cakephp/phinx/blob/81fd9769800342b49d15ae789f7f0c400f1f313a/src/Phinx/Db/Adapter/PdoAdapter.php#L600-L614

Looking at the git history, wasn't clear why postgres might want to operate differently, and so I think safe to just remove its override and use the default one all other adapters use.