### PR TITLE
Cache created decorated connection

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1531,7 +1531,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection(): Connection
+    protected function getDecoratedConnectionConfig(): array
     {
         $options = $this->getOptions();
         $options = [
@@ -1541,9 +1541,6 @@ class MysqlAdapter extends PdoAdapter
             'quoteIdentifiers' => true,
         ] + $options;
 
-        $driver = new MysqlDriver($options);
-        $driver->setConnection($this->connection);
-
-        return new Connection(['driver' => $driver] + $options);
+        return ['driver' => new MysqlDriver($options)] + $options;
     }
 }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -7,7 +7,6 @@
 
 namespace Phinx\Db\Adapter;
 
-use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql as MysqlDriver;
 use InvalidArgumentException;
 use PDO;

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -229,7 +229,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
 
         $config['driver']->setConnection($this->connection);
 
-        return $this->decoratedConnection = new Connection($this->getDecoratedConnectionConfig());
+        return $this->decoratedConnection = new Connection($config);
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1566,7 +1566,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection(): Connection
+    protected function getDecoratedConnectionConfig(): array
     {
         $options = $this->getOptions();
         $options = [
@@ -1576,11 +1576,7 @@ class PostgresAdapter extends PdoAdapter
             'quoteIdentifiers' => true,
         ] + $options;
 
-        $driver = new PostgresDriver($options);
-
-        $driver->setConnection($this->connection);
-
-        return new Connection(['driver' => $driver] + $options);
+        return ['driver' => new PostgresDriver($options)] + $options;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -7,7 +7,6 @@
 
 namespace Phinx\Db\Adapter;
 
-use Cake\Database\Connection;
 use Cake\Database\Driver\Postgres as PostgresDriver;
 use InvalidArgumentException;
 use PDO;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1932,7 +1932,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection(): Connection
+    protected function getDecoratedConnectionConfig(): array
     {
         $options = $this->getOptions();
         $options['quoteIdentifiers'] = true;
@@ -1949,9 +1949,6 @@ PCRE_PATTERN;
             throw new RuntimeException('You need to connect first.');
         }
 
-        $driver = new SqliteDriver($options);
-        $driver->setConnection($this->connection);
-
-        return new Connection(['driver' => $driver] + $options);
+        return ['driver' => new SqliteDriver($options)] + $options;
     }
 }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -8,7 +8,6 @@
 namespace Phinx\Db\Adapter;
 
 use BadMethodCallException;
-use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite as SqliteDriver;
 use InvalidArgumentException;
 use PDO;

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1359,7 +1359,7 @@ SQL;
     /**
      * @inheritDoc
      */
-    public function getDecoratedConnection(): Connection
+    protected function getDecoratedConnectionConfig(): array
     {
         $options = $this->getOptions();
         $options = [
@@ -1369,9 +1369,6 @@ SQL;
             'quoteIdentifiers' => true,
         ] + $options;
 
-        $driver = new SqlServerDriver($options);
-        $driver->setConnection($this->connection);
-
-        return new Connection(['driver' => $driver] + $options);
+        return ['driver' => new SqlServerDriver($options)] + $options;
     }
 }

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -8,7 +8,6 @@
 namespace Phinx\Db\Adapter;
 
 use BadMethodCallException;
-use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlserver as SqlServerDriver;
 use InvalidArgumentException;
 use PDO;


### PR DESCRIPTION
PR pulls a commit from the `1.x` branch, where when generating the decorated connection as part of `getDecoratedConnection`, since it's likely that each call to the function would always just return the same thing anyway currently, just with the overhead of creating a fresh class each time. This is most beneficial to people using the [Query Builder](https://book.cakephp.org/phinx/0/en/migrations.html#using-the-query-builder).

As part of this, I've moved `getDecoratedConnection` to be part of the base `PdoAdapter` class as it then allows some code sharing, while creating a new `getDecoratedConnectionConfig` function that gets the individual adapter code.