### PR TITLE
Add feature flags to disable some breaking changes

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -518,11 +518,12 @@ Feature Flags
 
 For some breaking changes, Phinx offers a way to opt-out of new behavior. The following flags are available:
 
-* ``unsigned_pks``: Should Phinx create primary keys as unsigned integers? (default: ``true``)
-* ``column_null``: Should Phinx create columns as null by default? (default: ``true``)
+* ``unsigned_primary_keys``: Should Phinx create primary keys as unsigned integers? (default: ``true``)
+* ``column_null_default``: Should Phinx create columns as null by default? (default: ``true``)
 
-These values can also be set by modifying class fields on the ```Phinx\Config\FeatureFlags``` class, for example:
+These values can also be set by modifying class fields on the ```Phinx\Config\FeatureFlags``` class, converting
+the flag name to ``camelCase``, for example:
 
 .. code-block:: php
 
-    Phinx\Config\FeatureFlags::$unsignedPks = false;
+    Phinx\Config\FeatureFlags::$unsignedPrimaryKeys = false;

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -512,3 +512,17 @@ Within the bootstrap script, the following variables will be available:
      * @var \Symfony\Component\Console\Output\OutputInterface $output The executing command's output object
      * @var \Phinx\Console\Command\AbstractCommand $context the executing command object
      */
+
+Feature Flags
+-------------
+
+For some breaking changes, Phinx offers a way to opt-out of new behavior. The following flags are available:
+
+* ``unsigned_pks``: Should Phinx create primary keys as unsigned integers? (default: ``true``)
+* ``column_null``: Should Phinx create columns as null by default? (default: ``true``)
+
+These values can also be set by modifying class fields on the ```Phinx\Config\FeatureFlags``` class, for example:
+
+.. code-block:: php
+
+    Phinx\Config\FeatureFlags::$unsignedPks = false;

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -57,6 +57,10 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     {
         $this->configFilePath = $configFilePath;
         $this->values = $this->replaceTokens($configArray);
+
+        if (isset($this->values['feature_flags'])) {
+            FeatureFlags::setFlagsFromConfig($this->values['feature_flags']);
+        }
     }
 
     /**

--- a/src/Phinx/Config/FeatureFlags.php
+++ b/src/Phinx/Config/FeatureFlags.php
@@ -22,7 +22,13 @@ class FeatureFlags {
      */
     public static $columnNull = true;
 
-    public static function setFlagsFromConfig(array $config): void {
+    /**
+     * Set the feature flags from a config object
+     *
+     * @param array $config
+     */
+    public static function setFlagsFromConfig(array $config): void
+    {
         if (isset($config['unsigned_pks'])) {
             self::$unsignedPks = (bool)$config['unsigned_pks'];
         }

--- a/src/Phinx/Config/FeatureFlags.php
+++ b/src/Phinx/Config/FeatureFlags.php
@@ -12,7 +12,8 @@ namespace Phinx\Config;
  *
  * New flags should be added very sparingly.
  */
-class FeatureFlags {
+class FeatureFlags
+{
     /**
      * @var bool Should Phinx create unsigned primary keys by default?
      */
@@ -23,9 +24,10 @@ class FeatureFlags {
     public static $columnNull = true;
 
     /**
-     * Set the feature flags from a config object
+     * Set the feature flags from the `feature_flags` section of the overall
+     * config.
      *
-     * @param array $config
+     * @param array $config The `feature_flags` section of the config
      */
     public static function setFlagsFromConfig(array $config): void
     {

--- a/src/Phinx/Config/FeatureFlags.php
+++ b/src/Phinx/Config/FeatureFlags.php
@@ -17,11 +17,11 @@ class FeatureFlags
     /**
      * @var bool Should Phinx create unsigned primary keys by default?
      */
-    public static $unsignedPks = true;
+    public static $unsignedPrimaryKeys = true;
     /**
      * @var bool Should Phinx create columns NULL by default?
      */
-    public static $columnNull = true;
+    public static $columnNullDefault = true;
 
     /**
      * Set the feature flags from the `feature_flags` section of the overall
@@ -31,11 +31,11 @@ class FeatureFlags
      */
     public static function setFlagsFromConfig(array $config): void
     {
-        if (isset($config['unsigned_pks'])) {
-            self::$unsignedPks = (bool)$config['unsigned_pks'];
+        if (isset($config['unsigned_primary_keys'])) {
+            self::$unsignedPrimaryKeys = (bool)$config['unsigned_primary_keys'];
         }
-        if (isset($config['column_null'])) {
-            self::$columnNull = (bool)$config['column_null'];
+        if (isset($config['column_null_default'])) {
+            self::$columnNullDefault = (bool)$config['column_null_default'];
         }
     }
 }

--- a/src/Phinx/Config/FeatureFlags.php
+++ b/src/Phinx/Config/FeatureFlags.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Phinx\Config;
+
+/**
+ * Class to hold features flags to toggle breaking changes in Phinx.
+ *
+ * New flags should be added very sparingly.
+ */
+class FeatureFlags {
+    /**
+     * Should Phinx create unsigned primary keys by default?
+     */
+    public static bool $unsignedPks = true;
+    /**
+     * Should Phinx create columns NULL by default?
+     */
+    public static bool $columnNull = true;
+
+    public static function setFlagsFromConfig(array $config): void {
+        if (isset($config['unsigned_pks'])) {
+            self::$unsignedPks = (bool)$config['unsigned_pks'];
+        }
+        if (isset($config['column_null'])) {
+            self::$columnNull = (bool)$config['column_null'];
+        }
+    }
+}

--- a/src/Phinx/Config/FeatureFlags.php
+++ b/src/Phinx/Config/FeatureFlags.php
@@ -14,13 +14,13 @@ namespace Phinx\Config;
  */
 class FeatureFlags {
     /**
-     * Should Phinx create unsigned primary keys by default?
+     * @var bool Should Phinx create unsigned primary keys by default?
      */
-    public static bool $unsignedPks = true;
+    public static $unsignedPks = true;
     /**
-     * Should Phinx create columns NULL by default?
+     * @var bool Should Phinx create columns NULL by default?
      */
-    public static bool $columnNull = true;
+    public static $columnNull = true;
 
     public static function setFlagsFromConfig(array $config): void {
         if (isset($config['unsigned_pks'])) {

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -11,6 +11,7 @@ use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql as MysqlDriver;
 use InvalidArgumentException;
 use PDO;
+use Phinx\Config\FeatureFlags;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\ForeignKey;
 use Phinx\Db\Table\Index;
@@ -285,7 +286,7 @@ class MysqlAdapter extends PdoAdapter
             $column->setName($options['id'])
                    ->setType('integer')
                    ->setOptions([
-                       'signed' => $options['signed'] ?? false,
+                       'signed' => $options['signed'] ?? !FeatureFlags::$unsignedPks,
                        'identity' => true,
                    ]);
 

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -286,7 +286,7 @@ class MysqlAdapter extends PdoAdapter
             $column->setName($options['id'])
                    ->setType('integer')
                    ->setOptions([
-                       'signed' => $options['signed'] ?? !FeatureFlags::$unsignedPks,
+                       'signed' => $options['signed'] ?? !FeatureFlags::$unsignedPrimaryKeys,
                        'identity' => true,
                    ]);
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -164,7 +164,7 @@ class Column
      */
     public function __construct()
     {
-        $this->null = FeatureFlags::$columnNull;
+        $this->null = FeatureFlags::$columnNullDefault;
     }
 
     /**

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -7,6 +7,7 @@
 
 namespace Phinx\Db\Table;
 
+use Phinx\Config\FeatureFlags;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\PostgresAdapter;
 use RuntimeException;
@@ -157,6 +158,11 @@ class Column
      * @var array|null
      */
     protected $values;
+
+    public function __construct()
+    {
+        $this->null = !FeatureFlags::$columnNull;
+    }
 
     /**
      * Sets the column name.

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -161,7 +161,7 @@ class Column
 
     public function __construct()
     {
-        $this->null = !FeatureFlags::$columnNull;
+        $this->null = FeatureFlags::$columnNull;
     }
 
     /**

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -159,6 +159,9 @@ class Column
      */
     protected $values;
 
+    /**
+     * Column constructor
+     */
     public function __construct()
     {
         $this->null = FeatureFlags::$columnNull;

--- a/tests/Phinx/Config/FeatureFlagsTest.php
+++ b/tests/Phinx/Config/FeatureFlagsTest.php
@@ -13,13 +13,13 @@ class FeatureFlagsTest extends TestCase
     public function testSetFlagsFromConfig(): void
     {
         $config = [
-            'unsigned_pks' => false,
-            'column_null' => false,
+            'unsigned_primary_keys' => false,
+            'column_null_default' => false,
         ];
-        $this->assertTrue(FeatureFlags::$unsignedPks);
-        $this->assertTrue(FeatureFlags::$columnNull);
+        $this->assertTrue(FeatureFlags::$unsignedPrimaryKeys);
+        $this->assertTrue(FeatureFlags::$columnNullDefault);
         FeatureFlags::setFlagsFromConfig($config);
-        $this->assertFalse(FeatureFlags::$unsignedPks);
-        $this->assertFalse(FeatureFlags::$columnNull);
+        $this->assertFalse(FeatureFlags::$unsignedPrimaryKeys);
+        $this->assertFalse(FeatureFlags::$columnNullDefault);
     }
 }

--- a/tests/Phinx/Config/FeatureFlagsTest.php
+++ b/tests/Phinx/Config/FeatureFlagsTest.php
@@ -2,8 +2,8 @@
 
 namespace Test\Phinx\Config;
 
-use PHPUnit\Framework\TestCase;
 use Phinx\Config\FeatureFlags;
+use PHPUnit\Framework\TestCase;
 
 class FeatureFlagsTest extends TestCase
 {

--- a/tests/Phinx/Config/FeatureFlagsTest.php
+++ b/tests/Phinx/Config/FeatureFlagsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Test\Phinx\Config;
+
+use PHPUnit\Framework\TestCase;
+use Phinx\Config\FeatureFlags;
+
+class FeatureFlagsTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSetFlagsFromConfig(): void
+    {
+        $config = [
+            'unsigned_pks' => false,
+            'column_null' => false,
+        ];
+        $this->assertTrue(FeatureFlags::$unsignedPks);
+        $this->assertTrue(FeatureFlags::$columnNull);
+        FeatureFlags::setFlagsFromConfig($config);
+        $this->assertFalse(FeatureFlags::$unsignedPks);
+        $this->assertFalse(FeatureFlags::$columnNull);
+    }
+}

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -491,7 +491,7 @@ class MysqlAdapterTest extends TestCase
     {
         $this->adapter->connect();
 
-        FeatureFlags::$unsignedPks = false;
+        FeatureFlags::$unsignedPrimaryKeys = false;
 
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);
         $table->create();

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -162,7 +162,6 @@ class MysqlAdapterTest extends TestCase
         $this->assertCount(3, $columns);
         $this->assertSame('id', $columns[0]->getName());
         $this->assertFalse($columns[0]->isSigned());
-
     }
 
     public function testCreateTableWithComment()

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Test\Phinx\Db\Adapter;
 
 use PDOException;
+use Phinx\Config\FeatureFlags;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Util\Literal;
@@ -156,6 +157,12 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));
         $this->assertTrue($this->adapter->hasColumn('ntable', 'email'));
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
+
+        $columns = $this->adapter->getColumns('ntable');
+        $this->assertCount(3, $columns);
+        $this->assertSame('id', $columns[0]->getName());
+        $this->assertFalse($columns[0]->isSigned());
+
     }
 
     public function testCreateTableWithComment()
@@ -421,6 +428,25 @@ class MysqlAdapterTest extends TestCase
         $this->assertEquals('latin1_general_ci', $row['Collation']);
     }
 
+    public function testCreateTableWithSignedPK()
+    {
+        $table = new \Phinx\Db\Table('ntable', ['signed' => true], $this->adapter);
+        $table->addColumn('realname', 'string')
+            ->addColumn('email', 'integer')
+            ->save();
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'email'));
+        $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
+        $column_definitions = $this->adapter->getColumns('ntable');
+        foreach ($column_definitions as $column_definition) {
+            if ($column_definition->getName() === 'id') {
+                $this->assertTrue($column_definition->getSigned());
+            }
+        }
+    }
+
     public function testCreateTableWithUnsignedPK()
     {
         $table = new \Phinx\Db\Table('ntable', ['signed' => false], $this->adapter);
@@ -457,6 +483,24 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));
         $this->assertTrue($this->adapter->hasColumn('ntable', 'email'));
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testUnsignedPksFeatureFlag()
+    {
+        $this->adapter->connect();
+
+        FeatureFlags::$unsignedPks = false;
+
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table->create();
+
+        $columns = $this->adapter->getColumns('table1');
+        $this->assertCount(1, $columns);
+        $this->assertSame('id', $columns[0]->getName());
+        $this->assertTrue($columns[0]->getSigned());
     }
 
     public function testCreateTableWithLimitPK()

--- a/tests/Phinx/Db/Table/ColumnTest.php
+++ b/tests/Phinx/Db/Table/ColumnTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Db\Table;
 
+use Phinx\Config\FeatureFlags;
 use Phinx\Db\Table\Column;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -27,5 +28,18 @@ class ColumnTest extends TestCase
         $column->setOptions(['identity' => true]);
         $this->assertFalse($column->isNull());
         $this->assertTrue($column->isIdentity());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testColumnNullFeatureFlag()
+    {
+        $column = new Column();
+        $this->assertTrue($column->isNull());
+
+        FeatureFlags::$columnNull = false;
+        $column = new Column();
+        $this->assertFalse($column->isNull());
     }
 }

--- a/tests/Phinx/Db/Table/ColumnTest.php
+++ b/tests/Phinx/Db/Table/ColumnTest.php
@@ -38,7 +38,7 @@ class ColumnTest extends TestCase
         $column = new Column();
         $this->assertTrue($column->isNull());
 
-        FeatureFlags::$columnNull = false;
+        FeatureFlags::$columnNullDefault = false;
         $column = new Column();
         $this->assertFalse($column->isNull());
     }


### PR DESCRIPTION
PR to address comments in #2154 

A new `FeatureFlags` class has been introduced that we can use to wrap larger breaking changes, such that end-users may optionally disable them.