### PR TITLE
Clarify where feature flags are in configuration file with a YAML example

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -521,6 +521,11 @@ For some breaking changes, Phinx offers a way to opt-out of new behavior. The fo
 * ``unsigned_primary_keys``: Should Phinx create primary keys as unsigned integers? (default: ``true``)
 * ``column_null_default``: Should Phinx create columns as null by default? (default: ``true``)
 
+.. code-block:: yaml
+
+    feature_flags:
+        unsigned_primary_keys: false
+
 These values can also be set by modifying class fields on the ```Phinx\Config\FeatureFlags``` class, converting
 the flag name to ``camelCase``, for example:
 


### PR DESCRIPTION
The feature flags documentation in configuration.rst now contains a YAML configuration example for them, to show that the flags belong in an array named `feature_flags`. Previously there was no mention of this, which made it unclear whether the flags belonged in the top level or under a specific configuration key.