### PR TITLE
Fix deprecated ${} string interpolation

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1363,7 +1363,7 @@ PCRE_PATTERN;
                     );
                     $createIndexSQL = $this->getDeclaringIndexSQL($tableName, $indexName);
                     $sql .= preg_replace(
-                        "/\b${tableName}\b/",
+                        "/\b{$tableName}\b/",
                         $tmpTableName,
                         $createIndexSQL
                     );


### PR DESCRIPTION
`"${var}"` is deprecated in PHP 8.2, and should be replaced with `"{$var}"`:
https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation

I searched for `${`, as far as I can tell this line was the only place where this occurred.