### PR TITLE
Add testcases for Util::getVersionFromFileName function

### DIFF
--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -90,8 +90,7 @@ class Util
     {
         $matches = [];
         preg_match('/^[0-9]+/', basename($fileName), $matches);
-
-        $value = (int)$matches[0];
+        $value = (int)($matches[0] ?? null);
         if (!$value) {
             throw new RuntimeException(sprintf('Cannot get a valid version from filename `%s`', $fileName));
         }

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Util;
 
+use RuntimeException;
 use Phinx\Util\Util;
 use Test\Phinx\TestCase;
 
@@ -45,6 +46,17 @@ class UtilTest extends TestCase
         $this->assertGreaterThanOrEqual($expected, $current);
         // We limit the assertion time to 2 seconds, which should never fail.
         $this->assertLessThanOrEqual($expected + 2, $current);
+    }
+
+    public function testGetVersionFromFileName(): void
+    {
+        $this->assertSame(20221130101652, Util::getVersionFromFileName('20221130101652_test.php'));
+    }
+
+    public function testGetVersionFromFileNameError(): void
+    {
+        $this->expectException(RuntimeException::class);
+        Util::getVersionFromFileName('foo.php');
     }
 
     public function providerMapClassNameToFileName(): array

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -2,8 +2,8 @@
 
 namespace Test\Phinx\Util;
 
-use RuntimeException;
 use Phinx\Util\Util;
+use RuntimeException;
 use Test\Phinx\TestCase;
 
 class UtilTest extends TestCase

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -53,10 +53,16 @@ class UtilTest extends TestCase
         $this->assertSame(20221130101652, Util::getVersionFromFileName('20221130101652_test.php'));
     }
 
-    public function testGetVersionFromFileNameError(): void
+    public function testGetVersionFromFileNameErrorNoVersion(): void
     {
         $this->expectException(RuntimeException::class);
         Util::getVersionFromFileName('foo.php');
+    }
+
+    public function testGetVersionFromFileNameErrorZeroVersion(): VoidCommand
+    {
+        $this->expectException(RuntimeException::class);
+        Util::getVersionFromFileName('0_foo.php');
     }
 
     public function providerMapClassNameToFileName(): array


### PR DESCRIPTION
PR works off the changes from #2150 by guarding against getting a filename that's got no version in the name, and also adding testcases for behavior to prevent regressions.