### PR TITLE
Restored migration template method return types

### DIFF
--- a/src/Phinx/Migration/Migration.change.template.php.dist
+++ b/src/Phinx/Migration/Migration.change.template.php.dist
@@ -16,7 +16,7 @@ final class $className extends $baseClassName
      * Remember to call "create()" or "update()" and NOT "save()" when working
      * with the Table class.
      */
-    public function change()
+    public function change(): void
     {
 
     }

--- a/src/Phinx/Migration/Migration.up_down.template.php.dist
+++ b/src/Phinx/Migration/Migration.up_down.template.php.dist
@@ -5,12 +5,12 @@ use $useClassName;
 
 final class $className extends $baseClassName
 {
-    public function up()
+    public function up(): void
     {
 
     }
 
-    public function down()
+    public function down(): void
     {
 
     }


### PR DESCRIPTION
I previously added this in #1819 but it was (inadvertently?) reverted in #1995, which claimed to be _adding_ type hints, but actually _removed_ them, at least in migration templates, as we can see in [this commit](https://github.com/cakephp/phinx/commit/f385bbb433cc1ab80b3a0b0a791c0a902775fc7a#diff-4f9657fd1a0873b5a146d11b6b6e71eece8c084e5e29f5f720d64ab3299297da). That commit purports to be _fixing tests_, but as we can see from this PR, no tests (at least at the present time) are broken by adding such types.

Since Phinx currently requires PHP 7.2, and [void functions](https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.void-functions) were added in PHP 7.1, there doesn't seem to be a compelling reason to _not_ to add these types.