### PR TITLE
Remove duplicate include matrix value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
-          - php-version: '8.2'
-            db-type: mysql
           - php-version: '7.2'
             db-type: mysql
             prefer-lowest: prefer-lowest


### PR DESCRIPTION
PR gets rid of the first `include` matrix value as it duplicates an auto-generated setup from above and is not necessary.