### PR TITLE
Fix rolling back columns with indices for SQLite and SQL Server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
 
     - name: Run PHPUnit
       env:
-        SQLSRV_DSN: 'sqlserver://(localdb)\MSSQLLocalDB/phinx'
+        SQLSRV_DSN: 'sqlsrv://(localdb)\MSSQLLocalDB/phinx'
         CODECOVERAGE: 1
       run: |
           vendor/bin/phpunit --verbose --coverage-clover=coverage.xml

--- a/src/Phinx/Db/Plan/Plan.php
+++ b/src/Phinx/Db/Plan/Plan.php
@@ -190,19 +190,6 @@ class Plan
             }
         }
 
-        // Columns that are dropped will automatically cause the indexes to be dropped as well
-        foreach ($this->columnRemoves as $columnRemove) {
-            foreach ($columnRemove->getActions() as $action) {
-                if ($action instanceof RemoveColumn) {
-                    [$this->indexes] = $this->forgetDropIndex(
-                        $action->getTable(),
-                        [$action->getColumn()->getName()],
-                        $this->indexes
-                    );
-                }
-            }
-        }
-
         // Renaming a column and then changing the renamed column is something people do,
         // but it is a conflicting action. Luckily solving the conflict can be done by moving
         // the ChangeColumn action to another AlterTable.

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20170824134305_direction_aware_reversible_up.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20170824134305_direction_aware_reversible_up.php
@@ -22,10 +22,10 @@ class DirectionAwareReversibleUp extends AbstractMigration
                     'thing' => 'two',
                 ],
                 [
-                    'thing' => 'fox_socks',
+                    'thing' => 'fox-socks',
                 ],
                 [
-                    'thing' => 'mouse_box',
+                    'thing' => 'mouse-box',
                 ],
             ])->save();
         }

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20170831121929_direction_aware_reversible_down.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20170831121929_direction_aware_reversible_down.php
@@ -15,13 +15,18 @@ class DirectionAwareReversibleDown extends AbstractMigration
             ->update();
 
         if ($this->isMigratingUp()) {
-            $this->execute("UPDATE change_direction_test
-                SET subthing = SUBSTRING(thing, LOCATE('_', thing) + 1),
-                    thing = LEFT(thing, LOCATE('_', thing) - 1)
-                WHERE thing LIKE '%\\\\_%'");
+            $query = $this->getQueryBuilder();
+            $query
+                ->update('change_direction_test')
+                ->set(['subthing' => $query->identifier('thing')])
+                ->where(['thing LIKE' => '%-%'])
+                ->execute();
         } else {
-            $this->execute("UPDATE change_direction_test
-                SET thing = CONCAT_WS('_', thing, subthing)");
+            $this
+                ->getQueryBuilder()
+                ->update('change_direction_test')
+                ->set(['subthing' => null])
+                ->execute();
         }
     }
 }

--- a/tests/Phinx/Migration/_files/reversiblemigrations/20190928220334_add_column_index_fk.php
+++ b/tests/Phinx/Migration/_files/reversiblemigrations/20190928220334_add_column_index_fk.php
@@ -33,21 +33,30 @@ class AddColumnIndexFk extends AbstractMigration
      */
     public function change()
     {
-        $this->table('statuses')
+        $table = $this->table('statuses')
             ->addColumn('user_id', Column::INTEGER, [
                 'null' => true,
                 'limit' => 20,
                 'signed' => false,
             ])
             ->addIndex(['user_id'], [
-                    'name' => 'statuses_users_id',
-                    'unique' => false,
-                ])
-            ->addForeignKey('user_id', 'users', 'id', [
-                    'constraint' => 'statuses_users_id',
-                    'update' => ForeignKey::RESTRICT,
-                    'delete' => ForeignKey::RESTRICT,
-                ])
-            ->update();
+                'name' => 'statuses_users_id',
+                'unique' => false,
+            ]);
+
+        if ($this->getAdapter()->getConnection()->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $table->addForeignKey('user_id', 'users', 'id', [
+                'update' => ForeignKey::NO_ACTION,
+                'delete' => ForeignKey::NO_ACTION,
+            ]);
+        } else {
+            $table->addForeignKey('user_id', 'users', 'id', [
+                'constraint' => 'statuses_users_id',
+                'update' => ForeignKey::NO_ACTION,
+                'delete' => ForeignKey::NO_ACTION,
+            ]);
+        }
+
+        $table->update();
     }
 }

--- a/tests/phpunit-bootstrap.php
+++ b/tests/phpunit-bootstrap.php
@@ -25,16 +25,20 @@ if (!getenv('SQLITE_DSN') && !getenv('MYSQL_DSN') && !getenv('PGSQL_DSN') && !ge
 
 if (getenv('SQLITE_DSN')) {
     define('SQLITE_DB_CONFIG', Util::parseDsn(getenv('SQLITE_DSN')));
+    define('DB_CONFIG', SQLITE_DB_CONFIG);
 }
 
 if (getenv('MYSQL_DSN')) {
     define('MYSQL_DB_CONFIG', Util::parseDsn(getenv('MYSQL_DSN')));
+    define('DB_CONFIG', MYSQL_DB_CONFIG);
 }
 
 if (getenv('PGSQL_DSN')) {
     define('PGSQL_DB_CONFIG', Util::parseDsn(getenv('PGSQL_DSN')));
+    define('DB_CONFIG', PGSQL_DB_CONFIG);
 }
 
 if (getenv('SQLSRV_DSN')) {
     define('SQLSRV_DB_CONFIG', Util::parseDsn(getenv('SQLSRV_DSN')));
+    define('DB_CONFIG', SQLSRV_DB_CONFIG);
 }


### PR DESCRIPTION
Instead of adding a new test for just this one problem, I've updated the existing reversible migrations test (it includes the problematic case of adding a column with an index to an existing table) and made it cross DBMS compatible, to add some more coverage in the process.

AFAICT, previously only MySQL was used except in one test for Postgres. Going forward, adding more cross DBMS coverage probably wouldn't hurt, so that finding DBMS specific issues becomes a bit easier.

refs #2126