### PR TITLE
Consistently test console commands' exit codes

### DIFF
--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -106,7 +106,8 @@ class BreakpointTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $commandLine = array_merge(['command' => $command->getName()], $commandLine);
-        $commandTester->execute($commandLine, ['decorated' => false]);
+        $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function provideBreakpointTests()
@@ -177,7 +178,7 @@ class BreakpointTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot toggle a breakpoint and remove all breakpoints at the same time.');
 
-        $commandTester->execute(
+        $exitCode = $commandTester->execute(
             [
                 'command' => $command->getName(),
                 '--remove-all' => true,
@@ -185,6 +186,7 @@ class BreakpointTest extends TestCase
             ],
             ['decorated' => false]
         );
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     /**
@@ -215,7 +217,8 @@ class BreakpointTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot use more than one of --set, --unset, or --remove-all at the same time.');
 
-        $commandTester->execute($commandLine, ['decorated' => false]);
+        $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function provideCombinedParametersToCauseException()

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -5,6 +5,7 @@ namespace Test\Phinx\Console\Command;
 use Exception;
 use InvalidArgumentException;
 use Phinx\Config\Config;
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Create;
 use Phinx\Console\PhinxApplication;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -87,7 +88,8 @@ class CreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()]);
+        $exitCode = $commandTester->execute(['command' => $command->getName()]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $files = array_diff(scandir($this->config->getMigrationPaths()[0]), ['.', '..']);
         $this->assertCount(1, $files);
@@ -120,7 +122,8 @@ class CreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'MyMigration']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'MyMigration']);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $files = array_diff(scandir($this->config->getMigrationPaths()[0]), ['.', '..']);
         $this->assertCount(1, $files);
@@ -154,7 +157,8 @@ class CreateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The migration class name "MyDuplicateMigration" already exists');
 
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function testExecuteWithDuplicateMigrationNamesWithNamespace()
@@ -180,13 +184,15 @@ class CreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
         time_nanosleep(1, 100000); // need at least a second due to file naming scheme
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The migration class name "Foo\Bar\MyDuplicateMigration" already exists');
 
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateMigration']);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function testSupplyingBothClassAndTemplateAtCommandLineThrowsException()
@@ -210,7 +216,8 @@ class CreateTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Cannot use --template and --class at the same time');
 
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'MyFailingMigration', '--template' => 'MyTemplate', '--class' => 'MyTemplateClass']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'MyFailingMigration', '--template' => 'MyTemplate', '--class' => 'MyTemplateClass']);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function testSupplyingBothClassAndTemplateInConfigThrowsException()
@@ -239,7 +246,8 @@ class CreateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot define template:class and template:file at the same time');
 
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'MyFailingMigration']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'MyFailingMigration']);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function provideFailingTemplateGenerator()
@@ -306,7 +314,8 @@ class CreateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($exceptionMessage);
 
-        $commandTester->execute($commandLine);
+        $exitCode = $commandTester->execute($commandLine);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function provideNullTemplateGenerator()
@@ -369,8 +378,8 @@ class CreateTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $commandLine = array_merge(['command' => $command->getName()], $commandLine);
-        $res = $commandTester->execute($commandLine);
-        $this->assertEquals(0, $res);
+        $exitCode = $commandTester->execute($commandLine);
+        $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function provideSimpleTemplateGenerator()
@@ -433,7 +442,8 @@ class CreateTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $commandLine = array_merge(['command' => $command->getName()], $commandLine);
-        $commandTester->execute($commandLine, ['decorated' => false]);
+        $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         // Get output.
         preg_match('`created (?P<MigrationFilename>.+(?P<Version>\d{14}).*?)\s`', $commandTester->getDisplay(), $match);
@@ -465,7 +475,8 @@ class CreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()]);
+        $exitCode = $commandTester->execute(['command' => $command->getName()]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $files = array_diff(scandir($this->config->getMigrationPaths()[0]), ['.', '..']);
         $this->assertCount(1, $files);
@@ -498,7 +509,8 @@ class CreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), '--style' => 'change']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), '--style' => 'change']);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $files = array_diff(scandir($this->config->getMigrationPaths()[0]), ['.', '..']);
         $this->assertCount(1, $files);
@@ -531,7 +543,8 @@ class CreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), '--style' => 'up_down']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), '--style' => 'up_down']);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $files = array_diff(scandir($this->config->getMigrationPaths()[0]), ['.', '..']);
         $this->assertCount(1, $files);
@@ -568,6 +581,7 @@ class CreateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('--style should be one of change or up_down');
 
-        $commandTester->execute(['command' => $command->getName(), '--style' => 'foo']);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), '--style' => 'foo']);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 }

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -38,7 +38,8 @@ class InitTest extends TestCase
             $command['--format'] = pathinfo($configName, PATHINFO_EXTENSION);
         }
 
-        $commandTester->execute($command, ['decorated' => false]);
+        $exitCode = $commandTester->execute($command, ['decorated' => false]);
+        $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $this->assertStringContainsString(
             "created $fullPath",
@@ -83,51 +84,59 @@ class InitTest extends TestCase
     public function testDefaults()
     {
         $current_dir = getcwd();
-        chdir(sys_get_temp_dir());
 
-        $application = new PhinxApplication();
-        $application->add(new Init());
+        try {
+            chdir(sys_get_temp_dir());
 
-        $command = $application->find('init');
+            $application = new PhinxApplication();
+            $application->add(new Init());
 
-        $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
-        $this->assertMatchesRegularExpression(
-            "/created (.*)[\/\\\\]phinx\.php\\n/",
-            $commandTester->getDisplay(true)
-        );
+            $command = $application->find('init');
 
-        $this->assertFileExists(
-            'phinx.php',
-            'Phinx configuration not existent'
-        );
+            $commandTester = new CommandTester($command);
+            $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
+            $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
+            $this->assertMatchesRegularExpression(
+                "/created (.*)[\/\\\\]phinx\.php\\n/",
+                $commandTester->getDisplay(true)
+            );
 
-        chdir($current_dir);
+            $this->assertFileExists(
+                'phinx.php',
+                'Phinx configuration not existent'
+            );
+        } finally {
+            chdir($current_dir);
+        }
     }
 
     public function testYamlFormat()
     {
         $current_dir = getcwd();
-        chdir(sys_get_temp_dir());
 
-        $application = new PhinxApplication();
-        $application->add(new Init());
+        try {
+            chdir(sys_get_temp_dir());
 
-        $command = $application->find('init');
+            $application = new PhinxApplication();
+            $application->add(new Init());
 
-        $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), '--format' => AbstractCommand::FORMAT_YML_ALIAS], ['decorated' => false]);
-        $this->assertMatchesRegularExpression(
-            "/created (.*)[\/\\\\]phinx.yaml\\n/",
-            $commandTester->getDisplay(true)
-        );
+            $command = $application->find('init');
 
-        $this->assertFileExists(
-            'phinx.yaml',
-            'Phinx configuration not existent'
-        );
+            $commandTester = new CommandTester($command);
+            $exitCode = $commandTester->execute(['command' => $command->getName(), '--format' => AbstractCommand::FORMAT_YML_ALIAS], ['decorated' => false]);
+            $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
+            $this->assertMatchesRegularExpression(
+                "/created (.*)[\/\\\\]phinx.yaml\\n/",
+                $commandTester->getDisplay(true)
+            );
 
-        chdir($current_dir);
+            $this->assertFileExists(
+                'phinx.yaml',
+                'Phinx configuration not existent'
+            );
+        } finally {
+            chdir($current_dir);
+        }
     }
 
     public function testThrowsExceptionWhenConfigFilePresent()
@@ -143,12 +152,13 @@ class InitTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/Config file ".*" already exists./');
 
-        $commandTester->execute([
+        $exitCode = $commandTester->execute([
             'command' => $command->getName(),
             'path' => sys_get_temp_dir(),
         ], [
             'decorated' => false,
         ]);
+        $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testThrowsExceptionWhenInvalidDir()
@@ -163,12 +173,13 @@ class InitTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/Invalid path ".*" for config file./');
 
-        $commandTester->execute([
+        $exitCode = $commandTester->execute([
             'command' => $command->getName(),
             'path' => '/this/dir/does/not/exists',
         ], [
             'decorated' => false,
         ]);
+        $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testThrowsExceptionWhenInvalidFormat()
@@ -183,12 +194,13 @@ class InitTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid format "invalid". Format must be either json, yaml, yml, php.');
 
-        $commandTester->execute([
+        $exitCode = $commandTester->execute([
             'command' => $command->getName(),
             'path' => sys_get_temp_dir() . DIRECTORY_SEPARATOR,
             '--format' => 'invalid',
         ], [
             'decorated' => false,
         ]);
+        $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 }

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Console\Command;
 
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\PhinxApplication;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -29,13 +30,14 @@ class ListAliasesTest extends TestCase
     {
         $command = (new PhinxApplication())->find('list:aliases');
         $commandTester = new CommandTester($command);
-        $commandTester->execute(
+        $exitCode = $commandTester->execute(
             [
                 'command' => $command->getName(),
                 '--configuration' => realpath(sprintf('%s/../../Config/_files/%s', __DIR__, $file)),
             ],
             ['decorated' => false]
         );
+        $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $display = $commandTester->getDisplay(false);
 

--- a/tests/Phinx/Console/Command/ListTest.php
+++ b/tests/Phinx/Console/Command/ListTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Console\Command;
 
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\PhinxApplication;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\ApplicationTester;
@@ -15,7 +16,8 @@ class ListTest extends TestCase
         $application->setCatchExceptions(false);
 
         $appTester = new ApplicationTester($application);
-        $appTester->run(['command' => 'list', '--format' => 'txt']);
+        $exitCode = $appTester->run(['command' => 'list', '--format' => 'txt']);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
         $stream = $appTester->getOutput()->getStream();
         rewind($stream);
 

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -82,7 +82,7 @@ class RollbackTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $display = $commandTester->getDisplay();
 
@@ -90,6 +90,7 @@ class RollbackTest extends TestCase
 
         // note that the default order is by creation time
         $this->assertStringContainsString('ordering by creation time', $display);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -167,8 +168,9 @@ class RollbackTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
         $this->assertStringContainsString('using database development', $commandTester->getDisplay());
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testStartTimeVersionOrder()
@@ -194,8 +196,9 @@ class RollbackTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
         $this->assertStringContainsString('ordering by execution time', $commandTester->getDisplay());
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testWithDate()
@@ -222,7 +225,8 @@ class RollbackTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), '-d' => $date], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), '-d' => $date], ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     /**
@@ -303,8 +307,9 @@ class RollbackTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), '-d' => $targetDate], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), '-d' => $targetDate], ['decorated' => false]);
         $this->assertStringContainsString('ordering by execution time', $commandTester->getDisplay());
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testFakeRollback()
@@ -328,11 +333,12 @@ class RollbackTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), '--fake' => true], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), '--fake' => true], ['decorated' => false]);
 
         $display = $commandTester->getDisplay();
 
         $this->assertStringContainsString('warning performing fake rollback', $display);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
     public function testRollbackMemorySqlite()

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -4,6 +4,7 @@ namespace Test\Phinx\Console\Command;
 
 use InvalidArgumentException;
 use Phinx\Config\Config;
+use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\SeedCreate;
 use Phinx\Console\PhinxApplication;
 use PHPUnit\Framework\TestCase;
@@ -78,12 +79,14 @@ class SeedCreateTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateSeeder'], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateSeeder'], ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The file "MyDuplicateSeeder.php" already exists');
 
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateSeeder'], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'MyDuplicateSeeder'], ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function testExecuteWithInvalidClassName()
@@ -108,7 +111,8 @@ class SeedCreateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed class name "badseedname" is invalid. Please use CamelCase format');
 
-        $commandTester->execute(['command' => $command->getName(), 'name' => 'badseedname'], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName(), 'name' => 'badseedname'], ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 
     public function testAlternativeTemplate()
@@ -130,7 +134,8 @@ class SeedCreateTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $commandLine = ['command' => $command->getName(), 'name' => 'AltTemplate', '--template' => __DIR__ . '/Templates/SimpleSeeder.template.php.dist'];
-        $commandTester->execute($commandLine, ['decorated' => false]);
+        $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         // Get output.
         preg_match('`created (?P<SeedFilename>.*?)\s`', $commandTester->getDisplay(), $match);
@@ -167,6 +172,7 @@ class SeedCreateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The template file "' . $template . '" does not exist');
 
-        $commandTester->execute($commandLine, ['decorated' => false]);
+        $exitCode = $commandTester->execute($commandLine, ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 }

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -73,8 +73,8 @@ class SeedRunTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
-
+        $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
         $this->assertStringContainsString('no environment specified', $commandTester->getDisplay());
     }
 
@@ -112,8 +112,8 @@ class SeedRunTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
-
+        $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
         $this->assertStringContainsString('no environment specified', $commandTester->getDisplay());
     }
 
@@ -190,7 +190,8 @@ class SeedRunTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
+        $exitCode = $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
         $this->assertStringContainsString('using database development', $commandTester->getDisplay());
     }
 
@@ -218,13 +219,14 @@ class SeedRunTest extends TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(
+        $exitCode = $commandTester->execute(
             [
                 'command' => $command->getName(),
                 '--seed' => ['One', 'Two', 'Three'],
             ],
             ['decorated' => false]
         );
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $this->assertStringContainsString('no environment specified', $commandTester->getDisplay());
     }


### PR DESCRIPTION
PR adds asserts for exit codes across all console command tests. Before, they were only consistently in place for the `MigrateTest` and `StatusTest`.

Somewhat unrelated, I also modified two tests in `InitTest` so that the use of `chdir` is better wrapped so that if something were to throw an exception in the test, we won't be potentially left in a different working directory for the rest of the suite / tests.