### PR TITLE
Fix reference to MysqlAdapter::FIRST constant in migrations doc

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -1194,8 +1194,7 @@ where its value is the name of the column to position it after.
             }
         }
 
-This would create the new column ``city`` and position it after the ``email`` column. You
-can use the `\Phinx\Db\Adapter\MysqlAdapter\FIRST` constant to specify that the new column should
+This would create the new column ``city`` and position it after the ``email`` column. ``\Phinx\Db\Adapter\MysqlAdapter::FIRST`` constant can be used to specify that the new column should be
 created as the first column in that table.
 
 Dropping a Column

--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -1195,7 +1195,8 @@ where its value is the name of the column to position it after.
             }
         }
 
-This would create the new column ``city`` and position it after the ``email`` column. ``\Phinx\Db\Adapter\MysqlAdapter::FIRST`` constant can be used to specify that the new column should be
+This would create the new column ``city`` and position it after the ``email`` column. The 
+``\Phinx\Db\Adapter\MysqlAdapter::FIRST`` constant can be used to specify that the new column should be
 created as the first column in that table.
 
 Dropping a Column

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -902,13 +902,11 @@ class Manager
     {
         $orderedSeeds = [];
         foreach ($seeds as $seed) {
-            $key = get_class($seed);
+            $orderedSeeds[get_class($seed)] = $seed;
+
             $dependencies = $this->getSeedDependenciesInstances($seed);
             if (!empty($dependencies)) {
-                $orderedSeeds[$key] = $seed;
                 $orderedSeeds = array_merge($this->orderSeedsByDependencies($dependencies), $orderedSeeds);
-            } else {
-                $orderedSeeds[$key] = $seed;
             }
         }
 


### PR DESCRIPTION
Fix full path to 'MysqlAdapter::FIRST' class constant
Fix wording in a sentence (typo and formatting)