### PR TITLE
add fix for mariadb virtual column creation

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1363,7 +1363,7 @@ class MysqlAdapter extends PdoAdapter
         $def .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
         $def .= !$column->isSigned() && isset($this->signedColumnTypes[$column->getType()]) ? ' unsigned' : '';
 
-        if (!($column->getType() instanceof Literal) || strpos($this->getConnection()->getAttribute(PDO::ATTR_SERVER_VERSION), "MariaDB") === false) {
+        if (!($column->getType() instanceof Literal) || strpos($this->getConnection()->getAttribute(PDO::ATTR_SERVER_VERSION), 'MariaDB') === false) {
             $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
         }
 

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1362,7 +1362,10 @@ class MysqlAdapter extends PdoAdapter
         $def .= $column->getEncoding() ? ' CHARACTER SET ' . $column->getEncoding() : '';
         $def .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
         $def .= !$column->isSigned() && isset($this->signedColumnTypes[$column->getType()]) ? ' unsigned' : '';
-        $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
+
+        if (!($column->getType() instanceof Literal) || strpos($this->getConnection()->getAttribute(PDO::ATTR_SERVER_VERSION), "MariaDB") === false) {
+            $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
+        }
 
         if (
             version_compare($this->getAttribute(\PDO::ATTR_SERVER_VERSION), '8', '>=')


### PR DESCRIPTION
When using virtual column definition with `Literal` class, migration fails with SQL syntax error on MariaDB as `NOT NULL` or `NULL` are not allowed at the end of column definition.  Below is the link to an issue.

Fixes https://github.com/cakephp/phinx/issues/2157