### PR TITLE
Fix tag name pattern for docs CI workflow

### DIFF
--- a/.github/workflows/deploy_docs_0x.yml
+++ b/.github/workflows/deploy_docs_0x.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       branch:
         description: Branch to run on
-        default: master
+        default: 0.x
         required: true
 
 jobs:

--- a/.github/workflows/deploy_docs_0x.yml
+++ b/.github/workflows/deploy_docs_0x.yml
@@ -4,7 +4,7 @@ name: 'deploy_docs_0x'
 on:
   push:
     tags:
-      - v0.*
+      - 0.*
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
This fixes the tag pattern so that they'll be built when a new version is released as our tags are not prefixed by a `v` since `0.11.1` (all prior tags did have a `v` prefix).

This also updates the default from `master` to `0.x` which happened a few months ago.