### PR TITLE
Test against PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0', '8.1']
+        php-version: ['7.2', '7.4', '8.0', '8.1', '8.2']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
@@ -98,7 +98,7 @@ jobs:
         if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export MYSQL_DSN='mysql://root:root@127.0.0.1/phinx'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export PGSQL_DSN='pgsql://postgres:postgres@127.0.0.1/phinx'; fi
 
-        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.2' ]]; then
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
@@ -109,16 +109,16 @@ jobs:
       run: composer require --dev dereuromark/composer-prefer-lowest && vendor/bin/validate-prefer-lowest -m
 
     - name: Submit code coverage
-      if: matrix.php-version == '8.1'
+      if: matrix.php-version == '8.2'
       uses: codecov/codecov-action@v3
 
   testsuite-windows:
     runs-on: windows-2019
-    name: Windows - PHP 8.1 & SQL Server
+    name: Windows - PHP 7.2 & SQL Server
 
     env:
       EXTENSIONS: pdo_sqlsrv
-      PHP_VERSION: '8.1'
+      PHP_VERSION: '7.2'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
PR adds PHP 8.2 to the test matrix, updating the code coverage to run against that version. I also downgraded the version of PHP used for testing sqlsrv to be our lowest version since it's exercising unique code paths compared to the other DB adapters, and I'd like to have confidence we're supporting those paths on the lowest PHP version.