### PR TITLE
Changed breakpoint column to disallow nulls again

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -311,7 +311,7 @@ abstract class AbstractAdapter implements AdapterInterface
                 ->addColumn('migration_name', 'string', ['limit' => 100, 'default' => null, 'null' => true])
                 ->addColumn('start_time', 'timestamp', ['default' => null, 'null' => true])
                 ->addColumn('end_time', 'timestamp', ['default' => null, 'null' => true])
-                ->addColumn('breakpoint', 'boolean', ['default' => false])
+                ->addColumn('breakpoint', 'boolean', ['default' => false, 'null' => false])
                 ->save();
         } catch (Exception $exception) {
             throw new InvalidArgumentException(


### PR DESCRIPTION
For reasons that remain unclear to me, rather than having a single source of truth, the `breakpoint` column of the migration table may be defined in one of two places, (either [here](https://github.com/cakephp/phinx/blob/2922b17953f4a0910efb4ba5ae7cb528eea5718e/src/Phinx/Db/Adapter/AbstractAdapter.php#L314) or [here](https://github.com/cakephp/phinx/blob/2922b17953f4a0910efb4ba5ae7cb528eea5718e/src/Phinx/Db/Adapter/PdoAdapter.php#L147)). Since 0.13, the breakpoint column may permit null or not, depending on which code path it ends up using. In my case, it suddenly stopped declaring _NOT NULL_ after the upgrade because it used the path which was seemingly missed in #1872. This PR fixes the missed code path.