### PR TITLE
Update version in docs

### DIFF
--- a/docs/config/all.py
+++ b/docs/config/all.py
@@ -29,7 +29,7 @@ languages = ['en']
 
 # The GitHub branch name for this version of the docs
 # for edit links to point at.
-branch = 'master'
+branch = '0.x'
 
 # Current version being built
 version = '0.13'

--- a/docs/config/all.py
+++ b/docs/config/all.py
@@ -8,7 +8,7 @@
 from cakephpsphinx.config.all import *
 
 # The full version, including alpha/beta/rc tags.
-release = '0.12.x'
+release = '0.13.x'
 
 # The search index version.
 search_version = 'phinx-0'
@@ -21,7 +21,7 @@ project = 'Phinx'
 
 # Other versions that display in the version picker menu.
 version_list = [
-    {'name': '0.12', 'number': '/phinx/0', 'title': '0.12', 'current': True},
+    {'name': '0.13', 'number': '/phinx/0', 'title': '0.13', 'current': True},
 ]
 
 # Languages available.
@@ -32,7 +32,7 @@ languages = ['en']
 branch = 'master'
 
 # Current version being built
-version = '0.12'
+version = '0.13'
 
 show_root_link = True
 


### PR DESCRIPTION
Updates the version we'll show for the docs to `0.13`, as well as make sure any built github links for the docs point back to the `0.x` branch.