### PR TITLE
Add existing comment to column object for mysql

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -455,7 +455,7 @@ class MysqlAdapter extends PdoAdapter
     public function getColumns(string $tableName): array
     {
         $columns = [];
-        $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName)));
+        $rows = $this->fetchAll(sprintf('SHOW FULL COLUMNS FROM %s', $this->quoteTableName($tableName)));
         foreach ($rows as $columnInfo) {
             $phinxType = $this->getPhinxType($columnInfo['Type']);
 
@@ -465,7 +465,8 @@ class MysqlAdapter extends PdoAdapter
                    ->setType($phinxType['name'])
                    ->setSigned(strpos($columnInfo['Type'], 'unsigned') === false)
                    ->setLimit($phinxType['limit'])
-                   ->setScale($phinxType['scale']);
+                   ->setScale($phinxType['scale'])
+                   ->setComment($columnInfo['Comment']);
 
             if ($columnInfo['Extra'] === 'auto_increment') {
                 $column->setIdentity(true);

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1289,7 +1289,7 @@ class MysqlAdapterTest extends TestCase
             ['column10', 'timestamp', []],
             ['column11', 'date', []],
             ['column12', 'binary', []],
-            ['column13', 'boolean', []],
+            ['column13', 'boolean', ['comment' => 'Lorem ipsum']],
             ['column14', 'string', ['limit' => 10]],
             ['column16', 'geometry', []],
             ['column17', 'point', []],
@@ -1332,6 +1332,10 @@ class MysqlAdapterTest extends TestCase
 
         if (isset($options['scale'])) {
             $this->assertEquals($options['scale'], $columns[1]->getScale());
+        }
+
+        if (isset($options['comment'])) {
+            $this->assertEquals($options['comment'], $columns[1]->getComment());
         }
     }
 


### PR DESCRIPTION
When using the `Table::getColumn($name)` method you would expect that afterwards the comment is available in the Column object. 

At least in Mysql this is not the case... therefore my change. 