### PR TITLE
Fix PostgresAdapter not returning limit for char and varchar

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -474,13 +474,7 @@ class PostgresAdapter extends PdoAdapter
 
             if (in_array($columnType, [static::PHINX_TYPE_TIME, static::PHINX_TYPE_DATETIME], true)) {
                 $column->setPrecision($columnInfo['datetime_precision']);
-            } elseif (
-                !in_array($columnType, [
-                    self::PHINX_TYPE_SMALL_INTEGER,
-                    self::PHINX_TYPE_INTEGER,
-                    self::PHINX_TYPE_BIG_INTEGER,
-                ], true)
-            ) {
+            } elseif ($columnType === self::PHINX_TYPE_DECIMAL) {
                 $column->setPrecision($columnInfo['numeric_precision']);
             }
             $columns[] = $column;

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -758,6 +758,25 @@ class PostgresAdapterTest extends TestCase
         );
     }
 
+    public function testAddStringWithLimit()
+    {
+        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table->save();
+        $table->addColumn('string1', 'string', ['limit' => 10])
+                ->addColumn('char1', 'char', ['limit' => 20])
+                ->save();
+        $columns = $this->adapter->getColumns('table1');
+        foreach ($columns as $column) {
+            if ($column->getName() === 'string1') {
+                    $this->assertEquals('10', $column->getLimit());
+            }
+
+            if ($column->getName() === 'char1') {
+                    $this->assertEquals('20', $column->getLimit());
+            }
+        }
+    }
+
     public function testAddDecimalWithPrecisionAndScale()
     {
         $table = new \Phinx\Db\Table('table1', [], $this->adapter);

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -6147,26 +6147,16 @@ class ManagerTest extends TestCase
         $this->assertArrayHasKey(3, $columns);
         $this->assertArrayHasKey(4, $columns);
 
-        $limit = 15;
-        if ($adapter->getAdapterType() === 'pgsql') {
-            $limit = null;
-        }
-
         $column = $columns[3];
         $this->assertSame('phone_number', $column->getName());
         $this->assertSame('string', $column->getType());
-        $this->assertSame($limit, $column->getLimit());
+        $this->assertSame(15, $column->getLimit());
         $this->assertTrue($column->getNull());
-
-        $limit = 30;
-        if ($adapter->getAdapterType() === 'pgsql') {
-            $limit = null;
-        }
 
         $column = $columns[4];
         $this->assertSame('phone_number_ext', $column->getName());
         $this->assertSame('string', $column->getType());
-        $this->assertSame($limit, $column->getLimit());
+        $this->assertSame(30, $column->getLimit());
         $this->assertFalse($column->getNull());
     }
 }


### PR DESCRIPTION
Fixes #2213 

Check to see if numeric_precision is set, before calling setPrecision in PostgresAdapter, to avoid unsetting the limit previously set while getting columns from the database.
Added testAddStringWithLimit to PostgresAdapterTest to ensure that limits are being properly set.
Updated ManagerTest->testMigrationWithCustomColumnTypes to no longer expect pgsql to return null for limit of custom columns.