### PR TITLE
Fix deprecation notices in MysqlAdapterTest

### DIFF
--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1061,7 +1061,7 @@ class MysqlAdapterTest extends TestCase
     }
 
     /** @dataProvider binaryToBlobAutomaticConversionData */
-    public function testBinaryToBlobAutomaticConversion(?int $limit = null, string $expectedType, int $expectedLimit)
+    public function testBinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
         $table->addColumn('column1', 'binary', ['limit' => $limit])
@@ -1088,7 +1088,7 @@ class MysqlAdapterTest extends TestCase
     }
 
     /** @dataProvider varbinaryToBlobAutomaticConversionData */
-    public function testVarbinaryToBlobAutomaticConversion(?int $limit = null, string $expectedType, int $expectedLimit)
+    public function testVarbinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
         $table->addColumn('column1', 'varbinary', ['limit' => $limit])
@@ -1130,7 +1130,7 @@ class MysqlAdapterTest extends TestCase
     }
 
     /** @dataProvider blobColumnsData */
-    public function testblobColumns(string $type, string $expectedType, ?int $limit = null, int $expectedLimit)
+    public function testblobColumns(string $type, string $expectedType, ?int $limit, int $expectedLimit)
     {
         $table = new \Phinx\Db\Table('t', [], $this->adapter);
         $table->addColumn('column1', $type, ['limit' => $limit])


### PR DESCRIPTION
Closes #2141

PR fixes the following deprecation warnings:

```
PHP Deprecated:  Optional parameter $limit declared before required parameter $expectedLimit is implicitly treated as a required parameter in /home/runner/work/phinx/phinx/tests/Phinx/Db/Adapter/MysqlAdapterTest.php on line 1064

PHP Deprecated:  Optional parameter $limit declared before required parameter $expectedLimit is implicitly treated as a required parameter in /home/runner/work/phinx/phinx/tests/Phinx/Db/Adapter/MysqlAdapterTest.php on line 1091
PHP Deprecated:  Optional parameter $limit declared before required parameter $expectedLimit is implicitly treated as a required parameter in /home/runner/work/phinx/phinx/tests/Phinx/Db/Adapter/MysqlAdapterTest.php on line 1133
Deprecated: Optional parameter $limit declared before required parameter $expectedLimit is implicitly treated as a required parameter in /home/runner/work/phinx/phinx/tests/Phinx/Db/Adapter/MysqlAdapterTest.php on line 1064

Deprecated: Optional parameter $limit declared before required parameter $expectedLimit is implicitly treated as a required parameter in /home/runner/work/phinx/phinx/tests/Phinx/Db/Adapter/MysqlAdapterTest.php on line 1091

Deprecated: Optional parameter $limit declared before required parameter $expectedLimit is implicitly treated as a required parameter in /home/runner/work/phinx/phinx/tests/Phinx/Db/Adapter/MysqlAdapterTest.php on line 1133
```

The fix was easy in just removing the default for the `$limit` parameter as we always explicitly pass a value to it so need to make it optional.