### PR TITLE
Update phinxlog as part of migration transaction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2
+FROM php:7.3
 
 # system dependecies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3
+FROM php:7.2
 
 # system dependecies
 RUN apt-get update && apt-get install -y \

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -110,6 +110,9 @@ class Environment
             } else {
                 $migration->{$direction}();
             }
+	    
+	    // Record it in the database
+            $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
 
             // commit the transaction if the adapter supports it
             if ($this->getAdapter()->hasTransactions()) {
@@ -118,9 +121,6 @@ class Environment
         }
 
         $migration->postFlightCheck();
-
-        // Record it in the database
-        $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
     }
 
     /**

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -110,16 +110,13 @@ class Environment
             } else {
                 $migration->{$direction}();
             }
-	    
-	        // Record it in the database
+            // Record it in the database
             $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
-
             // commit the transaction if the adapter supports it
             if ($this->getAdapter()->hasTransactions()) {
                 $this->getAdapter()->commitTransaction();
             }
         }
-
         $migration->postFlightCheck();
     }
 

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -110,6 +110,7 @@ class Environment
             } else {
                 $migration->{$direction}();
             }
+
             // Record it in the database
             $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
 

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -111,7 +111,7 @@ class Environment
                 $migration->{$direction}();
             }
 	    
-	    // Record it in the database
+	        // Record it in the database
             $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
 
             // commit the transaction if the adapter supports it

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -112,6 +112,7 @@ class Environment
             }
             // Record it in the database
             $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
+
             // commit the transaction if the adapter supports it
             if ($this->getAdapter()->hasTransactions()) {
                 $this->getAdapter()->commitTransaction();


### PR DESCRIPTION
Closes #2148 

PR makes it so that updating the phinxlog for the migration happens as part of the overall migration transaction, so that failing to update phinxlog would rollback the migration, instead of leaving the migration having been executed, but just not recorded.