### PR TITLE
Fix blank line above declare statement, see PSR-12

### DIFF
--- a/src/Phinx/Migration/Migration.change.template.php.dist
+++ b/src/Phinx/Migration/Migration.change.template.php.dist
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 $namespaceDefinition
 use $useClassName;

--- a/src/Phinx/Migration/Migration.up_down.template.php.dist
+++ b/src/Phinx/Migration/Migration.up_down.template.php.dist
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 $namespaceDefinition
 use $useClassName;

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -97,7 +97,7 @@ class CreateTest extends TestCase
         $this->assertMatchesRegularExpression('/^[0-9]{14}.php/', $fileName);
         $date = substr($fileName, 0, 14);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
-        $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
+        $prefix = "<?php\n\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
         $migrationContents = file_get_contents($this->config->getMigrationPaths()[0] . DIRECTORY_SEPARATOR . $fileName);
         $this->assertStringStartsWith($prefix, $migrationContents);
         $this->assertStringContainsString('public function change()', $migrationContents);
@@ -130,7 +130,7 @@ class CreateTest extends TestCase
         $fileName = current($files);
         $this->assertMatchesRegularExpression('/^[0-9]{14}_my_migration.php/', $fileName);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
-        $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class MyMigration extends AbstractMigration\n";
+        $prefix = "<?php\n\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class MyMigration extends AbstractMigration\n";
         $this->assertStringStartsWith($prefix, file_get_contents($this->config->getMigrationPaths()[0] . DIRECTORY_SEPARATOR . $fileName));
     }
 
@@ -484,7 +484,7 @@ class CreateTest extends TestCase
         $this->assertMatchesRegularExpression('/^[0-9]{14}.php/', $fileName);
         $date = substr($fileName, 0, 14);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
-        $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
+        $prefix = "<?php\n\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
         $migrationContents = file_get_contents($this->config->getMigrationPaths()[0] . DIRECTORY_SEPARATOR . $fileName);
         $this->assertStringStartsWith($prefix, $migrationContents);
         $this->assertStringContainsString('public function change()', $migrationContents);
@@ -518,7 +518,7 @@ class CreateTest extends TestCase
         $this->assertMatchesRegularExpression('/^[0-9]{14}.php/', $fileName);
         $date = substr($fileName, 0, 14);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
-        $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
+        $prefix = "<?php\n\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
         $migrationContents = file_get_contents($this->config->getMigrationPaths()[0] . DIRECTORY_SEPARATOR . $fileName);
         $this->assertStringStartsWith($prefix, $migrationContents);
         $this->assertStringContainsString('public function change()', $migrationContents);
@@ -552,7 +552,7 @@ class CreateTest extends TestCase
         $this->assertMatchesRegularExpression('/^[0-9]{14}.php/', $fileName);
         $date = substr($fileName, 0, 14);
         $this->assertFileExists($this->config->getMigrationPaths()[0]);
-        $prefix = "<?php\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
+        $prefix = "<?php\n\ndeclare(strict_types=1);\n\nuse Phinx\\Migration\\AbstractMigration;\n\nfinal class V{$date} extends AbstractMigration\n";
         $migrationContents = file_get_contents($this->config->getMigrationPaths()[0] . DIRECTORY_SEPARATOR . $fileName);
         $this->assertStringStartsWith($prefix, $migrationContents);
         $this->assertStringContainsString('public function up()', $migrationContents);

--- a/tests/Phinx/Console/Command/TemplateGenerators/DoesNotImplementRequiredInterface.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/DoesNotImplementRequiredInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Test\Phinx\Console\Command\TemplateGenerators;
 
 class DoesNotImplementRequiredInterface

--- a/tests/Phinx/Console/Command/TemplateGenerators/NullGenerator.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/NullGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Test\Phinx\Console\Command\TemplateGenerators;
 
 use Phinx\Migration\AbstractTemplateCreation;

--- a/tests/Phinx/Console/Command/TemplateGenerators/SimpleGenerator.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/SimpleGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Test\Phinx\Console\Command\TemplateGenerators;
 
 use Phinx\Migration\AbstractTemplateCreation;

--- a/tests/Phinx/TestCase.php
+++ b/tests/Phinx/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Test\Phinx;

--- a/tests/phpunit-bootstrap.php
+++ b/tests/phpunit-bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**


### PR DESCRIPTION
Fix PSR-12 compliance of generated migration scripts

According to PSR-12 (https://www.php-fig.org/psr/psr-12/), there MUST be a blank line above the `declare` statement (/block)