### PR TITLE
Unify multi-column foreign key handling

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -909,9 +909,6 @@ class PostgresAdapter extends PdoAdapter
      */
     public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
-        if (is_string($columns)) {
-            $columns = [$columns]; // str to array
-        }
         $foreignKeys = $this->getForeignKeys($tableName);
         if ($constraint) {
             if (isset($foreignKeys[$constraint])) {
@@ -921,9 +918,12 @@ class PostgresAdapter extends PdoAdapter
             return false;
         }
 
+        if (is_string($columns)) {
+            $columns = [$columns];
+        }
+
         foreach ($foreignKeys as $key) {
-            $a = array_diff($columns, $key['columns']);
-            if (empty($a)) {
+            if ($key['columns'] === $columns) {
                 return true;
             }
         }
@@ -952,7 +952,7 @@ class PostgresAdapter extends PdoAdapter
                     JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
                     JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
                 WHERE constraint_type = 'FOREIGN KEY' AND tc.table_schema = %s AND tc.table_name = %s
-                ORDER BY kcu.position_in_unique_constraint",
+                ORDER BY kcu.ordinal_position",
             $this->getConnection()->quote($parts['schema']),
             $this->getConnection()->quote($parts['table'])
         ));
@@ -961,6 +961,10 @@ class PostgresAdapter extends PdoAdapter
             $foreignKeys[$row['constraint_name']]['columns'][] = $row['column_name'];
             $foreignKeys[$row['constraint_name']]['referenced_table'] = $row['referenced_table_name'];
             $foreignKeys[$row['constraint_name']]['referenced_columns'][] = $row['referenced_column_name'];
+        }
+        foreach ($foreignKeys as $name => $key) {
+            $foreignKeys[$name]['columns'] = array_values(array_unique($key['columns']));
+            $foreignKeys[$name]['referenced_columns'] = array_values(array_unique($key['referenced_columns']));
         }
 
         return $foreignKeys;
@@ -999,37 +1003,25 @@ class PostgresAdapter extends PdoAdapter
     {
         $instructions = new AlterInstructions();
 
-        $parts = $this->getSchemaName($tableName);
-        $sql = 'SELECT c.CONSTRAINT_NAME
-                FROM (
-                    SELECT CONSTRAINT_NAME, array_agg(COLUMN_NAME::varchar) as columns
-                    FROM information_schema.KEY_COLUMN_USAGE
-                    WHERE TABLE_SCHEMA = %s
-                    AND TABLE_NAME IS NOT NULL
-                    AND TABLE_NAME = %s
-                    AND POSITION_IN_UNIQUE_CONSTRAINT IS NOT NULL
-                    GROUP BY CONSTRAINT_NAME
-                ) c
-                WHERE
-                    ARRAY[%s]::varchar[] <@ c.columns AND
-                    ARRAY[%s]::varchar[] @> c.columns';
-
-        $array = [];
-        foreach ($columns as $col) {
-            $array[] = "'$col'";
+        $matches = [];
+        $foreignKeys = $this->getForeignKeys($tableName);
+        foreach ($foreignKeys as $name => $key) {
+            if ($key['columns'] === $columns) {
+                $matches[] = $name;
+            }
         }
 
-        $rows = $this->fetchAll(sprintf(
-            $sql,
-            $this->getConnection()->quote($parts['schema']),
-            $this->getConnection()->quote($parts['table']),
-            implode(',', $array),
-            implode(',', $array)
-        ));
+        if (empty($matches)) {
+            throw new InvalidArgumentException(sprintf(
+                'No foreign key on column(s) `%s` exists',
+                implode(', ', $columns)
+            ));
+        }
 
-        foreach ($rows as $row) {
-            $newInstr = $this->getDropForeignKeyInstructions($tableName, $row['constraint_name']);
-            $instructions->merge($newInstr);
+        foreach ($matches as $name) {
+            $instructions->merge(
+                $this->getDropForeignKeyInstructions($tableName, $name)
+            );
         }
 
         return $instructions;

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -271,6 +271,39 @@ class SQLiteAdapter extends PdoAdapter
     }
 
     /**
+     * Generates a regular expression to match identifiers that may or
+     * may not be quoted with any of the supported quotes.
+     *
+     * @param string $identifier The identifier to match.
+     * @param bool $spacedNoQuotes Whether the non-quoted identifier requires to be surrounded by whitespace.
+     * @return string
+     */
+    protected function possiblyQuotedIdentifierRegex(string $identifier, bool $spacedNoQuotes = true): string
+    {
+        $identifiers = [];
+        $identifier = preg_quote($identifier, '/');
+
+        $hasTick = str_contains($identifier, '`');
+        $hasDoubleQuote = str_contains($identifier, '"');
+        $hasSingleQuote = str_contains($identifier, "'");
+
+        $identifiers[] = '\[' . $identifier . '\]';
+        $identifiers[] = '`' . ($hasTick ? str_replace('`', '``', $identifier) : $identifier) . '`';
+        $identifiers[] = '"' . ($hasDoubleQuote ? str_replace('"', '""', $identifier) : $identifier) . '"';
+        $identifiers[] = "'" . ($hasSingleQuote ? str_replace("'", "''", $identifier) : $identifier) . "'";
+
+        if (!$hasTick && !$hasDoubleQuote && !$hasSingleQuote) {
+            if ($spacedNoQuotes) {
+                $identifiers[] = "\s+$identifier\s+";
+            } else {
+                $identifiers[] = $identifier;
+            }
+        }
+
+        return '(' . implode('|', $identifiers) . ')';
+    }
+
+    /**
      * @param string $tableName Table name
      * @param bool $quoted Whether to return the schema name and table name escaped and quoted. If quoted, the schema (if any) will also be appended with a dot
      * @return array
@@ -757,11 +790,11 @@ PCRE_PATTERN;
         $columnsInfo = $this->getTableInfo($tableName);
 
         foreach ($columnsInfo as $column) {
-            $columnName = $column['name'];
+            $columnName = preg_quote($column['name'], '#');
             $columnNamePattern = "\"$columnName\"|`$columnName`|\\[$columnName\\]|$columnName";
             $columnNamePattern = "#([\(,]+\\s*)($columnNamePattern)(\\s)#iU";
 
-            $sql = preg_replace($columnNamePattern, "$1`$columnName`$3", $sql);
+            $sql = preg_replace($columnNamePattern, "$1`{$column['name']}`$3", $sql);
         }
 
         $tableNamePattern = "\"$tableName\"|`$tableName`|\\[$tableName\\]|$tableName";
@@ -1489,21 +1522,17 @@ PCRE_PATTERN;
     {
         if ($constraint !== null) {
             return preg_match(
-                "/,?\sCONSTRAINT\s" . preg_quote($this->quoteColumnName($constraint)) . ' FOREIGN KEY/',
+                "/,?\s*CONSTRAINT\s*" . $this->possiblyQuotedIdentifierRegex($constraint) . '\s*FOREIGN\s+KEY/is',
                 $this->getDeclaringSql($tableName)
             ) === 1;
         }
 
-        $columns = array_map('strtolower', (array)$columns);
-        $foreignKeys = $this->getForeignKeys($tableName);
+        $columns = array_map('mb_strtolower', (array)$columns);
 
-        foreach ($foreignKeys as $key) {
-            $key = array_map('strtolower', $key);
-            if (array_diff($key, $columns) || array_diff($columns, $key)) {
-                continue;
+        foreach ($this->getForeignKeys($tableName) as $key) {
+            if (array_map('mb_strtolower', $key) === $columns) {
+                return true;
             }
-
-            return true;
         }
 
         return false;
@@ -1671,18 +1700,27 @@ PCRE_PATTERN;
      */
     protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions
     {
+        if (!$this->hasForeignKey($tableName, $columns)) {
+            throw new InvalidArgumentException(sprintf(
+                'No foreign key on column(s) `%s` exists',
+                implode(', ', $columns)
+            ));
+        }
+
         $instructions = $this->beginAlterByCopyTable($tableName);
 
         $instructions->addPostStep(function ($state) use ($columns) {
-            $sql = '';
-
-            foreach ($columns as $columnName) {
-                $search = sprintf(
-                    "/,[^,]*\(%s(?:,`?(.*)`?)?\) REFERENCES[^,]*\([^\)]*\)[^,)]*/",
-                    $this->quoteColumnName($columnName)
-                );
-                $sql = preg_replace($search, '', $state['createSQL'], 1);
-            }
+            $search = sprintf(
+                "/,[^,]+?\(\s*%s\s*\)\s*REFERENCES[^,]*\([^\)]*\)[^,)]*/is",
+                implode(
+                    '\s*,\s*',
+                    array_map(
+                        fn ($column) => $this->possiblyQuotedIdentifierRegex($column, false),
+                        $columns
+                    )
+                ),
+            );
+            $sql = preg_replace($search, '', $state['createSQL']);
 
             if ($sql) {
                 $this->execute($sql);
@@ -1691,18 +1729,8 @@ PCRE_PATTERN;
             return $state;
         });
 
-        $instructions->addPostStep(function ($state) use ($columns) {
-            $newState = $this->calculateNewTableColumns($state['tmpTableName'], $columns[0], $columns[0]);
-
-            $selectColumns = $newState['selectColumns'];
-            $columns = array_map([$this, 'quoteColumnName'], $columns);
-            $diff = array_diff($columns, $selectColumns);
-
-            if (!empty($diff)) {
-                throw new InvalidArgumentException(sprintf(
-                    'The specified columns don\'t exist: ' . implode(', ', $diff)
-                ));
-            }
+        $instructions->addPostStep(function ($state) {
+            $newState = $this->calculateNewTableColumns($state['tmpTableName'], false, false);
 
             return $newState + $state;
         });

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Test\Phinx\Db\Adapter;
 
 use Cake\Database\Query;
+use InvalidArgumentException;
 use Phinx\Db\Adapter\AbstractAdapter;
 use Phinx\Db\Adapter\PostgresAdapter;
 use Phinx\Db\Adapter\UnsupportedColumnTypeException;
@@ -1550,6 +1551,227 @@ class PostgresAdapterTest extends TestCase
 
         $table->dropForeignKey(['ref_table_id'])->save();
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+    }
+
+    public function testDropForeignKeyWithMultipleColumns()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addColumn('field2', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->addIndex(['field1', 'id'], ['unique' => true])
+            ->addIndex(['id', 'field1', 'field2'], ['unique' => true])
+            ->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_field1', 'string')
+            ->addColumn('ref_table_field2', 'string')
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->addForeignKey(
+                ['ref_table_field1', 'ref_table_id'],
+                'ref_table',
+                ['field1', 'id']
+            )
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1', 'ref_table_field2'],
+                'ref_table',
+                ['id', 'field1', 'field2']
+            )
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertTrue(
+            $this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1', 'ref_table_field2']),
+            'dropForeignKey() should only affect foreign keys that comprise of exactly the given columns'
+        );
+        $this->assertTrue(
+            $this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']),
+            'dropForeignKey() should only affect foreign keys that comprise of columns in exactly the given order'
+        );
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']));
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']));
+    }
+
+    public function testDropForeignKeyWithIdenticalMultipleColumns()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addColumn('ref_table_field1', 'string')
+            ->addForeignKeyWithName(
+                'ref_table_fk_1',
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1'],
+            )
+            ->addForeignKeyWithName(
+                'ref_table_fk_2',
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_1'));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
+
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']);
+
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_1'));
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
+    }
+
+    public function nonExistentForeignKeyColumnsProvider(): array
+    {
+        return [
+            [['ref_table_id']],
+            [['ref_table_field1']],
+            [['ref_table_field1', 'ref_table_id']],
+            [['non_existent_column']],
+        ];
+    }
+
+    /**
+     * @dataProvider nonExistentForeignKeyColumnsProvider
+     * @param array $columns
+     */
+    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_field1', 'string')
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->save();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'No foreign key on column(s) `%s` exists',
+            implode(', ', $columns)
+        ));
+
+        $this->adapter->dropForeignKey($table->getName(), $columns);
+    }
+
+    public function testDropForeignKeyCaseSensitivity()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('REF_TABLE_ID', 'integer')
+            ->addForeignKey(['REF_TABLE_ID'], 'ref_table', ['id'])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['REF_TABLE_ID']));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'No foreign key on column(s) `%s` exists',
+            implode(', ', ['ref_table_id'])
+        ));
+
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id']);
+    }
+
+    public function testDropForeignKeyByName()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->save();
+
+        $this->adapter->dropForeignKey($table->getName(), [], 'my_constraint');
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+    }
+
+    /**
+     * @dataProvider provideForeignKeysToCheck
+     */
+    public function testHasForeignKey($tableDef, $key, $exp)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec('CREATE TABLE other(a int, b int, c int, unique(a), unique(b), unique(a,b), unique(a,b,c));');
+        $conn->exec($tableDef);
+        $this->assertSame($exp, $this->adapter->hasForeignKey('t', $key));
+    }
+
+    public function provideForeignKeysToCheck()
+    {
+        return [
+            ['create table t(a int)', 'a', false],
+            ['create table t(a int)', [], false],
+            ['create table t(a int primary key)', 'a', false],
+            ['create table t(a int, foreign key (a) references other(a))', 'a', true],
+            ['create table t(a int, foreign key (a) references other(b))', 'a', true],
+            ['create table t(a int, foreign key (a) references other(b))', ['a'], true],
+            ['create table t(a int, foreign key (a) references other(b))', ['a', 'a'], false],
+            ['create table t(a int, foreign key(a) references other(a))', 'a', true],
+            ['create table t(a int, b int, foreign key(a,b) references other(a,b))', 'a', false],
+            ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
+            ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['b', 'a'], false],
+            ['create table t(a int, "B" int, foreign key(a,"B") references other(a,b))', ['a', 'b'], false],
+            ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['a', 'B'], false],
+            ['create table t(a int, b int, c int, foreign key(a,b,c) references other(a,b,c))', ['a', 'b'], false],
+            ['create table t(a int, foreign key(a) references other(a))', ['a', 'b'], false],
+            ['create table t(a int, b int, foreign key(a) references other(a), foreign key(b) references other(b))', ['a', 'b'], false],
+            ['create table t(a int, b int, foreign key(a) references other(a), foreign key(b) references other(b))', ['a', 'b'], false],
+            ['create table t("0" int, foreign key("0") references other(a))', '0', true],
+            ['create table t("0" int, foreign key("0") references other(a))', '0e0', false],
+            ['create table t("0e0" int, foreign key("0e0") references other(a))', '0', false],
+        ];
+    }
+
+    public function testHasNamedForeignKey()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id'], 'my_constraint'));
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id'], 'my_constraint2'));
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'my_constraint'));
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'my_constraint2'));
     }
 
     public function testDropForeignKeyWithSchema()

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1371,21 +1371,224 @@ class SQLiteAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasTable($table->getName()));
     }
 
-    public function testFailingDropForeignKey()
+    public function testDropForeignKeyWithQuoteVariants()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable->addColumn('field1', 'string')
+            ->addIndex(['field1'], ['unique' => true])
+            ->save();
+
+        $this->adapter->execute("
+            CREATE TABLE `table` (
+                `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                [ref_[_brackets] INTEGER NOT NULL,
+                `ref_``_ticks` INTEGER NOT NULL,
+                \"ref_\"\"_double_quotes\" INTEGER NOT NULL,
+                'ref_''_single_quotes' INTEGER NOT NULL,
+                ref_no_quotes INTEGER NOT NULL,
+                ref_no_space INTEGER NOT NULL,
+                ref_lots_of_space INTEGER NOT NULL,
+                FOREIGN KEY ([ref_[_brackets]) REFERENCES `ref_table` (`id`),
+                FOREIGN KEY (`ref_``_ticks`) REFERENCES `ref_table` (`id`),
+                FOREIGN KEY (\"ref_\"\"_double_quotes\") REFERENCES `ref_table` (`id`),
+                FOREIGN KEY ('ref_''_single_quotes') REFERENCES `ref_table` (`id`),
+                FOREIGN KEY (ref_no_quotes) REFERENCES `ref_table` (`id`),
+                FOREIGN KEY (`ref_``_ticks`, 'ref_''_single_quotes') REFERENCES `ref_table` (`id`, `field1`),
+                FOREIGN KEY(`ref_no_space`,`ref_no_space`)REFERENCES`ref_table`(`id`,`id`),
+                foreign      KEY
+                    ( `ref_lots_of_space`		,`ref_lots_of_space`    )
+                        REFErences   `ref_table`  (`id`    ,	`id`)
+            )
+        ");
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_[_brackets']));
+        $this->adapter->dropForeignKey('table', ['ref_[_brackets']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_[_brackets']));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_"_double_quotes']));
+        $this->adapter->dropForeignKey('table', ['ref_"_double_quotes']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_"_double_quotes']));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ["ref_'_single_quotes"]));
+        $this->adapter->dropForeignKey('table', ["ref_'_single_quotes"]);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ["ref_'_single_quotes"]));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_no_quotes']));
+        $this->adapter->dropForeignKey('table', ['ref_no_quotes']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_no_quotes']));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_`_ticks', "ref_'_single_quotes"]));
+        $this->adapter->dropForeignKey('table', ['ref_`_ticks', "ref_'_single_quotes"]);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_`_ticks', "ref_'_single_quotes"]));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_no_space', 'ref_no_space']));
+        $this->adapter->dropForeignKey('table', ['ref_no_space', 'ref_no_space']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_no_space', 'ref_no_space']));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_lots_of_space', 'ref_lots_of_space']));
+        $this->adapter->dropForeignKey('table', ['ref_lots_of_space', 'ref_lots_of_space']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_lots_of_space', 'ref_lots_of_space']));
+    }
+
+    public function testDropForeignKeyWithMultipleColumns()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addColumn('field2', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->addIndex(['field1', 'id'], ['unique' => true])
+            ->addIndex(['id', 'field1', 'field2'], ['unique' => true])
+            ->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_field1', 'string')
+            ->addColumn('ref_table_field2', 'string')
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->addForeignKey(
+                ['ref_table_field1', 'ref_table_id'],
+                'ref_table',
+                ['field1', 'id']
+            )
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1', 'ref_table_field2'],
+                'ref_table',
+                ['id', 'field1', 'field2']
+            )
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertTrue(
+            $this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1', 'ref_table_field2']),
+            'dropForeignKey() should only affect foreign keys that comprise of exactly the given columns'
+        );
+        $this->assertTrue(
+            $this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']),
+            'dropForeignKey() should only affect foreign keys that comprise of columns in exactly the given order'
+        );
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']));
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']));
+    }
+
+    public function testDropForeignKeyWithIdenticalMultipleColumns()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addColumn('ref_table_field1', 'string')
+            ->addForeignKeyWithName(
+                'ref_table_fk_1',
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1'],
+            )
+            ->addForeignKeyWithName(
+                'ref_table_fk_2',
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_1'));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
+
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']);
+
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_1'));
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
+    }
+
+    public function nonExistentForeignKeyColumnsProvider(): array
+    {
+        return [
+            [['ref_table_id']],
+            [['ref_table_field1']],
+            [['ref_table_field1', 'ref_table_id']],
+            [['non_existent_column']],
+        ];
+    }
+
+    /**
+     * @dataProvider nonExistentForeignKeyColumnsProvider
+     * @param array $columns
+     */
+    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_field1', 'string')
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->save();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'No foreign key on column(s) `%s` exists',
+            implode(', ', $columns)
+        ));
+
+        $this->adapter->dropForeignKey($table->getName(), $columns);
+    }
+
+    public function testDropForeignKeyCaseInsensitivity()
     {
         $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
         $refTable->save();
 
-        $table = new \Phinx\Db\Table('another_table', [], $this->adapter);
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer')
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/test/');
+        $this->adapter->dropForeignKey($table->getName(), ['REF_TABLE_ID']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+    }
 
-        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'test']);
+    public function testDropForeignKeyByName()
+    {
+        $this->expectExceptionMessage('SQLite does not have named foreign keys');
+        $this->expectException(BadMethodCallException::class);
+
+        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable->save();
+
+        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->save();
+
+        $this->adapter->dropForeignKey($table->getName(), [], 'my_constraint');
     }
 
     public function testHasDatabase()
@@ -2309,12 +2512,12 @@ INPUT;
             ['create table t(a integer references other(a))', 'a', true],
             ['create table t(a integer references other(b))', 'a', true],
             ['create table t(a integer references other(b))', ['a'], true],
-            ['create table t(a integer references other(b))', ['a', 'a'], true], // duplicate column is collapsed
+            ['create table t(a integer references other(b))', ['a', 'a'], false],
             ['create table t(a integer, foreign key(a) references other(a))', 'a', true],
             ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', 'a', false],
             ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
-            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['b', 'a'], true],
-            ['create table t(a integer, "B" integer, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['b', 'a'], false],
+            ['create table t(a integer, "B" integer, foreign key(a,"B") references other(a,b))', ['a', 'b'], true],
             ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'B'], true],
             ['create table t(a integer, b integer, c integer, foreign key(a,b,c) references other(a,b,c))', ['a', 'b'], false],
             ['create table t(a integer, foreign key(a) references other(a))', ['a', 'b'], false],
@@ -2351,6 +2554,14 @@ INPUT;
             `parent_2_id` INTEGER NOT NULL,
             `parent_3_id` INTEGER NOT NULL,
             CONSTRAINT `fk_parent_1_id` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT [fk_[_brackets] FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT `fk_``_ticks` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT \"fk_\"\"_double_quotes\" FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT 'fk_''_single_quotes' FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT fk_no_quotes FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT`fk_no_space`FOREIGN KEY(`parent_1_id`)REFERENCES`tbl_parent_1`(`id`),
+            constraint
+                `fk_lots_of_space`    FOReign		KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
             FOREIGN KEY (`parent_2_id`) REFERENCES `tbl_parent_2` (`id`),
             CONSTRAINT `check_constraint_1` CHECK (column<>'world'),
             CONSTRAINT `fk_composite_key` FOREIGN KEY (`parent_3_id`,`column`) REFERENCES `tbl_parent_3` (`id`,`column`)
@@ -2358,6 +2569,13 @@ INPUT;
         )");
 
         $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_parent_1_id'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_[_brackets'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_`_ticks'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_"_double_quotes'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], "fk_'_single_quotes"));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_no_quotes'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_no_space'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_lots_of_space'));
         $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['parent_1_id']));
         $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['parent_2_id']));
         $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_composite_key'));


### PR DESCRIPTION
Multi-column foreign key support is currently very much broken, and there is no consistency in the behavior of `dropForeignKey()` and `hasForeignKey()` accross the various DBMS.

Currently the behavior looks like this:

|                                       | MySQL | Postgres | Sqlite | SQL Server |
|---------------------------------------|:-----:|:--------:|:------:|:----------:|
| Case-sensitive drop                   |   no  |    yes   |   yes  |     no¹    |
| Case-sensitive lookup                 |  yes  |    yes   |    no  |    yes¹    |
| Multi-column drop                     |  no²  |    yes   |   no³  |     no²    |
| Drop all column matches               |  yes  |    yes   |    no  |     yes    |
| Column order dependent drop           |   no  |     no   |    no  |      no    |
| Column order dependent lookup         |  yes  |     no   |    no  |      no    |
| Silently drop non-existent by columns |   no  |    yes   |    no  |     yes    |
| Silently drop non-existent by name    |   no  |     no   |     -  |      no    |

<sup>1) In a case sensitive database the query would produce an error.</sup>
<sup>2) Generates duplicate drop instructions, one for every key that has any of the given columns.</sup>
<sup>3) For every column, the first key that starts with that column would be deleted.</sup>

With these changes, the new behavior would be as follows:

|                                       | MySQL | Postgres | Sqlite | SQL Server |
|---------------------------------------|:-----:|:--------:|:------:|:----------:|
| Case-sensitive drop                   |   no  |   yes¹   |    no  |    yes¹    |
| Case-sensitive lookup                 |   no  |   yes¹   |    no  |    yes¹    |
| Multi-column drop                     |  yes  |    yes   |   yes  |     yes    |
| Drop all column matches               |  yes  |    yes   |   yes  |     yes    |
| Column order dependent drop           |  yes  |    yes   |   yes  |     yes    |
| Column order dependent lookup         |  yes  |    yes   |   yes  |     yes    |
| Silently drop non-existent by columns |   no  |     no   |    no  |      no    |
| Silently drop non-existent by name    |   no  |     no   |     -  |      no    |

<sup>1) The behavior is independent of whether the database/column is actually case-sensitive.<sup>

My reasoning for making dropping and looking up foreigny keys by column require to pass the columns in the exact order in which the columns appear in the foreign key definition, is the fact that it is possible to define multiple foreign keys using the same columns. Whether it makes sense to do that, well, I don't really know, but it's very much possible, so I'd rather be strict about it, and have for example `dropForeignKey(['a', 'b'])` only drop foreign keys that where defined as `(a, b)`, and not the ones defined as `(b, a)`. In the end consistency might be more important though, so please feel free to disagree, changing the behavior is easy enough (Sqlite might be a bit tricky).

Dropping all foreign keys that match the given columns in the correct order might be contentiuous. Not doing so would however mean that one would have to generate one call for each of those keys, and there would not really be any control over which key is being deleted exactly, it would simply be the first match, so it's not like one could drop only a specific key in a group of keys with the same order of columns anyways.

On a related note, the foreign key lookup queries for Postgres and SqlServer produce a lot of duplicates, so those queries might need to be optimized, but I don't really wanted to touch that right now, there's too many pitfalls for my taste, so I've chosen the easy route and just reduced the results, that's good enough to me for now. I only fixed up the ordering for Postgres, as it was sorting by the column order in the related unique constraint, not by the column order in the actual foreign key constraint.

Also this PR relaxes the foreign key SQL parsing for Sqlite, for better compatibility with existing databases that may not adhere to the exact syntax that Phinx creates.