### PR TITLE
Require php-64bit to install phinx

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php-64bit": ">=7.2",
         "cakephp/database": "^4.0",
         "psr/container": "^1.0 || ^2.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -3,7 +3,12 @@
 Phinx Documentation
 ===================
 
-Phinx makes it ridiculously easy to manage the database migrations for your PHP app. In less than 5 minutes, you can install Phinx using Composer and create your first database migration. Phinx is just about migrations without all the bloat of a database ORM system or application framework.
+Phinx makes it ridiculously easy to manage the database migrations for your PHP
+app. In less than 5 minutes, you can install Phinx using Composer and create
+your first database migration. Phinx is just about migrations without all the
+bloat of a database ORM system or application framework.
+
+Phinx requires a 64-bit version of PHP to function.
 
 Contents
 ========


### PR DESCRIPTION
PR modifies the `composer.json` such that now installing phinx will only work on php-64bit, which should hopefully avoid errors as shown in #2111 going forward. I think that the number of people using 32-bit PHP is probably low enough to not worry much about having them be stuck on an old version of phinx not realizing it'll break for them, where it's just people using PHP on windows and wherever they're getting PHP is pulling the modern x64 builds.

An alternative approach would be to rewrite phinx such that `$version` could be a string throughout and that we use an alternative data structure than an associative array for sorting migrations keyed by the version (due to how PHP implicitly cast integer looking keys to integers), but I'd say that's a lot of work to benefit a very small number of people.