### PR TITLE
Cast versions to string (#2196)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     ],
     "require": {
-        "php-64bit": ">=7.3",
+        "php": ">=7.3",
         "cakephp/database": "^4.0",
         "psr/container": "^1.0 || ^2.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -165,7 +165,7 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      * @inheritDoc
-     * @return array<int>
+     * @return array<string>
      */
     public function getVersions(): array
     {

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -79,7 +79,7 @@ interface AdapterInterface
     /**
      * Get all migrated version numbers.
      *
-     * @return array<int>
+     * @return array<string>
      */
     public function getVersions(): array;
 
@@ -87,7 +87,7 @@ interface AdapterInterface
      * Get all migration log entries, indexed by version creation time and sorted ascendingly by the configuration's
      * version order option
      *
-     * @return array<int, mixed>
+     * @return array<string, mixed>
      */
     public function getVersionLog(): array;
 

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -389,7 +389,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         }
 
         foreach ($rows as $version) {
-            $result[(int)$version['version']] = $version;
+            $result[$version['version']] = $version;
         }
 
         return $result;

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -32,7 +32,7 @@ abstract class AbstractMigration implements MigrationInterface
     protected $environment;
 
     /**
-     * @var int
+     * @var string
      */
     protected $version;
 
@@ -67,11 +67,11 @@ abstract class AbstractMigration implements MigrationInterface
 
     /**
      * @param string $environment Environment Detected
-     * @param int $version Migration Version
+     * @param string $version Migration Version
      * @param \Symfony\Component\Console\Input\InputInterface|null $input Input
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output
      */
-    final public function __construct(string $environment, int $version, ?InputInterface $input = null, ?OutputInterface $output = null)
+    final public function __construct(string $environment, string $version, ?InputInterface $input = null, ?OutputInterface $output = null)
     {
         $this->environment = $environment;
         $this->version = $version;
@@ -158,7 +158,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function setVersion($version): MigrationInterface
+    public function setVersion(string $version): MigrationInterface
     {
         $this->version = $version;
 
@@ -168,7 +168,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getVersion(): int
+    public function getVersion(): string
     {
         return $this->version;
     }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -304,11 +304,11 @@ class Manager
      * Migrate an environment to the specified version.
      *
      * @param string $environment Environment
-     * @param int|null $version version to migrate to
+     * @param string|null $version version to migrate to
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function migrate(string $environment, ?int $version = null, bool $fake = false): void
+    public function migrate(string $environment, ?string $version = null, bool $fake = false): void
     {
         $migrations = $this->getMigrations($environment);
         $env = $this->getEnvironment($environment);
@@ -845,6 +845,24 @@ class Manager
         }
 
         return $this->migrations;
+    }
+
+    /**
+     * Returns a list of the versions of the migration file
+     * array_keys() of $this->migrations is not reliable on 32 bit systems
+     *
+     * @param string $environment Environment
+     * @return string[]
+     */
+    public function getVersions(string $environment): array
+    {
+        $migrations = $this->getMigrations($environment);
+        $versions = [];
+        foreach ($migrations as $migration) {
+            $versions[] = $migration->getVersion();
+        }
+
+        return $versions;
     }
 
     /**

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -39,7 +39,7 @@ class Environment
     protected $output;
 
     /**
-     * @var int
+     * @var string
      */
     protected $currentVersion;
 
@@ -267,10 +267,10 @@ class Environment
     /**
      * Sets the current version of the environment.
      *
-     * @param int $version Environment Version
+     * @param string $version Environment Version
      * @return $this
      */
-    public function setCurrentVersion(int $version)
+    public function setCurrentVersion(string $version)
     {
         $this->currentVersion = $version;
 
@@ -280,15 +280,15 @@ class Environment
     /**
      * Gets the current version of the environment.
      *
-     * @return int
+     * @return string
      */
-    public function getCurrentVersion(): int
+    public function getCurrentVersion(): string
     {
         // We don't cache this code as the current version is pretty volatile.
         // that means they're no point in a setter then?
         // maybe we should cache and call a reset() method every time a migration is run
         $versions = $this->getVersions();
-        $version = 0;
+        $version = '0';
 
         if (!empty($versions)) {
             $version = end($versions);

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -102,17 +102,17 @@ interface MigrationInterface
     /**
      * Sets the migration version number.
      *
-     * @param int $version Version
+     * @param string $version Version
      * @return $this
      */
-    public function setVersion(int $version);
+    public function setVersion(string $version);
 
     /**
      * Gets the migration version number.
      *
-     * @return int
+     * @return string
      */
-    public function getVersion(): int;
+    public function getVersion(): string;
 
     /**
      * Sets whether this migration is being applied or reverted

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -84,13 +84,13 @@ class Util
      * Get the version from the beginning of a file name.
      *
      * @param string $fileName File Name
-     * @return int
+     * @return string
      */
-    public static function getVersionFromFileName(string $fileName): int
+    public static function getVersionFromFileName(string $fileName): string
     {
         $matches = [];
         preg_match('/^[0-9]+/', basename($fileName), $matches);
-        $value = (int)($matches[0] ?? null);
+        $value = $matches[0] ?? null;
         if (!$value) {
             throw new RuntimeException(sprintf('Cannot get a valid version from filename `%s`', $fileName));
         }

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -129,7 +129,7 @@ class EnvironmentTest extends TestCase
 
         $this->environment->setAdapter($stub);
 
-        $this->assertEquals('20110301080000', $this->environment->getCurrentVersion());
+        $this->assertSame('20110301080000', $this->environment->getCurrentVersion());
     }
 
     public function testExecutingAMigrationUp()

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5532,6 +5532,12 @@ class ManagerTest extends TestCase
         }
     }
 
+    public function testGetVersions()
+    {
+        $versions = $this->manager->getVersions('mockenv');
+        $this->assertSame(['20120111235330', '20120116183504'], $versions);
+    }
+
     public function testGettingAnInvalidEnvironment()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -50,7 +50,7 @@ class UtilTest extends TestCase
 
     public function testGetVersionFromFileName(): void
     {
-        $this->assertSame(20221130101652, Util::getVersionFromFileName('20221130101652_test.php'));
+        $this->assertSame('20221130101652', Util::getVersionFromFileName('20221130101652_test.php'));
     }
 
     public function testGetVersionFromFileNameErrorNoVersion(): void


### PR DESCRIPTION
This PR enables the package to work on 32 bit environement, by keeping the migration version typed as strings.

A PR is ready for the cakephp/migrations package based on this PR.