### PR TITLE
Make check for CURRENT_TIMESTAMP in default value case insensitive

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -601,7 +601,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     {
         if ($default instanceof Literal) {
             $default = (string)$default;
-        } elseif (is_string($default) && strpos($default, 'CURRENT_TIMESTAMP') !== 0) {
+        } elseif (is_string($default) && stripos($default, 'CURRENT_TIMESTAMP') !== 0) {
             // Ensure a defaults of CURRENT_TIMESTAMP(3) is not quoted.
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {


### PR DESCRIPTION
Changes check for CURRENT_TIMESTAMP at the beginning of $default from case sensitive to case insensitive. Sometimes $default contains "current_timestamp()" in lower case and the case sensitive check fails.