### PR TITLE
Fix missing quoting on constraints name for sqlserver

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1018,7 +1018,7 @@ ORDER BY T.[name], I.[index_id];";
         $instructions->addPostStep(sprintf(
             'ALTER TABLE %s DROP CONSTRAINT %s',
             $this->quoteTableName($tableName),
-            $constraint
+            $this->quoteColumnName($constraint)
         ));
 
         return $instructions;


### PR DESCRIPTION
Test with a constraint that contains `-` sign. It will break with following error: `SQLSTATE[42000]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Incorrect syntax near '-'.`