### PR TITLE
Update migrations.rst

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -825,7 +825,7 @@ timezone enable or disable the ``with time zone`` option for ``time`` and ``time
 
 You can add ``created_at`` and ``updated_at`` timestamps to a table using the ``addTimestamps()`` method. This method accepts
 three arguments, where the first two allow setting alternative names for the columns while the third argument allows you to
-enable the ``timezone`` option for the columns. The defaults for these arguments are ``created_at``, ``updated_at``, and ``true``
+enable the ``timezone`` option for the columns. The defaults for these arguments are ``created_at``, ``updated_at``, and ``false``
 respectively. For the first and second argument, if you provide ``null``, then the default name will be used, and if you provide
 ``false``, then that column will not be created. Please note that attempting to set both to ``false`` will throw a
 ``\RuntimeException``. Additionally, you can use the ``addTimestampsWithTimezone()`` method, which is an alias to


### PR DESCRIPTION
Wrong info about third argument's default value in 'addTimestamp()' method of phinx Table API