### PR TITLE
Add/improve type declarations for PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
+          - php-version: '8.3'
+            db-type: sqlite
+            prefer-lowest: ''
           - php-version: '8.1'
             db-type: sqlite
             prefer-lowest: prefer-lowest

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "phpunit/phpunit": "^9.5.19",
         "sebastian/comparator": ">=1.2.3",
         "cakephp/cakephp": "^5.0",
-        "cakephp/cakephp-codesniffer": "^4.0",
+        "cakephp/cakephp-codesniffer": "^5.0",
         "symfony/yaml": "^3.4|^4.0|^5.0|^6.0"
     },
     "autoload": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,16 +2,12 @@
 <ruleset name="Phinx">
     <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
 
+    <rule ref="CakePHP"/>
+
     <arg value="nps"/>
 
     <file>src/</file>
     <file>tests/</file>
 
     <exclude-pattern>*_files*</exclude-pattern>
-
-    <rule ref="CakePHP"/>
-
-    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
-        <severity>0</severity>
-    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15,13 +15,3 @@ parameters:
 			count: 2
 			path: src/Phinx/Db/Adapter/SqlServerAdapter.php
 
-		-
-			message: "#^Property Phinx\\\\Migration\\\\Manager\\\\Environment\\:\\:\\$adapter \\(Phinx\\\\Db\\\\Adapter\\\\AdapterInterface\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: src/Phinx/Migration/Manager/Environment.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: src/Phinx/Migration/Manager/Environment.php
-

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -12,15 +12,13 @@ use InvalidArgumentException;
 use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Util\Util;
 use Psr\Container\ContainerInterface;
+use ReturnTypeWillChange;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 use UnexpectedValueException;
 
 /**
  * Phinx configuration class.
- *
- * @package Phinx
- * @author Rob Morgan
  */
 class Config implements ConfigInterface, NamespaceAwareInterface
 {
@@ -42,12 +40,12 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @var array
      */
-    protected $values = [];
+    protected array $values = [];
 
     /**
      * @var string|null
      */
-    protected $configFilePath;
+    protected ?string $configFilePath = null;
 
     /**
      * @param array $configArray Config array
@@ -328,7 +326,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritdoc
      */
-    public function getTemplateFile()
+    public function getTemplateFile(): string|false
     {
         if (!isset($this->values['templates']['file'])) {
             return false;
@@ -340,7 +338,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritdoc
      */
-    public function getTemplateClass()
+    public function getTemplateClass(): string|false
     {
         if (!isset($this->values['templates']['class'])) {
             return false;
@@ -410,7 +408,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
     /**
      * @inheritdoc
      */
-    public function getBootstrapFile()
+    public function getBootstrapFile(): string|false
     {
         if (!isset($this->values['paths']['bootstrap'])) {
             return false;
@@ -511,7 +509,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
      * @throws \InvalidArgumentException
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($id)
     {
         if (!array_key_exists($id, $this->values)) {

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -12,9 +12,6 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Phinx configuration interface.
- *
- * @package Phinx
- * @author Woody Gilk
  */
 interface ConfigInterface extends ArrayAccess
 {
@@ -95,14 +92,14 @@ interface ConfigInterface extends ArrayAccess
      *
      * @return string|false
      */
-    public function getTemplateFile();
+    public function getTemplateFile(): string|false;
 
     /**
      * Get the template class name.
      *
      * @return string|false
      */
-    public function getTemplateClass();
+    public function getTemplateClass(): string|false;
 
     /**
      * Get the template style to use, either change or up_down.
@@ -144,7 +141,7 @@ interface ConfigInterface extends ArrayAccess
      *
      * @return string|false
      */
-    public function getBootstrapFile();
+    public function getBootstrapFile(): string|false;
 
     /**
      * Gets the base class name for migrations.

--- a/src/Phinx/Config/FeatureFlags.php
+++ b/src/Phinx/Config/FeatureFlags.php
@@ -17,11 +17,11 @@ class FeatureFlags
     /**
      * @var bool Should Phinx create unsigned primary keys by default?
      */
-    public static $unsignedPrimaryKeys = true;
+    public static bool $unsignedPrimaryKeys = true;
     /**
      * @var bool Should Phinx create columns NULL by default?
      */
-    public static $columnNullDefault = true;
+    public static bool $columnNullDefault = true;
 
     /**
      * Set the feature flags from the `feature_flags` section of the overall

--- a/src/Phinx/Config/NamespaceAwareInterface.php
+++ b/src/Phinx/Config/NamespaceAwareInterface.php
@@ -9,9 +9,6 @@ namespace Phinx\Config;
 
 /**
  * Config aware getNamespaceByPath method.
- *
- * @package Phinx\Config
- * @author Andrey N. Mokhov
  */
 interface NamespaceAwareInterface
 {

--- a/src/Phinx/Config/NamespaceAwareTrait.php
+++ b/src/Phinx/Config/NamespaceAwareTrait.php
@@ -9,9 +9,6 @@ namespace Phinx\Config;
 
 /**
  * Trait implemented NamespaceAwareInterface.
- *
- * @package Phinx\Config
- * @author Andrey N. Mokhov
  */
 trait NamespaceAwareTrait
 {

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -23,8 +24,6 @@ use UnexpectedValueException;
 
 /**
  * Abstract command, contains bootstrapping info
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 abstract class AbstractCommand extends Command
 {
@@ -52,22 +51,22 @@ abstract class AbstractCommand extends Command
     /**
      * @var \Phinx\Config\ConfigInterface|null
      */
-    protected $config;
+    protected ?ConfigInterface $config = null;
 
     /**
      * @var \Phinx\Db\Adapter\AdapterInterface
      */
-    protected $adapter;
+    protected AdapterInterface $adapter;
 
     /**
      * @var \Phinx\Migration\Manager
      */
-    protected $manager;
+    protected Manager $manager;
 
     /**
      * @var int
      */
-    protected $verbosityLevel = OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL;
+    protected int $verbosityLevel = OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL;
 
     /**
      * Exit code for when command executes successfully
@@ -235,7 +234,7 @@ abstract class AbstractCommand extends Command
      */
     public function getManager(): ?Manager
     {
-        return $this->manager;
+        return $this->manager ?? null;
     }
 
     /**
@@ -342,7 +341,7 @@ abstract class AbstractCommand extends Command
      */
     protected function loadManager(InputInterface $input, OutputInterface $output): void
     {
-        if ($this->getManager() === null) {
+        if (!isset($this->manager)) {
             $manager = new Manager($this->getConfig(), $input, $output);
             $manager->setVerbosityLevel($this->verbosityLevel);
             $container = $this->getConfig()->getContainer();

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -19,6 +20,7 @@ class Breakpoint extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'breakpoint';
 
     /**

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -27,6 +28,7 @@ class Create extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'create';
 
     /**

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -23,7 +24,7 @@ class Init extends Command
     /**
      * @var string[]
      */
-    protected static $supportedFormats = [
+    protected static array $supportedFormats = [
         AbstractCommand::FORMAT_JSON,
         AbstractCommand::FORMAT_YML_ALIAS,
         AbstractCommand::FORMAT_YML,
@@ -33,6 +34,7 @@ class Init extends Command
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'init';
 
     /**

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -18,6 +19,7 @@ class ListAliases extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'list:aliases';
 
     /**

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -21,6 +22,7 @@ class Migrate extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'migrate';
 
     /**

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -20,6 +21,7 @@ class Rollback extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'rollback';
 
     /**

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -26,6 +27,7 @@ class SeedCreate extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'seed:create';
 
     /**

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -18,6 +19,7 @@ class SeedRun extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'seed:run';
 
     /**

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -18,6 +19,7 @@ class Status extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'status';
 
     /**

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -21,6 +22,7 @@ class Test extends AbstractCommand
     /**
      * @var string|null
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     protected static $defaultName = 'test';
 
     /**

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -23,8 +24,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Phinx console application.
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 class PhinxApplication extends Application
 {

--- a/src/Phinx/Db/Action/Action.php
+++ b/src/Phinx/Db/Action/Action.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -14,7 +15,7 @@ abstract class Action
     /**
      * @var \Phinx\Db\Table\Table
      */
-    protected $table;
+    protected Table $table;
 
     /**
      * Constructor

--- a/src/Phinx/Db/Action/AddColumn.php
+++ b/src/Phinx/Db/Action/AddColumn.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -9,6 +10,7 @@ namespace Phinx\Db\Action;
 
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
+use Phinx\Util\Literal;
 
 class AddColumn extends Action
 {
@@ -17,7 +19,7 @@ class AddColumn extends Action
      *
      * @var \Phinx\Db\Table\Column
      */
-    protected $column;
+    protected Column $column;
 
     /**
      * Constructor
@@ -40,7 +42,7 @@ class AddColumn extends Action
      * @param array<string, mixed> $options The column options
      * @return static
      */
-    public static function build(Table $table, string $columnName, $type = null, array $options = [])
+    public static function build(Table $table, string $columnName, string|Literal $type, array $options = []): static
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/AddForeignKey.php
+++ b/src/Phinx/Db/Action/AddForeignKey.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -17,7 +18,7 @@ class AddForeignKey extends Action
      *
      * @var \Phinx\Db\Table\ForeignKey
      */
-    protected $foreignKey;
+    protected ForeignKey $foreignKey;
 
     /**
      * Constructor
@@ -43,7 +44,7 @@ class AddForeignKey extends Action
      * @param string|null $name The name of the foreign key
      * @return static
      */
-    public static function build(Table $table, $columns, $referencedTable, $referencedColumns = ['id'], array $options = [], ?string $name = null)
+    public static function build(Table $table, string|array $columns, Table|string $referencedTable, string|array $referencedColumns = ['id'], array $options = [], ?string $name = null): static
     {
         if (is_string($referencedColumns)) {
             $referencedColumns = [$referencedColumns]; // str to array

--- a/src/Phinx/Db/Action/AddIndex.php
+++ b/src/Phinx/Db/Action/AddIndex.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -17,7 +18,7 @@ class AddIndex extends Action
      *
      * @var \Phinx\Db\Table\Index
      */
-    protected $index;
+    protected Index $index;
 
     /**
      * Constructor
@@ -40,7 +41,7 @@ class AddIndex extends Action
      * @param array<string, mixed> $options Additional options for the index creation
      * @return static
      */
-    public static function build(Table $table, $columns, array $options = [])
+    public static function build(Table $table, string|array|Index $columns, array $options = []): static
     {
         // create a new index object if strings or an array of strings were supplied
         $index = $columns;

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -9,6 +10,7 @@ namespace Phinx\Db\Action;
 
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
+use Phinx\Util\Literal;
 
 class ChangeColumn extends Action
 {
@@ -17,14 +19,14 @@ class ChangeColumn extends Action
      *
      * @var \Phinx\Db\Table\Column
      */
-    protected $column;
+    protected Column $column;
 
     /**
      * The name of the column to be changed
      *
      * @var string
      */
-    protected $columnName;
+    protected string $columnName;
 
     /**
      * Constructor
@@ -55,7 +57,7 @@ class ChangeColumn extends Action
      * @param array<string, mixed> $options Additional options for the column
      * @return static
      */
-    public static function build(Table $table, string $columnName, $type = null, array $options = [])
+    public static function build(Table $table, string $columnName, string|Column|Literal $type, array $options = []): static
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/ChangeColumn.php
+++ b/src/Phinx/Db/Action/ChangeColumn.php
@@ -53,11 +53,11 @@ class ChangeColumn extends Action
      *
      * @param \Phinx\Db\Table\Table $table The table to alter
      * @param string $columnName The name of the column to change
-     * @param string|\Phinx\Db\Table\Column|\Phinx\Util\Literal $type The type of the column
+     * @param string|\Phinx\Util\Literal $type The type of the column
      * @param array<string, mixed> $options Additional options for the column
      * @return static
      */
-    public static function build(Table $table, string $columnName, string|Column|Literal $type, array $options = []): static
+    public static function build(Table $table, string $columnName, string|Literal $type, array $options = []): static
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/ChangeComment.php
+++ b/src/Phinx/Db/Action/ChangeComment.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -16,7 +17,7 @@ class ChangeComment extends Action
      *
      * @var string|null
      */
-    protected $newComment;
+    protected ?string $newComment = null;
 
     /**
      * Constructor

--- a/src/Phinx/Db/Action/ChangePrimaryKey.php
+++ b/src/Phinx/Db/Action/ChangePrimaryKey.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -16,7 +17,7 @@ class ChangePrimaryKey extends Action
      *
      * @var string|string[]|null
      */
-    protected $newColumns;
+    protected string|array|null $newColumns = null;
 
     /**
      * Constructor
@@ -24,7 +25,7 @@ class ChangePrimaryKey extends Action
      * @param \Phinx\Db\Table\Table $table The table to be changed
      * @param string|string[]|null $newColumns The new columns for the primary key
      */
-    public function __construct(Table $table, $newColumns)
+    public function __construct(Table $table, string|array|null $newColumns)
     {
         parent::__construct($table);
         $this->newColumns = $newColumns;
@@ -35,7 +36,7 @@ class ChangePrimaryKey extends Action
      *
      * @return string|string[]|null
      */
-    public function getNewColumns()
+    public function getNewColumns(): string|array|null
     {
         return $this->newColumns;
     }

--- a/src/Phinx/Db/Action/CreateTable.php
+++ b/src/Phinx/Db/Action/CreateTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License

--- a/src/Phinx/Db/Action/DropForeignKey.php
+++ b/src/Phinx/Db/Action/DropForeignKey.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -17,7 +18,7 @@ class DropForeignKey extends Action
      *
      * @var \Phinx\Db\Table\ForeignKey
      */
-    protected $foreignKey;
+    protected ForeignKey $foreignKey;
 
     /**
      * Constructor
@@ -40,7 +41,7 @@ class DropForeignKey extends Action
      * @param string|null $constraint The constraint name
      * @return static
      */
-    public static function build(Table $table, $columns, ?string $constraint = null)
+    public static function build(Table $table, string|array $columns, ?string $constraint = null): static
     {
         if (is_string($columns)) {
             $columns = [$columns];

--- a/src/Phinx/Db/Action/DropIndex.php
+++ b/src/Phinx/Db/Action/DropIndex.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -17,7 +18,7 @@ class DropIndex extends Action
      *
      * @var \Phinx\Db\Table\Index
      */
-    protected $index;
+    protected Index $index;
 
     /**
      * Constructor
@@ -39,7 +40,7 @@ class DropIndex extends Action
      * @param string[] $columns the indexed columns
      * @return static
      */
-    public static function build(Table $table, array $columns = [])
+    public static function build(Table $table, array $columns = []): static
     {
         $index = new Index();
         $index->setColumns($columns);
@@ -55,7 +56,7 @@ class DropIndex extends Action
      * @param string $name The name of the index
      * @return static
      */
-    public static function buildFromName(Table $table, string $name)
+    public static function buildFromName(Table $table, string $name): static
     {
         $index = new Index();
         $index->setName($name);

--- a/src/Phinx/Db/Action/DropTable.php
+++ b/src/Phinx/Db/Action/DropTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License

--- a/src/Phinx/Db/Action/RemoveColumn.php
+++ b/src/Phinx/Db/Action/RemoveColumn.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -17,7 +18,7 @@ class RemoveColumn extends Action
      *
      * @var \Phinx\Db\Table\Column
      */
-    protected $column;
+    protected Column $column;
 
     /**
      * Constructor
@@ -39,7 +40,7 @@ class RemoveColumn extends Action
      * @param string $columnName The name of the column to drop
      * @return static
      */
-    public static function build(Table $table, string $columnName)
+    public static function build(Table $table, string $columnName): static
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/RenameColumn.php
+++ b/src/Phinx/Db/Action/RenameColumn.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -17,14 +18,14 @@ class RenameColumn extends Action
      *
      * @var \Phinx\Db\Table\Column
      */
-    protected $column;
+    protected Column $column;
 
     /**
      * The new name for the column
      *
      * @var string
      */
-    protected $newName;
+    protected string $newName;
 
     /**
      * Constructor
@@ -49,7 +50,7 @@ class RenameColumn extends Action
      * @param string $newName The new name for the column
      * @return static
      */
-    public static function build(Table $table, string $columnName, string $newName)
+    public static function build(Table $table, string $columnName, string $newName): static
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Phinx/Db/Action/RenameTable.php
+++ b/src/Phinx/Db/Action/RenameTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -16,7 +17,7 @@ class RenameTable extends Action
      *
      * @var string
      */
-    protected $newName;
+    protected string $newName;
 
     /**
      * Constructor

--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -24,32 +25,32 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @var array<string, mixed>
      */
-    protected $options = [];
+    protected array $options = [];
 
     /**
      * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input;
+    protected ?InputInterface $input = null;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface
      */
-    protected $output;
+    protected OutputInterface $output;
 
     /**
      * @var string[]
      */
-    protected $createdTables = [];
+    protected array $createdTables = [];
 
     /**
      * @var string
      */
-    protected $schemaTableName = 'phinxlog';
+    protected string $schemaTableName = 'phinxlog';
 
     /**
      * @var array
      */
-    protected $dataDomain = [];
+    protected array $dataDomain = [];
 
     /**
      * Class Constructor.
@@ -113,7 +114,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritDoc
      */
-    public function getOption(string $name)
+    public function getOption(string $name): mixed
     {
         if (!$this->hasOption($name)) {
             return null;
@@ -155,7 +156,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function getOutput(): OutputInterface
     {
-        if ($this->output === null) {
+        if (!isset($this->output)) {
             $output = new NullOutput();
             $this->setOutput($output);
         }
@@ -222,7 +223,7 @@ abstract class AbstractAdapter implements AdapterInterface
         // and it is compatible with the base Phinx types.
         foreach ($dataDomain as $type => $options) {
             if (!isset($options['type'])) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'You must specify a type for data domain type "%s".',
                     $type
                 ));
@@ -234,7 +235,7 @@ abstract class AbstractAdapter implements AdapterInterface
             }
 
             if (!in_array($options['type'], $this->getColumnTypes(), true)) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'An invalid column type "%s" was specified for data domain type "%s".',
                     $options['type'],
                     $type
@@ -253,7 +254,7 @@ abstract class AbstractAdapter implements AdapterInterface
 
             if (isset($options['limit']) && !is_numeric($options['limit'])) {
                 if (!defined('static::' . $options['limit'])) {
-                    throw new \InvalidArgumentException(sprintf(
+                    throw new InvalidArgumentException(sprintf(
                         'An invalid limit value "%s" was specified for data domain type "%s".',
                         $options['limit'],
                         $type

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -13,22 +14,20 @@ use RuntimeException;
  * Adapter factory and registry.
  *
  * Used for registering adapters and creating instances of adapters.
- *
- * @author Woody Gilk <woody.gilk@gmail.com>
  */
 class AdapterFactory
 {
     /**
-     * @var \Phinx\Db\Adapter\AdapterFactory|null
+     * @var static|null
      */
-    protected static $instance;
+    protected static ?AdapterFactory $instance = null;
 
     /**
      * Get the factory singleton instance.
      *
-     * @return \Phinx\Db\Adapter\AdapterFactory
+     * @return static
      */
-    public static function instance()
+    public static function instance(): static
     {
         if (!static::$instance) {
             static::$instance = new static();
@@ -43,7 +42,7 @@ class AdapterFactory
      * @var array<string, \Phinx\Db\Adapter\AdapterInterface|string>
      * @phpstan-var array<string, \Phinx\Db\Adapter\AdapterInterface|class-string<\Phinx\Db\Adapter\AdapterInterface>>
      */
-    protected $adapters = [
+    protected array $adapters = [
         'mysql' => 'Phinx\Db\Adapter\MysqlAdapter',
         'pgsql' => 'Phinx\Db\Adapter\PostgresAdapter',
         'sqlite' => 'Phinx\Db\Adapter\SQLiteAdapter',
@@ -55,7 +54,7 @@ class AdapterFactory
      *
      * @var array<string, \Phinx\Db\Adapter\WrapperInterface|string>
      */
-    protected $wrappers = [
+    protected array $wrappers = [
         'prefix' => 'Phinx\Db\Adapter\TablePrefixAdapter',
         'proxy' => 'Phinx\Db\Adapter\ProxyAdapter',
         'timed' => 'Phinx\Db\Adapter\TimedOutputAdapter',
@@ -69,7 +68,7 @@ class AdapterFactory
      * @throws \RuntimeException
      * @return $this
      */
-    public function registerAdapter(string $name, $class)
+    public function registerAdapter(string $name, object|string $class)
     {
         if (!is_subclass_of($class, 'Phinx\Db\Adapter\AdapterInterface')) {
             throw new RuntimeException(sprintf(
@@ -90,7 +89,7 @@ class AdapterFactory
      * @return object|string
      * @phpstan-return object|class-string<\Phinx\Db\Adapter\AdapterInterface>
      */
-    protected function getClass(string $name)
+    protected function getClass(string $name): object|string
     {
         if (empty($this->adapters[$name])) {
             throw new RuntimeException(sprintf(
@@ -124,7 +123,7 @@ class AdapterFactory
      * @throws \RuntimeException
      * @return $this
      */
-    public function registerWrapper(string $name, $class)
+    public function registerWrapper(string $name, object|string $class)
     {
         if (!is_subclass_of($class, 'Phinx\Db\Adapter\WrapperInterface')) {
             throw new RuntimeException(sprintf(
@@ -144,7 +143,7 @@ class AdapterFactory
      * @throws \RuntimeException
      * @return \Phinx\Db\Adapter\WrapperInterface|string
      */
-    protected function getWrapperClass(string $name)
+    protected function getWrapperClass(string $name): WrapperInterface|string
     {
         if (empty($this->wrappers[$name])) {
             throw new RuntimeException(sprintf(

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -11,13 +12,13 @@ use Cake\Database\Query;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
 use Phinx\Migration\MigrationInterface;
+use Phinx\Util\Literal;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Adapter Interface.
  *
- * @author Rob Morgan <robbym@gmail.com>
  * @method \PDO getConnection()
  */
 interface AdapterInterface
@@ -120,7 +121,7 @@ interface AdapterInterface
      * @param string $name Name
      * @return mixed
      */
-    public function getOption(string $name);
+    public function getOption(string $name): mixed;
 
     /**
      * Sets the console input.
@@ -295,7 +296,7 @@ interface AdapterInterface
      * @param array $params parameters to use for prepared query
      * @return mixed
      */
-    public function query(string $sql, array $params = []);
+    public function query(string $sql, array $params = []): mixed;
 
     /**
      * Executes a query and returns only one row as an array.
@@ -303,7 +304,7 @@ interface AdapterInterface
      * @param string $sql SQL
      * @return array|false
      */
-    public function fetchRow(string $sql);
+    public function fetchRow(string $sql): array|false;
 
     /**
      * Executes a query and returns an array of rows.
@@ -397,7 +398,7 @@ interface AdapterInterface
      * @param string|string[] $columns Column(s)
      * @return bool
      */
-    public function hasIndex(string $tableName, $columns): bool;
+    public function hasIndex(string $tableName, string|array $columns): bool;
 
     /**
      * Checks to see if an index specified by name exists.
@@ -416,7 +417,7 @@ interface AdapterInterface
      * @param string|null $constraint Constraint name
      * @return bool
      */
-    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool;
+    public function hasPrimaryKey(string $tableName, string|array $columns, ?string $constraint = null): bool;
 
     /**
      * Checks to see if a foreign key exists.
@@ -426,7 +427,7 @@ interface AdapterInterface
      * @param string|null $constraint Constraint name
      * @return bool
      */
-    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool;
+    public function hasForeignKey(string $tableName, string|array $columns, ?string $constraint = null): bool;
 
     /**
      * Returns an array of the supported Phinx column types.
@@ -450,7 +451,7 @@ interface AdapterInterface
      * @param int|null $limit Limit
      * @return array
      */
-    public function getSqlType($type, ?int $limit = null): array;
+    public function getSqlType(Literal|string $type, ?int $limit = null): array;
 
     /**
      * Creates a new database.
@@ -501,5 +502,5 @@ interface AdapterInterface
      * @param mixed $value The value to be cast
      * @return mixed
      */
-    public function castToBool($value);
+    public function castToBool(mixed $value): mixed;
 }

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -8,9 +9,11 @@
 namespace Phinx\Db\Adapter;
 
 use Cake\Database\Query;
+use PDO;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
 use Phinx\Migration\MigrationInterface;
+use Phinx\Util\Literal;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -19,15 +22,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Proxy commands through to another adapter, allowing modification of
  * parameters during calls.
- *
- * @author Woody Gilk <woody.gilk@gmail.com>
  */
 abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
 {
     /**
      * @var \Phinx\Db\Adapter\AdapterInterface
      */
-    protected $adapter;
+    protected AdapterInterface $adapter;
 
     /**
      * @inheritDoc
@@ -84,7 +85,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getOption(string $name)
+    public function getOption(string $name): mixed
     {
         return $this->adapter->getOption($name);
     }
@@ -160,7 +161,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function query(string $sql, array $params = [])
+    public function query(string $sql, array $params = []): mixed
     {
         return $this->getAdapter()->query($sql, $params);
     }
@@ -184,7 +185,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function fetchRow(string $sql)
+    public function fetchRow(string $sql): array|false
     {
         return $this->getAdapter()->fetchRow($sql);
     }
@@ -368,7 +369,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, $columns): bool
+    public function hasIndex(string $tableName, string|array $columns): bool
     {
         return $this->getAdapter()->hasIndex($tableName, $columns);
     }
@@ -400,7 +401,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType(Literal|string $type, ?int $limit = null): array
     {
         return $this->getAdapter()->getSqlType($type, $limit);
     }
@@ -456,7 +457,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @inheritDoc
      */
-    public function castToBool($value)
+    public function castToBool($value): mixed
     {
         return $this->getAdapter()->castToBool($value);
     }
@@ -464,7 +465,7 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * @return \PDO
      */
-    public function getConnection()
+    public function getConnection(): PDO
     {
         return $this->getAdapter()->getConnection();
     }

--- a/src/Phinx/Db/Adapter/DirectActionInterface.php
+++ b/src/Phinx/Db/Adapter/DirectActionInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -42,7 +43,7 @@ interface DirectActionInterface
      * @param string|string[]|null $newColumns Column name(s) to belong to the primary key, or null to drop the key
      * @return void
      */
-    public function changePrimaryKey(Table $table, $newColumns): void;
+    public function changePrimaryKey(Table $table, string|array|null $newColumns): void;
 
     /**
      * Changes the comment of the specified database table.
@@ -107,7 +108,7 @@ interface DirectActionInterface
      * @param string|string[] $columns Column(s)
      * @return void
      */
-    public function dropIndex(string $tableName, $columns): void;
+    public function dropIndex(string $tableName, string|array $columns): void;
 
     /**
      * Drops the index specified by name from a database table.

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -19,18 +20,17 @@ use Phinx\Db\Table\Table;
 use Phinx\Db\Util\AlterInstructions;
 use Phinx\Util\Literal;
 use RuntimeException;
+use UnexpectedValueException;
 
 /**
  * Phinx MySQL Adapter.
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 class MysqlAdapter extends PdoAdapter
 {
     /**
      * @var string[]
      */
-    protected static $specificColumnTypes = [
+    protected static array $specificColumnTypes = [
         self::PHINX_TYPE_ENUM,
         self::PHINX_TYPE_SET,
         self::PHINX_TYPE_YEAR,
@@ -45,7 +45,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @var bool[]
      */
-    protected $signedColumnTypes = [
+    protected array $signedColumnTypes = [
         self::PHINX_TYPE_INTEGER => true,
         self::PHINX_TYPE_TINY_INTEGER => true,
         self::PHINX_TYPE_SMALL_INTEGER => true,
@@ -149,7 +149,7 @@ class MysqlAdapter extends PdoAdapter
                 if (strpos($key, 'mysql_attr_') === 0) {
                     $pdoConstant = '\PDO::' . strtoupper($key);
                     if (!defined($pdoConstant)) {
-                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
+                        throw new UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
                     }
                     $driverOptions[constant($pdoConstant)] = $option;
                 }
@@ -637,7 +637,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, $columns): bool
+    public function hasIndex(string $tableName, string|array $columns): bool
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -943,8 +943,9 @@ class MysqlAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType(Literal|string $type, ?int $limit = null): array
     {
+        $type = (string)$type;
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:
             case static::PHINX_TYPE_DOUBLE:
@@ -1117,7 +1118,7 @@ class MysqlAdapter extends PdoAdapter
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      * @return array Phinx type
      */
-    public function getPhinxType($sqlTypeDef)
+    public function getPhinxType(string $sqlTypeDef): array
     {
         $matches = [];
         if (!preg_match('/^([\w]+)(\(([\d]+)*(,([\d]+))*\))*(.+)*$/', $sqlTypeDef, $matches)) {
@@ -1367,7 +1368,7 @@ class MysqlAdapter extends PdoAdapter
         $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
 
         if (
-            version_compare($this->getAttribute(\PDO::ATTR_SERVER_VERSION), '8', '>=')
+            version_compare($this->getAttribute(PDO::ATTR_SERVER_VERSION), '8', '>=')
             && in_array($column->getType(), static::PHINX_TYPES_GEOSPATIAL)
             && !is_null($column->getSrid())
         ) {
@@ -1379,7 +1380,7 @@ class MysqlAdapter extends PdoAdapter
         $default = $column->getDefault();
         // MySQL 8 supports setting default for the following tested types, but only if they are "cast as expressions"
         if (
-            version_compare($this->getAttribute(\PDO::ATTR_SERVER_VERSION), '8', '>=') &&
+            version_compare($this->getAttribute(PDO::ATTR_SERVER_VERSION), '8', '>=') &&
             is_string($default) &&
             in_array(
                 $column->getType(),

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -33,7 +34,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @var string[]
      */
-    protected static $specificColumnTypes = [
+    protected static array $specificColumnTypes = [
         self::PHINX_TYPE_JSON,
         self::PHINX_TYPE_JSONB,
         self::PHINX_TYPE_CIDR,
@@ -50,14 +51,14 @@ class PostgresAdapter extends PdoAdapter
      *
      * @var \Phinx\Db\Table\Column[]
      */
-    protected $columnsWithComments = [];
+    protected array $columnsWithComments = [];
 
     /**
      * Use identity columns if available (Postgres >= 10.0)
      *
      * @var bool
      */
-    protected $useIdentity;
+    protected bool $useIdentity;
 
     /**
      * {@inheritDoc}
@@ -715,7 +716,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return array
      */
-    protected function getIndexes($tableName)
+    protected function getIndexes(string $tableName): array
     {
         $parts = $this->getSchemaName($tableName);
 
@@ -759,7 +760,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, $columns): bool
+    public function hasIndex(string $tableName, string|array $columns): bool
     {
         if (is_string($columns)) {
             $columns = [$columns];
@@ -1039,8 +1040,9 @@ class PostgresAdapter extends PdoAdapter
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType(Literal|string $type, ?int $limit = null): array
     {
+        $type = (string)$type;
         switch ($type) {
             case static::PHINX_TYPE_TEXT:
             case static::PHINX_TYPE_TIME:
@@ -1513,7 +1515,7 @@ class PostgresAdapter extends PdoAdapter
      * @param string|\Phinx\Util\Literal $columnType Column type
      * @return bool
      */
-    protected function isArrayType($columnType): bool
+    protected function isArrayType(string|Literal $columnType): bool
     {
         if (!preg_match('/^([a-z]+)(?:\[\]){1,}$/', $columnType, $matches)) {
             return false;
@@ -1557,7 +1559,7 @@ class PostgresAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function castToBool($value)
+    public function castToBool($value): mixed
     {
         return (bool)$value ? 'TRUE' : 'FALSE';
     }

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -26,15 +27,13 @@ use Phinx\Migration\IrreversibleMigrationException;
  * Phinx Proxy Adapter.
  *
  * Used for recording migration commands to automatically reverse them.
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 class ProxyAdapter extends AdapterWrapper
 {
     /**
      * @var \Phinx\Db\Action\Action[]
      */
-    protected $commands = [];
+    protected array $commands = [];
 
     /**
      * @inheritDoc

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -21,18 +22,17 @@ use Phinx\Db\Util\AlterInstructions;
 use Phinx\Migration\MigrationInterface;
 use Phinx\Util\Literal;
 use RuntimeException;
+use UnexpectedValueException;
 
 /**
  * Phinx SqlServer Adapter.
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 class SqlServerAdapter extends PdoAdapter
 {
     /**
      * @var string[]
      */
-    protected static $specificColumnTypes = [
+    protected static array $specificColumnTypes = [
         self::PHINX_TYPE_FILESTREAM,
         self::PHINX_TYPE_BINARYUUID,
     ];
@@ -40,12 +40,12 @@ class SqlServerAdapter extends PdoAdapter
     /**
      * @var string
      */
-    protected $schema = 'dbo';
+    protected string $schema = 'dbo';
 
     /**
      * @var bool[]
      */
-    protected $signedColumnTypes = [
+    protected array $signedColumnTypes = [
         self::PHINX_TYPE_INTEGER => true,
         self::PHINX_TYPE_BIG_INTEGER => true,
         self::PHINX_TYPE_FLOAT => true,
@@ -106,7 +106,7 @@ class SqlServerAdapter extends PdoAdapter
                 if (strpos($key, 'sqlsrv_attr_') === 0) {
                     $pdoConstant = '\PDO::' . strtoupper($key);
                     if (!defined($pdoConstant)) {
-                        throw new \UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
+                        throw new UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
                     }
                     $driverOptions[constant($pdoConstant)] = $option;
                 }
@@ -360,7 +360,7 @@ class SqlServerAdapter extends PdoAdapter
      * @param string $tableName Table name
      * @return string
      */
-    protected function getColumnCommentSqlDefinition(Column $column, $tableName): string
+    protected function getColumnCommentSqlDefinition(Column $column, string $tableName): string
     {
         // passing 'null' is to remove column comment
         $currentComment = $this->getColumnComment($tableName, $column->getName());
@@ -479,7 +479,7 @@ class SqlServerAdapter extends PdoAdapter
                    ->setComment($this->getColumnComment($columnInfo['table_name'], $columnInfo['name']));
 
             if (!empty($columnInfo['char_length'])) {
-                $column->setLimit($columnInfo['char_length']);
+                $column->setLimit((int)$columnInfo['char_length']);
             }
 
             $columns[$columnInfo['name']] = $column;
@@ -492,7 +492,7 @@ class SqlServerAdapter extends PdoAdapter
      * @param string|null $default Default
      * @return int|string|null
      */
-    protected function parseDefault(?string $default)
+    protected function parseDefault(?string $default): int|string|null
     {
         // if a column is non-nullable and has no default, the value of column_default is null,
         // otherwise it should be a string value that we parse below, including "(NULL)" which
@@ -693,7 +693,7 @@ SQL;
      * @param string $columnName Column name
      * @return string|false
      */
-    protected function getDefaultConstraint(string $tableName, string $columnName)
+    protected function getDefaultConstraint(string $tableName, string $columnName): string|false
     {
         $sql = "SELECT
     default_constraints.name
@@ -723,11 +723,11 @@ WHERE
     }
 
     /**
-     * @param int $tableId Table ID
-     * @param int $indexId Index ID
+     * @param string $tableId Table ID
+     * @param string $indexId Index ID
      * @return array
      */
-    protected function getIndexColums(int $tableId, int $indexId): array
+    protected function getIndexColums(string $tableId, string $indexId): array
     {
         $sql = "SELECT AC.[name] AS [column_name]
 FROM sys.[index_columns] IC
@@ -771,7 +771,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, $columns): bool
+    public function hasIndex(string $tableName, string|array $columns): bool
     {
         if (is_string($columns)) {
             $columns = [$columns]; // str to array
@@ -1062,8 +1062,9 @@ ORDER BY T.[name], I.[index_id];";
      *
      * @throws \Phinx\Db\Adapter\UnsupportedColumnTypeException
      */
-    public function getSqlType($type, ?int $limit = null): array
+    public function getSqlType(Literal|string $type, ?int $limit = null): array
     {
+        $type = (string)$type;
         switch ($type) {
             case static::PHINX_TYPE_FLOAT:
             case static::PHINX_TYPE_DECIMAL:

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -30,8 +31,6 @@ use Phinx\Db\Table\Table;
  * Table prefix/suffix adapter.
  *
  * Used for inserting a prefix or suffix into table names.
- *
- * @author Samuel Fisher <sam@sfisher.co>
  */
 class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
 {
@@ -236,7 +235,7 @@ class TablePrefixAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, $columns): bool
+    public function hasIndex(string $tableName, string|array $columns): bool
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
 

--- a/src/Phinx/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Phinx/Db/Adapter/TimedOutputAdapter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -36,7 +37,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     {
         $started = microtime(true);
 
-        return function () use ($started) {
+        return function () use ($started): void {
             $end = microtime(true);
             if (OutputInterface::VERBOSITY_VERBOSE <= $this->getOutput()->getVerbosity()) {
                 $this->getOutput()->writeln('    -> ' . sprintf('%.4fs', $end - $started));

--- a/src/Phinx/Db/Adapter/UnsupportedColumnTypeException.php
+++ b/src/Phinx/Db/Adapter/UnsupportedColumnTypeException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -11,8 +12,6 @@ use RuntimeException;
 
 /**
  * Exception thrown when a column type doesn't match a Phinx type.
- *
- * @author Martijn Gastkemper <martijngastkemper@gmail.com>
  */
 class UnsupportedColumnTypeException extends RuntimeException
 {

--- a/src/Phinx/Db/Adapter/WrapperInterface.php
+++ b/src/Phinx/Db/Adapter/WrapperInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -9,8 +10,6 @@ namespace Phinx\Db\Adapter;
 
 /**
  * Wrapper Interface.
- *
- * @author Woody Gilk <woody.gilk@gmail.com>
  */
 interface WrapperInterface
 {

--- a/src/Phinx/Db/Plan/AlterTable.php
+++ b/src/Phinx/Db/Plan/AlterTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -20,14 +21,14 @@ class AlterTable
      *
      * @var \Phinx\Db\Table\Table
      */
-    protected $table;
+    protected Table $table;
 
     /**
      * The list of actions to execute
      *
      * @var \Phinx\Db\Action\Action[]
      */
-    protected $actions = [];
+    protected array $actions = [];
 
     /**
      * Constructor

--- a/src/Phinx/Db/Plan/Intent.php
+++ b/src/Phinx/Db/Plan/Intent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -19,7 +20,7 @@ class Intent
      *
      * @var \Phinx\Db\Action\Action[]
      */
-    protected $actions = [];
+    protected array $actions = [];
 
     /**
      * Adds a new action to the collection

--- a/src/Phinx/Db/Plan/NewTable.php
+++ b/src/Phinx/Db/Plan/NewTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -21,21 +22,21 @@ class NewTable
      *
      * @var \Phinx\Db\Table\Table
      */
-    protected $table;
+    protected Table $table;
 
     /**
      * The list of columns to add
      *
      * @var \Phinx\Db\Table\Column[]
      */
-    protected $columns = [];
+    protected array $columns = [];
 
     /**
      * The list of indexes to create
      *
      * @var \Phinx\Db\Table\Index[]
      */
-    protected $indexes = [];
+    protected array $indexes = [];
 
     /**
      * Constructor

--- a/src/Phinx/Db/Plan/Plan.php
+++ b/src/Phinx/Db/Plan/Plan.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -39,42 +40,42 @@ class Plan
      *
      * @var \Phinx\Db\Plan\NewTable[]
      */
-    protected $tableCreates = [];
+    protected array $tableCreates = [];
 
     /**
      * List of table updates
      *
      * @var \Phinx\Db\Plan\AlterTable[]
      */
-    protected $tableUpdates = [];
+    protected array $tableUpdates = [];
 
     /**
      * List of table removals or renames
      *
      * @var \Phinx\Db\Plan\AlterTable[]
      */
-    protected $tableMoves = [];
+    protected array $tableMoves = [];
 
     /**
      * List of index additions or removals
      *
      * @var \Phinx\Db\Plan\AlterTable[]
      */
-    protected $indexes = [];
+    protected array $indexes = [];
 
     /**
      * List of constraint additions or removals
      *
      * @var \Phinx\Db\Plan\AlterTable[]
      */
-    protected $constraints = [];
+    protected array $constraints = [];
 
     /**
      * List of dropped columns
      *
      * @var \Phinx\Db\Plan\AlterTable[]
      */
-    protected $columnRemoves = [];
+    protected array $columnRemoves = [];
 
     /**
      * Constructor

--- a/src/Phinx/Db/Plan/Solver/ActionSplitter.php
+++ b/src/Phinx/Db/Plan/Solver/ActionSplitter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -23,7 +24,7 @@ class ActionSplitter
      *
      * @var string
      */
-    protected $conflictClass;
+    protected string $conflictClass;
 
     /**
      * The fully qualified class name of the Action class to match for conflicts, which
@@ -31,7 +32,7 @@ class ActionSplitter
      *
      * @var string
      */
-    protected $conflictClassDual;
+    protected string $conflictClassDual;
 
     /**
      * A callback used to signal the actual presence of a conflict, that will be used to

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -10,6 +11,7 @@ namespace Phinx\Db\Table;
 use Phinx\Config\FeatureFlags;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\PostgresAdapter;
+use Phinx\Util\Literal;
 use RuntimeException;
 
 /**
@@ -60,104 +62,104 @@ class Column
     /**
      * @var string
      */
-    protected $name;
+    protected ?string $name = null;
 
     /**
      * @var string|\Phinx\Util\Literal
      */
-    protected $type;
+    protected string|Literal $type;
 
     /**
      * @var int|null
      */
-    protected $limit;
+    protected ?int $limit = null;
 
     /**
      * @var bool
      */
-    protected $null = true;
+    protected bool $null = true;
 
     /**
      * @var mixed
      */
-    protected $default;
+    protected mixed $default = null;
 
     /**
      * @var bool
      */
-    protected $identity = false;
+    protected bool $identity = false;
 
     /**
      * Postgres-only column option for identity (always|default)
      *
      * @var ?string
      */
-    protected $generated = PostgresAdapter::GENERATED_BY_DEFAULT;
+    protected ?string $generated = PostgresAdapter::GENERATED_BY_DEFAULT;
 
     /**
      * @var int|null
      */
-    protected $seed;
+    protected ?int $seed = null;
 
     /**
      * @var int|null
      */
-    protected $increment;
+    protected ?int $increment = null;
 
     /**
      * @var int|null
      */
-    protected $scale;
+    protected ?int $scale = null;
 
     /**
      * @var string|null
      */
-    protected $after;
+    protected ?string $after = null;
 
     /**
      * @var string|null
      */
-    protected $update;
+    protected ?string $update = null;
 
     /**
      * @var string|null
      */
-    protected $comment;
+    protected ?string $comment = null;
 
     /**
      * @var bool
      */
-    protected $signed = true;
+    protected bool $signed = true;
 
     /**
      * @var bool
      */
-    protected $timezone = false;
+    protected bool $timezone = false;
 
     /**
      * @var array
      */
-    protected $properties = [];
+    protected array $properties = [];
 
     /**
      * @var string|null
      */
-    protected $collation;
+    protected ?string $collation = null;
 
     /**
      * @var string|null
      */
-    protected $encoding;
+    protected ?string $encoding = null;
 
     /**
      * @var int|null
      */
-    protected $srid;
+    protected ?int $srid = null;
 
     /**
      * @var array|null
      */
-    protected $values;
+    protected ?array $values = null;
 
     /**
      * Column constructor
@@ -196,7 +198,7 @@ class Column
      * @param string|\Phinx\Util\Literal $type Column type
      * @return $this
      */
-    public function setType($type)
+    public function setType(string|Literal $type)
     {
         $this->type = $type;
 
@@ -208,7 +210,7 @@ class Column
      *
      * @return string|\Phinx\Util\Literal
      */
-    public function getType()
+    public function getType(): string|Literal
     {
         return $this->type;
     }
@@ -275,7 +277,7 @@ class Column
      * @param mixed $default Default
      * @return $this
      */
-    public function setDefault($default)
+    public function setDefault(mixed $default)
     {
         $this->default = $default;
 
@@ -287,7 +289,7 @@ class Column
      *
      * @return mixed
      */
-    public function getDefault()
+    public function getDefault(): mixed
     {
         return $this->default;
     }
@@ -635,7 +637,7 @@ class Column
      * @param string[]|string $values Value(s)
      * @return $this
      */
-    public function setValues($values)
+    public function setValues(array|string $values)
     {
         if (!is_array($values)) {
             $values = preg_split('/,\s*/', $values) ?: [];

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -20,37 +21,37 @@ class ForeignKey
     /**
      * @var array<string>
      */
-    protected static $validOptions = ['delete', 'update', 'constraint'];
+    protected static array $validOptions = ['delete', 'update', 'constraint'];
 
     /**
      * @var string[]
      */
-    protected $columns = [];
+    protected array $columns = [];
 
     /**
      * @var \Phinx\Db\Table\Table
      */
-    protected $referencedTable;
+    protected Table $referencedTable;
 
     /**
      * @var string[]
      */
-    protected $referencedColumns = [];
+    protected array $referencedColumns = [];
 
     /**
      * @var string|null
      */
-    protected $onDelete;
+    protected ?string $onDelete = null;
 
     /**
      * @var string|null
      */
-    protected $onUpdate;
+    protected ?string $onUpdate = null;
 
     /**
      * @var string|null
      */
-    protected $constraint;
+    protected ?string $constraint = null;
 
     /**
      * Sets the foreign key columns.
@@ -58,7 +59,7 @@ class ForeignKey
      * @param string[]|string $columns Columns
      * @return $this
      */
-    public function setColumns($columns)
+    public function setColumns(array|string $columns)
     {
         $this->columns = is_string($columns) ? [$columns] : $columns;
 

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -29,32 +30,32 @@ class Index
     /**
      * @var string[]|null
      */
-    protected $columns;
+    protected ?array $columns = null;
 
     /**
      * @var string
      */
-    protected $type = self::INDEX;
+    protected string $type = self::INDEX;
 
     /**
      * @var string|null
      */
-    protected $name;
+    protected ?string $name = null;
 
     /**
      * @var int|array|null
      */
-    protected $limit;
+    protected int|array|null $limit = null;
 
     /**
      * @var string[]|null
      */
-    protected $order;
+    protected ?array $order = null;
 
     /**
      * @var string[]|null
      */
-    protected $includedColumns;
+    protected ?array $includedColumns = null;
 
     /**
      * Sets the index columns.
@@ -62,7 +63,7 @@ class Index
      * @param string|string[] $columns Columns
      * @return $this
      */
-    public function setColumns($columns)
+    public function setColumns(string|array $columns)
     {
         $this->columns = is_string($columns) ? [$columns] : $columns;
 
@@ -131,7 +132,7 @@ class Index
      * @param int|array $limit limit value or array of limit value
      * @return $this
      */
-    public function setLimit($limit)
+    public function setLimit(int|array $limit)
     {
         $this->limit = $limit;
 
@@ -143,7 +144,7 @@ class Index
      *
      * @return int|array|null
      */
-    public function getLimit()
+    public function getLimit(): int|array|null
     {
         return $this->limit;
     }

--- a/src/Phinx/Db/Table/Table.php
+++ b/src/Phinx/Db/Table/Table.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -14,19 +15,19 @@ class Table
     /**
      * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * @var array<string, mixed>
      */
-    protected $options;
+    protected array $options;
 
     /**
      * @param string $name The table name
      * @param array<string, mixed> $options The creation options for this table
      * @throws \InvalidArgumentException
      */
-    public function __construct($name, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         if (empty($name)) {
             throw new InvalidArgumentException('Cannot use an empty table name');

--- a/src/Phinx/Db/Util/AlterInstructions.php
+++ b/src/Phinx/Db/Util/AlterInstructions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -16,12 +17,12 @@ class AlterInstructions
     /**
      * @var string[] The SQL snippets to be added to an ALTER instruction
      */
-    protected $alterParts = [];
+    protected array $alterParts = [];
 
     /**
      * @var (string|callable)[] The SQL commands to be executed after the ALTER instruction
      */
-    protected $postSteps = [];
+    protected array $postSteps = [];
 
     /**
      * Constructor
@@ -57,7 +58,7 @@ class AlterInstructions
      * @param string|callable $sql The SQL to run after, or a callable to execute
      * @return void
      */
-    public function addPostStep($sql): void
+    public function addPostStep(string|callable $sql): void
     {
         $this->postSteps[] = $sql;
     }

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -21,49 +22,47 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * This abstract class proxies the various database methods to your specified
  * adapter.
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 abstract class AbstractMigration implements MigrationInterface
 {
     /**
      * @var string
      */
-    protected $environment;
+    protected string $environment;
 
     /**
      * @var int
      */
-    protected $version;
+    protected int $version;
 
     /**
      * @var \Phinx\Db\Adapter\AdapterInterface|null
      */
-    protected $adapter;
+    protected ?AdapterInterface $adapter = null;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface|null
      */
-    protected $output;
+    protected ?OutputInterface $output = null;
 
     /**
      * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input;
+    protected ?InputInterface $input = null;
 
     /**
      * Whether this migration is being applied or reverted
      *
      * @var bool
      */
-    protected $isMigratingUp = true;
+    protected bool $isMigratingUp = true;
 
     /**
      * List of all the table objects created by this migration
      *
      * @var array<\Phinx\Db\Table>
      */
-    protected $tables = [];
+    protected array $tables = [];
 
     /**
      * @param string $environment Environment Detected
@@ -202,7 +201,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function query(string $sql, array $params = [])
+    public function query(string $sql, array $params = []): mixed
     {
         return $this->getAdapter()->query($sql, $params);
     }
@@ -218,7 +217,7 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function fetchRow(string $sql)
+    public function fetchRow(string $sql): array|false
     {
         return $this->getAdapter()->fetchRow($sql);
     }

--- a/src/Phinx/Migration/AbstractTemplateCreation.php
+++ b/src/Phinx/Migration/AbstractTemplateCreation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -15,12 +16,12 @@ abstract class AbstractTemplateCreation implements CreationInterface
     /**
      * @var \Symfony\Component\Console\Input\InputInterface
      */
-    protected $input;
+    protected InputInterface $input;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface
      */
-    protected $output;
+    protected OutputInterface $output;
 
     /**
      * @param \Symfony\Component\Console\Input\InputInterface|null $input Input

--- a/src/Phinx/Migration/CreationInterface.php
+++ b/src/Phinx/Migration/CreationInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -12,8 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Migration interface
- *
- * @author Richard Quadling <RQuadling@GMail.com>
  */
 interface CreationInterface
 {

--- a/src/Phinx/Migration/IrreversibleMigrationException.php
+++ b/src/Phinx/Migration/IrreversibleMigrationException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -12,8 +13,6 @@ use Exception;
 /**
  * Exception class thrown when migrations cannot be reversed using the 'change'
  * feature.
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 class IrreversibleMigrationException extends Exception
 {

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -31,42 +32,42 @@ class Manager
     /**
      * @var \Phinx\Config\ConfigInterface
      */
-    protected $config;
+    protected ConfigInterface $config;
 
     /**
      * @var \Symfony\Component\Console\Input\InputInterface
      */
-    protected $input;
+    protected InputInterface $input;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface
      */
-    protected $output;
+    protected OutputInterface $output;
 
     /**
      * @var \Phinx\Migration\Manager\Environment[]
      */
-    protected $environments = [];
+    protected array $environments = [];
 
     /**
      * @var \Phinx\Migration\MigrationInterface[]|null
      */
-    protected $migrations;
+    protected ?array $migrations = null;
 
     /**
      * @var \Phinx\Seed\SeedInterface[]|null
      */
-    protected $seeds;
+    protected ?array $seeds = null;
 
     /**
      * @var \Psr\Container\ContainerInterface
      */
-    protected $container;
+    protected ContainerInterface $container;
 
     /**
      * @var int
      */
-    private $verbosityLevel = OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL;
+    private int $verbosityLevel = OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL;
 
     /**
      * @param \Phinx\Config\ConfigInterface $config Configuration Object
@@ -489,7 +490,7 @@ class Manager
      * @param bool $fake Flag that if true, we just record running the migration, but not actually do the migration
      * @return void
      */
-    public function rollback(string $environment, $target = null, bool $force = false, bool $targetMustMatchVersion = true, bool $fake = false): void
+    public function rollback(string $environment, int|string|null $target = null, bool $force = false, bool $targetMustMatchVersion = true, bool $fake = false): void
     {
         // note that the migrations are indexed by name (aka creation time) in ascending order
         $migrations = $this->getMigrations($environment);
@@ -952,7 +953,7 @@ class Manager
 
                     // instantiate it
                     /** @var \Phinx\Seed\AbstractSeed $seed */
-                    if ($this->container !== null) {
+                    if (isset($this->container)) {
                         $seed = $this->container->get($class);
                     } else {
                         $seed = new $class();

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -21,37 +22,37 @@ class Environment
     /**
      * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * @var array<string, mixed>
      */
-    protected $options;
+    protected array $options;
 
     /**
      * @var \Symfony\Component\Console\Input\InputInterface|null
      */
-    protected $input;
+    protected ?InputInterface $input = null;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface|null
      */
-    protected $output;
+    protected ?OutputInterface $output = null;
 
     /**
      * @var int
      */
-    protected $currentVersion;
+    protected int $currentVersion;
 
     /**
      * @var string
      */
-    protected $schemaTableName = 'phinxlog';
+    protected string $schemaTableName = 'phinxlog';
 
     /**
      * @var \Phinx\Db\Adapter\AdapterInterface
      */
-    protected $adapter;
+    protected AdapterInterface $adapter;
 
     /**
      * @param string $name Environment Name
@@ -378,7 +379,7 @@ class Environment
      * @param string $schemaTableName Schema Table Name
      * @return $this
      */
-    public function setSchemaTableName($schemaTableName)
+    public function setSchemaTableName(string $schemaTableName)
     {
         $this->schemaTableName = $schemaTableName;
 

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -15,8 +16,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Migration interface
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 interface MigrationInterface
 {
@@ -151,7 +150,7 @@ interface MigrationInterface
      * @param array $params parameters to use for prepared query
      * @return mixed
      */
-    public function query(string $sql, array $params = []);
+    public function query(string $sql, array $params = []): mixed;
 
     /**
      * Returns a new Query object that can be used to build complex SELECT, UPDATE, INSERT or DELETE
@@ -172,7 +171,7 @@ interface MigrationInterface
      * @param string $sql SQL
      * @return array|false
      */
-    public function fetchRow(string $sql);
+    public function fetchRow(string $sql): array|false;
 
     /**
      * Executes a query and returns an array of rows.

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -19,30 +20,28 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * This abstract class proxies the various database methods to your specified
  * adapter.
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 abstract class AbstractSeed implements SeedInterface
 {
     /**
      * @var string
      */
-    protected $environment;
+    protected string $environment;
 
     /**
      * @var \Phinx\Db\Adapter\AdapterInterface
      */
-    protected $adapter;
+    protected AdapterInterface $adapter;
 
     /**
      * @var \Symfony\Component\Console\Input\InputInterface
      */
-    protected $input;
+    protected InputInterface $input;
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface
      */
-    protected $output;
+    protected OutputInterface $output;
 
     /**
      * Override to specify dependencies for dependency injection from the configured PSR-11 container
@@ -149,7 +148,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function execute(string $sql, array $params = [])
+    public function execute(string $sql, array $params = []): int
     {
         return $this->getAdapter()->execute($sql, $params);
     }
@@ -157,7 +156,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function query(string $sql, array $params = [])
+    public function query(string $sql, array $params = []): mixed
     {
         return $this->getAdapter()->query($sql, $params);
     }
@@ -165,7 +164,7 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * @inheritDoc
      */
-    public function fetchRow(string $sql)
+    public function fetchRow(string $sql): array|false
     {
         return $this->getAdapter()->fetchRow($sql);
     }

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -8,13 +9,12 @@
 namespace Phinx\Seed;
 
 use Phinx\Db\Adapter\AdapterInterface;
+use Phinx\Db\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Seed interface
- *
- * @author Rob Morgan <robbym@gmail.com>
  */
 interface SeedInterface
 {
@@ -115,7 +115,7 @@ interface SeedInterface
      * @param array $params parameters to use for prepared query
      * @return int
      */
-    public function execute(string $sql, array $params = []);
+    public function execute(string $sql, array $params = []): int;
 
     /**
      * Executes a SQL statement.
@@ -129,7 +129,7 @@ interface SeedInterface
      * @param array $params parameters to use for prepared query
      * @return mixed
      */
-    public function query(string $sql, array $params = []);
+    public function query(string $sql, array $params = []): mixed;
 
     /**
      * Executes a query and returns only one row as an array.
@@ -137,7 +137,7 @@ interface SeedInterface
      * @param string $sql SQL
      * @return array|false
      */
-    public function fetchRow(string $sql);
+    public function fetchRow(string $sql): array|false;
 
     /**
      * Executes a query and returns an array of rows.
@@ -173,7 +173,7 @@ interface SeedInterface
      * @param array<string, mixed> $options Options
      * @return \Phinx\Db\Table
      */
-    public function table(string $tableName, array $options): \Phinx\Db\Table;
+    public function table(string $tableName, array $options): Table;
 
     /**
      * Checks to see if the seed should be executed.

--- a/src/Phinx/Util/Expression.php
+++ b/src/Phinx/Util/Expression.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -12,7 +13,7 @@ class Expression
     /**
      * @var string The expression
      */
-    protected $value;
+    protected string $value;
 
     /**
      * @param string $value The expression

--- a/src/Phinx/Util/Literal.php
+++ b/src/Phinx/Util/Literal.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -12,7 +13,7 @@ class Literal
     /**
      * @var string The literal's value
      */
-    protected $value;
+    protected string $value;
 
     /**
      * @param string $value The literal's value

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -236,7 +237,7 @@ class Util
      * @throws \Exception
      * @return string
      */
-    public static function loadPhpFile(string $filename, ?InputInterface $input = null, ?OutputInterface $output = null, $context = null): string
+    public static function loadPhpFile(string $filename, ?InputInterface $input = null, ?OutputInterface $output = null, mixed $context = null): string
     {
         $filePath = realpath($filename);
         if (!file_exists($filePath)) {
@@ -268,7 +269,7 @@ class Util
      * @param string|string[] $paths Path or array of paths to get .php files.
      * @return string[]
      */
-    public static function getFiles($paths): array
+    public static function getFiles(string|array $paths): array
     {
         $files = static::globAll(array_map(function ($path) {
             return $path . DIRECTORY_SEPARATOR . '*.php';

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * MIT License
@@ -14,25 +15,23 @@ use Symfony\Component\Console\Output\StreamOutput;
 /**
  * Phinx text wrapper: a way to run `status`, `migrate`, and `rollback` commands
  * and get the output of the command back as plain text.
- *
- * @author Woody Gilk <woody.gilk@gmail.com>
  */
 class TextWrapper
 {
     /**
      * @var \Phinx\Console\PhinxApplication
      */
-    protected $app;
+    protected PhinxApplication $app;
 
     /**
      * @var array<string, mixed>
      */
-    protected $options;
+    protected array $options;
 
     /**
      * @var int
      */
-    protected $exitCode;
+    protected int $exitCode;
 
     /**
      * @param \Phinx\Console\PhinxApplication $app Application
@@ -93,7 +92,7 @@ class TextWrapper
      * @param string|null $env environment name
      * @return bool
      */
-    private function hasEnvValue($env): bool
+    private function hasEnvValue(?string $env): bool
     {
         return $env || $this->hasOption('environment');
     }
@@ -132,7 +131,7 @@ class TextWrapper
      * @param string[]|string|null $seed Array of seed names or seed name
      * @return string
      */
-    public function getSeed(?string $env = null, ?string $target = null, $seed = null): string
+    public function getSeed(?string $env = null, ?string $target = null, array|string|null $seed = null): string
     {
         $command = ['seed:run'];
         if ($this->hasEnvValue($env)) {
@@ -162,7 +161,7 @@ class TextWrapper
      * @param mixed $target Target version, or 0 (zero) fully revert (optional)
      * @return string
      */
-    public function getRollback(?string $env = null, $target = null): string
+    public function getRollback(?string $env = null, mixed $target = null): string
     {
         $command = ['rollback'];
         if ($this->hasEnvValue($env)) {

--- a/src/composer_autoloader.php
+++ b/src/composer_autoloader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Attempts to load Composer's autoload.php as either a dependency or a

--- a/tests/Phinx/Config/ConfigPhpTest.php
+++ b/tests/Phinx/Config/ConfigPhpTest.php
@@ -34,8 +34,7 @@ class ConfigPhpTest extends TestCase
         $path = __DIR__ . '/_files';
 
         $this->expectException(RuntimeException::class);
-
-        $config = Config::fromPhp($path . '/config_without_array.php');
+        Config::fromPhp($path . '/config_without_array.php');
     }
 
     /**
@@ -47,7 +46,6 @@ class ConfigPhpTest extends TestCase
         $path = __DIR__ . '/_files';
 
         $this->expectException(RuntimeException::class);
-
-        $config = Config::fromPhp($path . '/empty.json');
+        Config::fromPhp($path . '/empty.json');
     }
 }

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -216,41 +216,41 @@ class ConfigTest extends AbstractConfigTest
      */
     public function testGetTemplateValuesFalseOnEmpty()
     {
-        $config = new \Phinx\Config\Config([]);
+        $config = new Config([]);
         $this->assertFalse($config->getTemplateFile());
         $this->assertFalse($config->getTemplateClass());
     }
 
     public function testGetAliasNoAliasesEntry()
     {
-        $config = new \Phinx\Config\Config([]);
+        $config = new Config([]);
         $this->assertNull($config->getAlias('Short'));
     }
 
     public function testGetAliasEmptyAliasesEntry()
     {
-        $config = new \Phinx\Config\Config(['aliases' => []]);
+        $config = new Config(['aliases' => []]);
         $this->assertNull($config->getAlias('Short'));
     }
 
     public function testGetAliasInvalidAliasRequest()
     {
-        $config = new \Phinx\Config\Config(['aliases' => ['Medium' => 'Some\Long\Classname']]);
+        $config = new Config(['aliases' => ['Medium' => 'Some\Long\Classname']]);
         $this->assertNull($config->getAlias('Short'));
     }
 
     public function testGetAliasValidAliasRequest()
     {
-        $config = new \Phinx\Config\Config(['aliases' => ['Short' => 'Some\Long\Classname']]);
+        $config = new Config(['aliases' => ['Short' => 'Some\Long\Classname']]);
         $this->assertEquals('Some\Long\Classname', $config->getAlias('Short'));
     }
 
     public function testGetSeedPath()
     {
-        $config = new \Phinx\Config\Config(['paths' => ['seeds' => 'db/seeds']]);
+        $config = new Config(['paths' => ['seeds' => 'db/seeds']]);
         $this->assertEquals(['db/seeds'], $config->getSeedPaths());
 
-        $config = new \Phinx\Config\Config(['paths' => ['seeds' => ['db/seeds1', 'db/seeds2']]]);
+        $config = new Config(['paths' => ['seeds' => ['db/seeds1', 'db/seeds2']]]);
         $this->assertEquals(['db/seeds1', 'db/seeds2'], $config->getSeedPaths());
     }
 
@@ -259,7 +259,7 @@ class ConfigTest extends AbstractConfigTest
      */
     public function testGetSeedPathThrowsException()
     {
-        $config = new \Phinx\Config\Config([]);
+        $config = new Config([]);
 
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Seeds path missing from config file');
@@ -296,9 +296,9 @@ class ConfigTest extends AbstractConfigTest
      */
     public function testGetVersionOrder()
     {
-        $config = new \Phinx\Config\Config([]);
-        $config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, $config->getVersionOrder());
+        $config = new Config([]);
+        $config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->assertEquals(Config::VERSION_ORDER_EXECUTION_TIME, $config->getVersionOrder());
     }
 
     /**
@@ -328,11 +328,11 @@ class ConfigTest extends AbstractConfigTest
         return [
             'With Creation Time Version Order' =>
             [
-                \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, true,
+                Config::VERSION_ORDER_CREATION_TIME, true,
             ],
             'With Execution Time Version Order' =>
             [
-                \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, false,
+                Config::VERSION_ORDER_EXECUTION_TIME, false,
             ],
         ];
     }
@@ -345,7 +345,7 @@ class ConfigTest extends AbstractConfigTest
         $_ENV['PHINX_TEST_CONFIG_SUFFIX'] = 'foo';
 
         try {
-            $config = new \Phinx\Config\Config([
+            $config = new Config([
                 'environments' => [
                     'production' => [
                         'adapter' => '%%PHINX_TEST_CONFIG_ADAPTER%%',
@@ -369,7 +369,7 @@ class ConfigTest extends AbstractConfigTest
 
     public function testSqliteMemorySetsName()
     {
-        $config = new \Phinx\Config\Config([
+        $config = new Config([
             'environments' => [
                 'production' => [
                     'adapter' => 'sqlite',
@@ -385,7 +385,7 @@ class ConfigTest extends AbstractConfigTest
 
     public function testSqliteMemoryOverridesName()
     {
-        $config = new \Phinx\Config\Config([
+        $config = new Config([
             'environments' => [
                 'production' => [
                     'adapter' => 'sqlite',
@@ -402,7 +402,7 @@ class ConfigTest extends AbstractConfigTest
 
     public function testSqliteNonBooleanMemory()
     {
-        $config = new \Phinx\Config\Config([
+        $config = new Config([
             'environments' => [
                 'production' => [
                     'adapter' => 'sqlite',
@@ -418,7 +418,7 @@ class ConfigTest extends AbstractConfigTest
 
     public function testDefaultTemplateStyle(): void
     {
-        $config = new \Phinx\Config\Config([]);
+        $config = new Config([]);
         $this->assertSame('change', $config->getTemplateStyle());
     }
 
@@ -436,7 +436,7 @@ class ConfigTest extends AbstractConfigTest
      */
     public function testTemplateStyle(string $style, string $expected): void
     {
-        $config = new \Phinx\Config\Config(['templates' => ['style' => $style]]);
+        $config = new Config(['templates' => ['style' => $style]]);
         $this->assertSame($expected, $config->getTemplateStyle());
     }
 }

--- a/tests/Phinx/Console/Command/BreakpointTest.php
+++ b/tests/Phinx/Console/Command/BreakpointTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 

--- a/tests/Phinx/Console/Command/ListTest.php
+++ b/tests/Phinx/Console/Command/ListTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 
@@ -228,7 +229,7 @@ class MigrateTest extends TestCase
 
     public function testMigrateExecutionOrder()
     {
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
 
         $application = new PhinxApplication();
         $application->add(new Migrate());

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 
@@ -175,11 +176,11 @@ class RollbackTest extends TestCase
 
     public function testStartTimeVersionOrder()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Rollback());
 
         // setup dependencies
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command = $application->find('rollback');
 
@@ -203,7 +204,7 @@ class RollbackTest extends TestCase
 
     public function testWithDate()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
 
         $date = '20160101';
         $target = '20160101000000';
@@ -286,11 +287,11 @@ class RollbackTest extends TestCase
 
     public function testStarTimeVersionOrderWithDate()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Rollback());
 
         // setup dependencies
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command = $application->find('rollback');
 

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 
@@ -7,6 +8,7 @@ use Phinx\Config\Config;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\SeedCreate;
 use Phinx\Console\PhinxApplication;
+use Phinx\Migration\Manager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -77,7 +79,7 @@ class SeedCreateTest extends TestCase
 
         // mock the manager class
         /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -105,7 +107,7 @@ class SeedCreateTest extends TestCase
 
         // mock the manager class
         /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -130,7 +132,7 @@ class SeedCreateTest extends TestCase
         $command = $application->find('seed:create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -163,7 +165,7 @@ class SeedCreateTest extends TestCase
         $command = $application->find('seed:create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -193,7 +195,7 @@ class SeedCreateTest extends TestCase
         $this->configValues['templates']['seedFile'] = __DIR__ . '/Templates/SimpleSeeder.templateFromConfig.php.dist';
         $this->config = new Config($this->configValues);
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -230,7 +232,7 @@ class SeedCreateTest extends TestCase
         $this->configValues['templates']['seedFile'] = $template;
         $this->config = new Config($this->configValues);
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 
@@ -259,7 +261,7 @@ class SeedCreateTest extends TestCase
         $this->configValues['templates']['seedFile'] = __DIR__ . '/Templates/SimpleSeeder.templateFromConfig.php.dist';
         $this->config = new Config($this->configValues);
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMockBuilder(\Phinx\Migration\Manager::class)
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
 

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 
@@ -234,7 +235,7 @@ class StatusTest extends TestCase
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
                     ->will($this->returnValue(['hasMissingMigration' => false, 'hasDownMigration' => false]));
 
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -267,7 +268,7 @@ class StatusTest extends TestCase
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
                     ->will($this->returnValue(['hasMissingMigration' => true, 'hasDownMigration' => false]));
 
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -296,7 +297,7 @@ class StatusTest extends TestCase
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
                     ->will($this->returnValue(['hasMissingMigration' => false, 'hasDownMigration' => true]));
 
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -325,7 +326,7 @@ class StatusTest extends TestCase
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
                     ->will($this->returnValue(['hasMissingMigration' => true, 'hasDownMigration' => true]));
 
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);

--- a/tests/Phinx/Console/Command/TemplateGenerators/DoesNotImplementRequiredInterface.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/DoesNotImplementRequiredInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command\TemplateGenerators;
 

--- a/tests/Phinx/Console/Command/TemplateGenerators/NullGenerator.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/NullGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command\TemplateGenerators;
 

--- a/tests/Phinx/Console/Command/TemplateGenerators/SimpleGenerator.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/SimpleGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command\TemplateGenerators;
 

--- a/tests/Phinx/Console/Output/RawBufferedOutput.php
+++ b/tests/Phinx/Console/Output/RawBufferedOutput.php
@@ -1,12 +1,15 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console\Output;
+
+use Symfony\Component\Console\Output\BufferedOutput;
 
 /**
  * RawBufferedOutput is a specialized BufferedOutput that outputs raw "writeln" calls (ie. it doesn't replace the
  * tags like <info>message</info>.
  */
-class RawBufferedOutput extends \Symfony\Component\Console\Output\BufferedOutput
+class RawBufferedOutput extends BufferedOutput
 {
     /**
      * @param iterable|string $messages

--- a/tests/Phinx/Console/PhinxApplicationTest.php
+++ b/tests/Phinx/Console/PhinxApplicationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Console;
 

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\AdapterFactory;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use RuntimeException;
 
 class AdapterFactoryTest extends TestCase
@@ -32,7 +34,7 @@ class AdapterFactoryTest extends TestCase
     {
         // AdapterFactory::getClass is protected, work around it to avoid
         // creating unnecessary instances and making the test more complex.
-        $method = new \ReflectionMethod(get_class($this->factory), 'getClass');
+        $method = new ReflectionMethod(get_class($this->factory), 'getClass');
         $method->setAccessible(true);
 
         $adapter = $method->invoke($this->factory, 'mysql');
@@ -70,7 +72,7 @@ class AdapterFactoryTest extends TestCase
     {
         // WrapperFactory::getClass is protected, work around it to avoid
         // creating unnecessary instances and making the test more complex.
-        $method = new \ReflectionMethod(get_class($this->factory), 'getWrapperClass');
+        $method = new ReflectionMethod(get_class($this->factory), 'getWrapperClass');
         $method->setAccessible(true);
 
         $wrapper = $method->invoke($this->factory, 'proxy');

--- a/tests/Phinx/Db/Adapter/DataDomainTest.php
+++ b/tests/Phinx/Db/Adapter/DataDomainTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1636,7 +1636,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testDropForeignKeyWithMultipleColumns()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string', ['limit' => 8])
             ->addColumn('field2', 'string', ['limit' => 8])
@@ -1645,7 +1645,7 @@ class MysqlAdapterTest extends TestCase
             ->addIndex(['id', 'field1', 'field2'], ['unique' => true])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addColumn('ref_table_field1', 'string', ['limit' => 8])
@@ -1686,13 +1686,13 @@ class MysqlAdapterTest extends TestCase
 
     public function testDropForeignKeyWithIdenticalMultipleColumns()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string', ['limit' => 8])
             ->addIndex(['id', 'field1'], ['unique' => true])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addColumn('ref_table_field1', 'string', ['limit' => 8])
@@ -1737,13 +1737,13 @@ class MysqlAdapterTest extends TestCase
      */
     public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string', ['limit' => 8])
             ->addIndex(['id', 'field1'])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addColumn('ref_table_field1', 'string', ['limit' => 8])
@@ -1765,10 +1765,10 @@ class MysqlAdapterTest extends TestCase
 
     public function testDropForeignKeyCaseInsensitivity()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
@@ -1780,10 +1780,10 @@ class MysqlAdapterTest extends TestCase
 
     public function testDropForeignKeyByName()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -1,9 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 
 use PDO;
 use PDOException;
+use Phinx\Config\Config;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -122,10 +124,10 @@ class PdoAdapterTest extends TestCase
     {
         return [
             'With Creation Time Version Order' => [
-                \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, 'version ASC',
+                Config::VERSION_ORDER_CREATION_TIME, 'version ASC',
             ],
             'With Execution Time Version Order' => [
-                \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, 'start_time ASC, version ASC',
+                Config::VERSION_ORDER_EXECUTION_TIME, 'start_time ASC, version ASC',
             ],
         ];
     }
@@ -147,7 +149,7 @@ class PdoAdapterTest extends TestCase
     {
         $adapter = $this->getMockForAbstractClass(
             '\Phinx\Db\Adapter\PdoAdapter',
-            [['version_order' => \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME]],
+            [['version_order' => Config::VERSION_ORDER_CREATION_TIME]],
             '',
             true,
             true,

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1580,7 +1580,7 @@ class PostgresAdapterTest extends TestCase
 
     public function testDropForeignKeyWithMultipleColumns()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string')
             ->addColumn('field2', 'string')
@@ -1589,7 +1589,7 @@ class PostgresAdapterTest extends TestCase
             ->addIndex(['id', 'field1', 'field2'], ['unique' => true])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer')
             ->addColumn('ref_table_field1', 'string')
@@ -1630,13 +1630,13 @@ class PostgresAdapterTest extends TestCase
 
     public function testDropForeignKeyWithIdenticalMultipleColumns()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string')
             ->addIndex(['id', 'field1'], ['unique' => true])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addColumn('ref_table_field1', 'string')
@@ -1681,13 +1681,13 @@ class PostgresAdapterTest extends TestCase
      */
     public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string')
             ->addIndex(['id', 'field1'], ['unique' => true])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer')
             ->addColumn('ref_table_field1', 'string')
@@ -1709,10 +1709,10 @@ class PostgresAdapterTest extends TestCase
 
     public function testDropForeignKeyCaseSensitivity()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('REF_TABLE_ID', 'integer')
             ->addForeignKey(['REF_TABLE_ID'], 'ref_table', ['id'])
@@ -1731,10 +1731,10 @@ class PostgresAdapterTest extends TestCase
 
     public function testDropForeignKeyByName()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
@@ -1783,10 +1783,10 @@ class PostgresAdapterTest extends TestCase
 
     public function testHasNamedForeignKey()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer')
             ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 
 use Phinx\Db\Adapter\ProxyAdapter;
+use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
 use Phinx\Migration\IrreversibleMigrationException;
 use PHPUnit\Framework\TestCase;
@@ -35,7 +37,7 @@ class ProxyAdapterTest extends TestCase
 
     public function testProxyAdapterCanInvertCreateTable()
     {
-        $table = new \Phinx\Db\Table('atable', [], $this->adapter);
+        $table = new Table('atable', [], $this->adapter);
         $table->addColumn('column1', 'string')
               ->save();
 
@@ -46,7 +48,7 @@ class ProxyAdapterTest extends TestCase
 
     public function testProxyAdapterCanInvertRenameTable()
     {
-        $table = new \Phinx\Db\Table('oldname', [], $this->adapter);
+        $table = new Table('oldname', [], $this->adapter);
         $table->rename('newname')
               ->save();
 
@@ -75,7 +77,7 @@ class ProxyAdapterTest extends TestCase
                     ->setOptions($options);
             });
 
-        $table = new \Phinx\Db\Table('atable', [], $this->adapter);
+        $table = new Table('atable', [], $this->adapter);
         $table->addColumn('acolumn', 'string')
               ->save();
 
@@ -93,7 +95,7 @@ class ProxyAdapterTest extends TestCase
             ->method('hasTable')
             ->will($this->returnValue(true));
 
-        $table = new \Phinx\Db\Table('atable', [], $this->adapter);
+        $table = new Table('atable', [], $this->adapter);
         $table->renameColumn('oldname', 'newname')
               ->save();
 
@@ -111,7 +113,7 @@ class ProxyAdapterTest extends TestCase
             ->method('hasTable')
             ->will($this->returnValue(true));
 
-        $table = new \Phinx\Db\Table('atable', [], $this->adapter);
+        $table = new Table('atable', [], $this->adapter);
         $table->addIndex(['email'])
               ->save();
 
@@ -129,7 +131,7 @@ class ProxyAdapterTest extends TestCase
             ->method('hasTable')
             ->will($this->returnValue(true));
 
-        $table = new \Phinx\Db\Table('atable', [], $this->adapter);
+        $table = new Table('atable', [], $this->adapter);
         $table->addForeignKey(['ref_table_id'], 'refTable')
               ->save();
 
@@ -147,7 +149,7 @@ class ProxyAdapterTest extends TestCase
             ->method('hasTable')
             ->will($this->returnValue(true));
 
-        $table = new \Phinx\Db\Table('atable', [], $this->adapter);
+        $table = new Table('atable', [], $this->adapter);
         $table->removeColumn('thing')
               ->save();
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1382,7 +1382,7 @@ class SQLiteAdapterTest extends TestCase
 
     public function testDropForeignKeyWithQuoteVariants()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->addColumn('field1', 'string')
             ->addIndex(['field1'], ['unique' => true])
             ->save();
@@ -1441,7 +1441,7 @@ class SQLiteAdapterTest extends TestCase
 
     public function testDropForeignKeyWithMultipleColumns()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string')
             ->addColumn('field2', 'string')
@@ -1450,7 +1450,7 @@ class SQLiteAdapterTest extends TestCase
             ->addIndex(['id', 'field1', 'field2'], ['unique' => true])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer')
             ->addColumn('ref_table_field1', 'string')
@@ -1491,13 +1491,13 @@ class SQLiteAdapterTest extends TestCase
 
     public function testDropForeignKeyWithIdenticalMultipleColumns()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string')
             ->addIndex(['id', 'field1'], ['unique' => true])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addColumn('ref_table_field1', 'string')
@@ -1542,13 +1542,13 @@ class SQLiteAdapterTest extends TestCase
      */
     public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string')
             ->addIndex(['id', 'field1'], ['unique' => true])
             ->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer')
             ->addColumn('ref_table_field1', 'string')
@@ -1588,10 +1588,10 @@ class SQLiteAdapterTest extends TestCase
         $this->expectExceptionMessage('SQLite does not have named foreign keys');
         $this->expectException(BadMethodCallException::class);
 
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -1,10 +1,16 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 
 use BadMethodCallException;
 use Cake\Database\Query;
+use InvalidArgumentException;
+use PDO;
 use Phinx\Db\Adapter\SqlServerAdapter;
+use Phinx\Db\Table;
+use Phinx\Db\Table\Column;
+use Phinx\Db\Table\ForeignKey;
 use Phinx\Util\Literal;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -13,6 +19,7 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
+use UnexpectedValueException;
 
 class SqlServerAdapterTest extends TestCase
 {
@@ -48,7 +55,7 @@ class SqlServerAdapterTest extends TestCase
     public function testConnection()
     {
         $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-        $this->assertSame(\PDO::ERRMODE_EXCEPTION, $this->adapter->getConnection()->getAttribute(\PDO::ATTR_ERRMODE));
+        $this->assertSame(PDO::ERRMODE_EXCEPTION, $this->adapter->getConnection()->getAttribute(PDO::ATTR_ERRMODE));
     }
 
     public function testConnectionWithDsnOptions()
@@ -65,7 +72,7 @@ class SqlServerAdapterTest extends TestCase
         $options['fetch_mode'] = 'assoc';
         $this->adapter->setOptions($options);
         $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-        $this->assertSame(\PDO::FETCH_ASSOC, $this->adapter->getConnection()->getAttribute(\PDO::ATTR_DEFAULT_FETCH_MODE));
+        $this->assertSame(PDO::FETCH_ASSOC, $this->adapter->getConnection()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
     }
 
     public function testConnectionWithoutPort()
@@ -85,7 +92,7 @@ class SqlServerAdapterTest extends TestCase
             $adapter = new SqlServerAdapter($options, new ArrayInput([]), new NullOutput());
             $adapter->connect();
             $this->fail('Expected the adapter to throw an exception');
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $this->assertInstanceOf(
                 'InvalidArgumentException',
                 $e,
@@ -113,7 +120,7 @@ class SqlServerAdapterTest extends TestCase
     public function testSchemaTableIsCreatedWithPrimaryKey()
     {
         $this->adapter->connect();
-        $table = new \Phinx\Db\Table($this->adapter->getSchemaTableName(), [], $this->adapter);
+        new Table($this->adapter->getSchemaTableName(), [], $this->adapter);
         $this->assertTrue($this->adapter->hasIndex($this->adapter->getSchemaTableName(), ['version']));
     }
 
@@ -129,7 +136,7 @@ class SqlServerAdapterTest extends TestCase
 
     public function testCreateTable()
     {
-        $table = new \Phinx\Db\Table('ntable', [], $this->adapter);
+        $table = new Table('ntable', [], $this->adapter);
         $table->addColumn('realname', 'string')
               ->addColumn('email', 'integer')
               ->save();
@@ -142,7 +149,7 @@ class SqlServerAdapterTest extends TestCase
 
     public function testCreateTableCustomIdColumn()
     {
-        $table = new \Phinx\Db\Table('ntable', ['id' => 'custom_id'], $this->adapter);
+        $table = new Table('ntable', ['id' => 'custom_id'], $this->adapter);
         $table->addColumn('realname', 'string')
               ->addColumn('email', 'integer')
               ->save();
@@ -155,7 +162,7 @@ class SqlServerAdapterTest extends TestCase
 
     public function testCreateTableIdentityColumn()
     {
-        $table = new \Phinx\Db\Table('ntable', ['id' => false, 'primary_key' => 'id'], $this->adapter);
+        $table = new Table('ntable', ['id' => false, 'primary_key' => 'id'], $this->adapter);
         $table->addColumn('id', 'integer', ['identity' => true, 'seed' => 1, 'increment' => 10 ])
               ->save();
         $this->assertTrue($this->adapter->hasTable('ntable'));
@@ -175,7 +182,7 @@ WHERE t.name='ntable'");
         $options = [
             'id' => false,
         ];
-        $table = new \Phinx\Db\Table('atable', $options, $this->adapter);
+        $table = new Table('atable', $options, $this->adapter);
         $table->addColumn('user_id', 'integer')
               ->save();
         $this->assertFalse($this->adapter->hasColumn('atable', 'id'));
@@ -186,9 +193,9 @@ WHERE t.name='ntable'");
         $options = [
             'primary_key' => 'user_id',
         ];
-        $table = new \Phinx\Db\Table('atable', $options, $this->adapter);
+        $table = new Table('atable', $options, $this->adapter);
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You cannot enable an auto incrementing ID field and a primary key');
         $table->addColumn('user_id', 'integer')->save();
     }
@@ -198,7 +205,7 @@ WHERE t.name='ntable'");
         $options = [
             'primary_key' => 'id',
         ];
-        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table = new Table('ztable', $options, $this->adapter);
         $table->addColumn('user_id', 'integer')->save();
         $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
         $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
@@ -210,7 +217,7 @@ WHERE t.name='ntable'");
         $options = [
             'primary_key' => ['id'],
         ];
-        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table = new Table('ztable', $options, $this->adapter);
         $table->addColumn('user_id', 'integer')->save();
         $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
         $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
@@ -222,8 +229,8 @@ WHERE t.name='ntable'");
         $options = [
             'primary_key' => ['id', 'user_id'],
         ];
-        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
-        $this->expectException(\InvalidArgumentException::class);
+        $table = new Table('ztable', $options, $this->adapter);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You cannot enable an auto incrementing ID field and a primary key');
         $table->addColumn('user_id', 'integer')->save();
     }
@@ -234,7 +241,7 @@ WHERE t.name='ntable'");
             'id' => false,
             'primary_key' => ['user_id', 'tag_id'],
         ];
-        $table = new \Phinx\Db\Table('table1', $options, $this->adapter);
+        $table = new Table('table1', $options, $this->adapter);
         $table->addColumn('user_id', 'integer', ['null' => false])
               ->addColumn('tag_id', 'integer', ['null' => false])
               ->save();
@@ -249,7 +256,7 @@ WHERE t.name='ntable'");
             'id' => false,
             'primary_key' => 'id',
         ];
-        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table = new Table('ztable', $options, $this->adapter);
         $table->addColumn('id', 'uuid', ['null' => false])->save();
         $table->addColumn('user_id', 'integer')->save();
         $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
@@ -263,7 +270,7 @@ WHERE t.name='ntable'");
             'id' => false,
             'primary_key' => 'id',
         ];
-        $table = new \Phinx\Db\Table('ztable', $options, $this->adapter);
+        $table = new Table('ztable', $options, $this->adapter);
         $table->addColumn('id', 'binaryuuid', ['null' => false])->save();
         $table->addColumn('user_id', 'integer')->save();
         $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
@@ -273,7 +280,7 @@ WHERE t.name='ntable'");
 
     public function testCreateTableWithMultipleIndexes()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->addColumn('name', 'string')
               ->addIndex('email')
@@ -287,7 +294,7 @@ WHERE t.name='ntable'");
 
     public function testCreateTableWithUniqueIndexes()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->addIndex('email', ['unique' => true])
               ->save();
@@ -297,7 +304,7 @@ WHERE t.name='ntable'");
 
     public function testCreateTableWithNamedIndexes()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->addIndex('email', ['name' => 'myemailindex'])
               ->save();
@@ -308,7 +315,7 @@ WHERE t.name='ntable'");
 
     public function testAddPrimaryKey()
     {
-        $table = new \Phinx\Db\Table('table1', ['id' => false], $this->adapter);
+        $table = new Table('table1', ['id' => false], $this->adapter);
         $table
             ->addColumn('column1', 'integer', ['null' => false])
             ->save();
@@ -322,7 +329,7 @@ WHERE t.name='ntable'");
 
     public function testChangePrimaryKey()
     {
-        $table = new \Phinx\Db\Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
+        $table = new Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
         $table
             ->addColumn('column1', 'integer', ['null' => false])
             ->addColumn('column2', 'integer', ['null' => false])
@@ -339,7 +346,7 @@ WHERE t.name='ntable'");
 
     public function testDropPrimaryKey()
     {
-        $table = new \Phinx\Db\Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
+        $table = new Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
         $table
             ->addColumn('column1', 'integer', ['null' => false])
             ->save();
@@ -353,7 +360,7 @@ WHERE t.name='ntable'");
 
     public function testChangeCommentFails()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->save();
 
         $this->expectException(BadMethodCallException::class);
@@ -365,7 +372,7 @@ WHERE t.name='ntable'");
 
     public function testRenameTable()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->save();
         $this->assertTrue($this->adapter->hasTable('table1'));
         $this->assertFalse($this->adapter->hasTable('table2'));
@@ -376,7 +383,7 @@ WHERE t.name='ntable'");
 
     public function testAddColumn()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->save();
         $this->assertFalse($table->hasColumn('email'));
         $table->addColumn('email', 'string')
@@ -386,7 +393,7 @@ WHERE t.name='ntable'");
 
     public function testAddColumnWithDefaultValue()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->save();
         $table->addColumn('default_zero', 'string', ['default' => 'test'])
               ->save();
@@ -400,7 +407,7 @@ WHERE t.name='ntable'");
 
     public function testAddColumnWithDefaultZero()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->save();
         $table->addColumn('default_zero', 'integer', ['default' => 0])
               ->save();
@@ -415,7 +422,7 @@ WHERE t.name='ntable'");
 
     public function testAddColumnWithDefaultNull()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->save();
         $table->addColumn('default_null', 'string', ['null' => true, 'default' => null])
             ->save();
@@ -429,7 +436,7 @@ WHERE t.name='ntable'");
 
     public function testAddColumnWithNotNullableNoDefault()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table
             ->addColumn('col', 'string', ['null' => false])
             ->create();
@@ -444,7 +451,7 @@ WHERE t.name='ntable'");
 
     public function testAddColumnWithDefaultBool()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->save();
         $table
             ->addColumn('default_false', 'integer', ['default' => false])
@@ -470,7 +477,7 @@ WHERE t.name='ntable'");
             ],
         ]);
 
-        (new \Phinx\Db\Table('table1', [], $this->adapter))
+        (new Table('table1', [], $this->adapter))
             ->addColumn('custom', 'custom')
             ->addColumn('custom_ext', 'custom', [
                 'null' => false,
@@ -496,7 +503,7 @@ WHERE t.name='ntable'");
 
     public function testRenameColumn()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string')
               ->save();
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
@@ -508,14 +515,14 @@ WHERE t.name='ntable'");
 
     public function testRenamingANonExistentColumn()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string')
               ->save();
 
         try {
             $this->adapter->renameColumn('t', 'column2', 'column1');
             $this->fail('Expected the adapter to throw an exception');
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $this->assertInstanceOf(
                 'InvalidArgumentException',
                 $e,
@@ -527,11 +534,11 @@ WHERE t.name='ntable'");
 
     public function testChangeColumnType()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string')
               ->save();
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
-        $newColumn1 = new \Phinx\Db\Table\Column();
+        $newColumn1 = new Column();
         $newColumn1->setType('string');
         $table->changeColumn('column1', $newColumn1)->save();
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
@@ -545,10 +552,10 @@ WHERE t.name='ntable'");
 
     public function testChangeColumnNameAndNull()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string', ['null' => false])
             ->save();
-        $newColumn2 = new \Phinx\Db\Table\Column();
+        $newColumn2 = new Column();
         $newColumn2->setName('column2')
             ->setType('string')
             ->setNull(true);
@@ -565,7 +572,7 @@ WHERE t.name='ntable'");
 
     public function testChangeColumnDefaults()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string', ['default' => 'test'])
             ->save();
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
@@ -573,7 +580,7 @@ WHERE t.name='ntable'");
         $columns = $this->adapter->getColumns('t');
         $this->assertSame('test', $columns['column1']->getDefault());
 
-        $newColumn1 = new \Phinx\Db\Table\Column();
+        $newColumn1 = new Column();
         $newColumn1
             ->setType('string')
             ->setDefault('another test');
@@ -586,10 +593,10 @@ WHERE t.name='ntable'");
 
     public function testChangeColumnDefaultToNull()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string', ['null' => true, 'default' => 'test'])
             ->save();
-        $newColumn1 = new \Phinx\Db\Table\Column();
+        $newColumn1 = new Column();
         $newColumn1
             ->setType('string')
             ->setDefault(null);
@@ -600,10 +607,10 @@ WHERE t.name='ntable'");
 
     public function testChangeColumnDefaultToZero()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'integer')
             ->save();
-        $newColumn1 = new \Phinx\Db\Table\Column();
+        $newColumn1 = new Column();
         $newColumn1
             ->setType('string')
             ->setDefault(0);
@@ -614,7 +621,7 @@ WHERE t.name='ntable'");
 
     public function testDropColumn()
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string')
             ->save();
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
@@ -650,7 +657,7 @@ WHERE t.name='ntable'");
      */
     public function testGetColumns($colName, $type, $options)
     {
-        $table = new \Phinx\Db\Table('t', [], $this->adapter);
+        $table = new Table('t', [], $this->adapter);
         $table
             ->addColumn($colName, $type, $options)
             ->save();
@@ -663,7 +670,7 @@ WHERE t.name='ntable'");
 
     public function testAddIndex()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->save();
         $this->assertFalse($table->hasIndex('email'));
@@ -674,7 +681,7 @@ WHERE t.name='ntable'");
 
     public function testAddIndexWithSort()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->addColumn('username', 'string')
               ->save();
@@ -702,7 +709,7 @@ WHERE t.name='ntable'");
 
     public function testAddIndexWithIncludeColumns()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->addColumn('firstname', 'string')
               ->addColumn('lastname', 'string')
@@ -740,7 +747,7 @@ WHERE t.name='ntable'");
     public function testGetIndexes()
     {
         // single column index
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->addColumn('username', 'string')
               ->addIndex('email')
@@ -760,7 +767,7 @@ WHERE t.name='ntable'");
     public function testDropIndex()
     {
         // single column index
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->addIndex('email')
               ->save();
@@ -769,7 +776,7 @@ WHERE t.name='ntable'");
         $this->assertFalse($table->hasIndex('email'));
 
         // multiple column index
-        $table2 = new \Phinx\Db\Table('table2', [], $this->adapter);
+        $table2 = new Table('table2', [], $this->adapter);
         $table2->addColumn('fname', 'string')
                ->addColumn('lname', 'string')
                ->addIndex(['fname', 'lname'])
@@ -779,7 +786,7 @@ WHERE t.name='ntable'");
         $this->assertFalse($table2->hasIndex(['fname', 'lname']));
 
         // index with name specified, but dropping it by column name
-        $table3 = new \Phinx\Db\Table('table3', [], $this->adapter);
+        $table3 = new Table('table3', [], $this->adapter);
         $table3->addColumn('email', 'string')
                ->addIndex('email', ['name' => 'someindexname'])
                ->save();
@@ -788,7 +795,7 @@ WHERE t.name='ntable'");
         $this->assertFalse($table3->hasIndex('email'));
 
         // multiple column index with name specified
-        $table4 = new \Phinx\Db\Table('table4', [], $this->adapter);
+        $table4 = new Table('table4', [], $this->adapter);
         $table4->addColumn('fname', 'string')
                ->addColumn('lname', 'string')
                ->addIndex(['fname', 'lname'], ['name' => 'multiname'])
@@ -801,7 +808,7 @@ WHERE t.name='ntable'");
     public function testDropIndexByName()
     {
         // single column index
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('email', 'string')
               ->addIndex('email', ['name' => 'myemailindex'])
               ->save();
@@ -810,7 +817,7 @@ WHERE t.name='ntable'");
         $this->assertFalse($table->hasIndex('email'));
 
         // multiple column index
-        $table2 = new \Phinx\Db\Table('table2', [], $this->adapter);
+        $table2 = new Table('table2', [], $this->adapter);
         $table2->addColumn('fname', 'string')
                ->addColumn('lname', 'string')
                ->addIndex(
@@ -825,13 +832,13 @@ WHERE t.name='ntable'");
 
     public function testAddForeignKey()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->addColumn('field1', 'string')->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table->addColumn('ref_table_id', 'integer')->save();
 
-        $fk = new \Phinx\Db\Table\ForeignKey();
+        $fk = new ForeignKey();
         $fk->setReferencedTable($refTable->getTable())
            ->setColumns(['ref_table_id'])
            ->setReferencedColumns(['id'])
@@ -843,13 +850,13 @@ WHERE t.name='ntable'");
 
     public function dropForeignKey()
     {
-        $refTable = new \Phinx\Db\Table('ref_table', [], $this->adapter);
+        $refTable = new Table('ref_table', [], $this->adapter);
         $refTable->addColumn('field1', 'string')->save();
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table->addColumn('ref_table_id', 'integer')->save();
 
-        $fk = new \Phinx\Db\Table\ForeignKey();
+        $fk = new ForeignKey();
         $fk->setReferencedTable($refTable)
            ->setColumns(['ref_table_id'])
            ->setReferencedColumns(['id']);
@@ -914,7 +921,7 @@ WHERE t.name='ntable'");
 
     public function testAddColumnComment()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('field1', 'string', ['comment' => $comment = 'Comments from column "field1"'])
               ->save();
 
@@ -928,7 +935,7 @@ WHERE t.name='ntable'");
      */
     public function testChangeColumnComment()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('field1', 'string', ['comment' => 'Comments from column "field1"'])
               ->save();
 
@@ -945,7 +952,7 @@ WHERE t.name='ntable'");
      */
     public function testRemoveColumnComment()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('field1', 'string', ['comment' => 'Comments from column "field1"'])
               ->save();
 
@@ -965,10 +972,10 @@ WHERE t.name='ntable'");
         $userId = 'user';
         $sessionId = 'session';
 
-        $local = new \Phinx\Db\Table('users', ['id' => $userId], $this->adapter);
+        $local = new Table('users', ['id' => $userId], $this->adapter);
         $local->create();
 
-        $foreign = new \Phinx\Db\Table('sessions', ['id' => $sessionId], $this->adapter);
+        $foreign = new Table('sessions', ['id' => $sessionId], $this->adapter);
         $foreign->addColumn('user', 'integer')
                 ->addForeignKey('user', 'users', $userId)
                 ->create();
@@ -978,7 +985,7 @@ WHERE t.name='ntable'");
 
     public function testBulkInsertData()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('column1', 'string')
               ->addColumn('column2', 'integer')
               ->save();
@@ -1013,7 +1020,7 @@ WHERE t.name='ntable'");
 
     public function testInsertData()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('column1', 'string')
               ->addColumn('column2', 'integer')
               ->insert([
@@ -1046,7 +1053,7 @@ WHERE t.name='ntable'");
 
     public function testTruncateTable()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('column1', 'string')
               ->addColumn('column2', 'integer')
               ->insert([
@@ -1076,7 +1083,7 @@ WHERE t.name='ntable'");
         $consoleOutput = new BufferedOutput();
         $this->adapter->setOutput($consoleOutput);
 
-        $table = new \Phinx\Db\Table('table1', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
+        $table = new Table('table1', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
 
         $table->addColumn('column1', 'string', ['null' => false])
             ->addColumn('column2', 'integer')
@@ -1084,7 +1091,7 @@ WHERE t.name='ntable'");
 
         $expectedOutput = 'C';
 
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->insert([
             'column1' => 'id1',
             'column2' => 1,
@@ -1107,7 +1114,7 @@ OUTPUT;
         $this->adapter->setOutput($consoleOutput);
 
         $this->adapter->beginTransaction();
-        $table = new \Phinx\Db\Table('schema1.table1', [], $this->adapter);
+        $table = new Table('schema1.table1', [], $this->adapter);
 
         $table->addColumn('column1', 'string')
             ->addColumn('column2', 'integer')
@@ -1126,7 +1133,7 @@ OUTPUT;
      */
     public function testQueryBuilder()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('string_col', 'string')
             ->addColumn('int_col', 'integer')
             ->save();
@@ -1167,7 +1174,7 @@ OUTPUT;
 
     public function testQueryWithParams()
     {
-        $table = new \Phinx\Db\Table('table1', [], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table->addColumn('string_col', 'string')
             ->addColumn('int_col', 'integer')
             ->save();
@@ -1202,7 +1209,7 @@ OUTPUT;
 CREATE TABLE test (smallmoney_col smallmoney)
 INPUT;
         $this->adapter->execute($createQuery);
-        $table = new \Phinx\Db\Table('test', [], $this->adapter);
+        $table = new Table('test', [], $this->adapter);
         $columns = $table->getColumns();
         $this->assertCount(1, $columns);
         $this->assertEquals(Literal::from('smallmoney'), array_pop($columns)->getType());
@@ -1222,7 +1229,7 @@ INPUT;
     public function testInvalidPdoAttribute($attribute)
     {
         $adapter = new SqlServerAdapter(SQLSRV_DB_CONFIG + [$attribute => true]);
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (\PDO::' . strtoupper($attribute) . ')');
         $adapter->connect();
     }

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 
@@ -15,9 +16,10 @@ use Phinx\Db\Action\RemoveColumn;
 use Phinx\Db\Action\RenameColumn;
 use Phinx\Db\Action\RenameTable;
 use Phinx\Db\Adapter\TablePrefixAdapter;
+use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\ForeignKey;
-use Phinx\Db\Table\Table;
+use Phinx\Db\Table\Table as TableValue;
 use PHPUnit\Framework\TestCase;
 
 class TablePrefixAdapterTest extends TestCase
@@ -93,7 +95,7 @@ class TablePrefixAdapterTest extends TestCase
 
     public function testCreateTable()
     {
-        $table = new Table('table');
+        $table = new TableValue('table');
 
         $this->mock
             ->expects($this->once())
@@ -109,10 +111,10 @@ class TablePrefixAdapterTest extends TestCase
 
     public function testChangePrimaryKey()
     {
-        $table = new Table('table');
+        $table = new TableValue('table');
         $newColumns = 'column1';
 
-        $expectedTable = new Table('pre_table_suf');
+        $expectedTable = new TableValue('pre_table_suf');
         $this->mock
             ->expects($this->once())
             ->method('changePrimaryKey')
@@ -126,10 +128,10 @@ class TablePrefixAdapterTest extends TestCase
 
     public function testChangeComment()
     {
-        $table = new Table('table');
+        $table = new TableValue('table');
         $newComment = 'comment';
 
-        $expectedTable = new Table('pre_table_suf');
+        $expectedTable = new TableValue('pre_table_suf');
         $this->mock
             ->expects($this->once())
             ->method('changeComment')
@@ -189,7 +191,7 @@ class TablePrefixAdapterTest extends TestCase
 
     public function testAddColumn()
     {
-        $table = new Table('table');
+        $table = new TableValue('table');
         $column = new Column();
 
         $this->mock
@@ -327,7 +329,7 @@ class TablePrefixAdapterTest extends TestCase
 
     public function testAddForeignKey()
     {
-        $table = new Table('table');
+        $table = new TableValue('table');
         $foreignKey = new ForeignKey();
 
         $this->mock
@@ -374,20 +376,20 @@ class TablePrefixAdapterTest extends TestCase
                 $this->equalTo($row)
             ));
 
-        $table = new \Phinx\Db\Table('table', [], $this->adapter);
+        $table = new Table('table', [], $this->adapter);
         $table->insert($row)
               ->save();
     }
 
     public function actionsProvider()
     {
-        $table = new Table('my_test');
+        $table = new TableValue('my_test');
 
         return [
-            [AddColumn::build($table, 'acolumn')],
+            [AddColumn::build($table, 'acolumn', 'int')],
             [AddIndex::build($table, ['acolumn'])],
             [AddForeignKey::build($table, ['acolumn'], 'another_table'), true],
-            [ChangeColumn::build($table, 'acolumn')],
+            [ChangeColumn::build($table, 'acolumn', 'int')],
             [DropForeignKey::build($table, ['acolumn'])],
             [DropIndex::build($table, ['acolumn'])],
             [new DropTable($table)],
@@ -426,7 +428,7 @@ class TablePrefixAdapterTest extends TestCase
                 }
             }));
 
-        $table = new Table('my_test');
+        $table = new TableValue('my_test');
         $this->adapter->executeActions($table, [$action]);
     }
 }

--- a/tests/Phinx/Db/Table/ColumnTest.php
+++ b/tests/Phinx/Db/Table/ColumnTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Table;
 

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Table;
 

--- a/tests/Phinx/Db/Table/IndexTest.php
+++ b/tests/Phinx/Db/Table/IndexTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Db\Table;
 

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Migration;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class AbstractMigrationTest extends TestCase
 {
@@ -276,7 +278,7 @@ class AbstractMigrationTest extends TestCase
         $table = $migrationStub->table('test_table');
         $table->addColumn('column1', 'integer', ['null' => true]);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Migration has pending actions after execution!');
 
         $migrationStub->postFlightCheck();

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -1,13 +1,16 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Migration\Manager;
 
 use PDO;
 use Phinx\Db\Adapter\AdapterFactory;
+use Phinx\Db\Adapter\TablePrefixAdapter;
 use Phinx\Migration\Manager\Environment;
 use Phinx\Migration\MigrationInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use stdClass;
 
 class EnvironmentTest extends TestCase
 {
@@ -88,12 +91,12 @@ class EnvironmentTest extends TestCase
         AdapterFactory::instance()->registerAdapter('pdomock', $adapter);
         $this->environment->setOptions(['connection' => $this->getPdoMock()]);
         $options = $this->environment->getAdapter()->getOptions();
-        $this->assertEquals(\PDO::ERRMODE_EXCEPTION, $options['connection']->getAttribute(\PDO::ATTR_ERRMODE));
+        $this->assertEquals(PDO::ERRMODE_EXCEPTION, $options['connection']->getAttribute(PDO::ATTR_ERRMODE));
     }
 
     public function testGetAdapterWithBadExistingPdoInstance()
     {
-        $this->environment->setOptions(['connection' => new \stdClass()]);
+        $this->environment->setOptions(['connection' => new stdClass()]);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The specified connection is not a PDO instance');
@@ -104,7 +107,7 @@ class EnvironmentTest extends TestCase
     public function testTablePrefixAdapter()
     {
         $this->environment->setOptions(['table_prefix' => 'tbl_', 'adapter' => 'mysql']);
-        $this->assertInstanceOf(\Phinx\Db\Adapter\TablePrefixAdapter::class, $this->environment->getAdapter());
+        $this->assertInstanceOf(TablePrefixAdapter::class, $this->environment->getAdapter());
 
         $tablePrefixAdapter = $this->environment->getAdapter();
         $this->assertInstanceOf('Phinx\Db\Adapter\MysqlAdapter', $tablePrefixAdapter->getAdapter()->getAdapter());
@@ -125,11 +128,11 @@ class EnvironmentTest extends TestCase
             ->getMock();
         $stub->expects($this->any())
              ->method('getVersions')
-             ->will($this->returnValue(['20110301080000']));
+             ->will($this->returnValue([20110301080000]));
 
         $this->environment->setAdapter($stub);
 
-        $this->assertEquals('20110301080000', $this->environment->getCurrentVersion());
+        $this->assertEquals(20110301080000, $this->environment->getCurrentVersion());
     }
 
     public function testExecutingAMigrationUp()

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -1,7 +1,9 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Migration;
 
+use DateTime;
 use InvalidArgumentException;
 use Phinx\Config\Config;
 use Phinx\Console\Command\AbstractCommand;
@@ -1284,7 +1286,7 @@ class ManagerTest extends TestCase
                     ->will($this->returnValue($availableMigrations));
         }
         $this->manager->setEnvironments(['mockenv' => $envStub]);
-        $this->manager->migrateToDateTime('mockenv', new \DateTime($dateString));
+        $this->manager->migrateToDateTime('mockenv', new DateTime($dateString));
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedMigration)) {
@@ -1514,7 +1516,7 @@ class ManagerTest extends TestCase
 
         // get a manager with a config whose version order is set to execution time
         $configArray = $this->getConfigArray();
-        $configArray['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $configArray['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
         $config = new Config($configArray);
         $this->input = new ArrayInput([]);
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
@@ -1557,7 +1559,7 @@ class ManagerTest extends TestCase
 
         // get a manager with a config whose version order is set to execution time
         $configArray = $this->getConfigArray();
-        $configArray['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $configArray['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
         $config = new Config($configArray);
         $this->input = new ArrayInput([]);
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
@@ -1600,7 +1602,7 @@ class ManagerTest extends TestCase
 
         // get a manager with a config whose version order is set to execution time
         $config = $this->getConfigWithNamespace();
-        $config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
         $this->input = new ArrayInput([]);
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
         $this->output->setDecorated(false);
@@ -1642,7 +1644,7 @@ class ManagerTest extends TestCase
 
         // get a manager with a config whose version order is set to execution time
         $configArray = $this->getConfigArray();
-        $configArray['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $configArray['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
         $config = new Config($configArray);
         $this->input = new ArrayInput([]);
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
@@ -1685,7 +1687,7 @@ class ManagerTest extends TestCase
 
         // get a manager with a config whose version order is set to execution time
         $config = $this->getConfigWithNamespace();
-        $config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $config['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
         $this->input = new ArrayInput([]);
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
         $this->output->setDecorated(false);
@@ -4809,7 +4811,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20120116183504 TestMigration2: reverted',
                 ],
 
@@ -4819,7 +4821,7 @@ class ManagerTest extends TestCase
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted',
                 ],
 
@@ -4830,7 +4832,7 @@ class ManagerTest extends TestCase
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20120116183504 TestMigration2: reverted',
                 ],
 
@@ -4841,7 +4843,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted',
                 ],
 
@@ -4853,7 +4855,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -4863,7 +4865,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20120116183504 TestMigration2: reverted',
                 ],
 
@@ -4874,7 +4876,7 @@ class ManagerTest extends TestCase
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -4885,7 +4887,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -4896,7 +4898,7 @@ class ManagerTest extends TestCase
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20120116183504 TestMigration2: reverted',
                 ],
 
@@ -4907,7 +4909,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted',
                 ],
 
@@ -4919,7 +4921,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -4929,7 +4931,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -4940,7 +4942,7 @@ class ManagerTest extends TestCase
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -4951,7 +4953,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
             ];
@@ -4974,7 +4976,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 0],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20160116183504 Foo\Bar\TestMigration2: reverted',
                 ],
 
@@ -4984,7 +4986,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-10 18:35:04', 'breakpoint' => 0],
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20160111235330 Foo\Bar\TestMigration: reverted',
                 ],
 
@@ -4995,7 +4997,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 0],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20160116183504 Foo\Bar\TestMigration2: reverted',
                 ],
 
@@ -5006,7 +5008,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 0],
                         '20170101225232' => ['version' => '20130101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20160111235330 Foo\Bar\TestMigration: reverted',
                 ],
 
@@ -5018,7 +5020,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 0],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5028,7 +5030,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 1],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20160116183504 Foo\Bar\TestMigration2: reverted',
                 ],
 
@@ -5039,7 +5041,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 1],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5050,7 +5052,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 1],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5061,7 +5063,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 0],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20160116183504 Foo\Bar\TestMigration2: reverted',
                 ],
 
@@ -5072,7 +5074,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 0],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20160111235330 Foo\Bar\TestMigration: reverted',
                 ],
 
@@ -5084,7 +5086,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 1],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5094,7 +5096,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 1],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5105,7 +5107,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2016-01-16 18:35:04', 'breakpoint' => 1],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5116,7 +5118,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2016-01-12 23:53:30', 'breakpoint' => 1],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
             ];
@@ -5143,7 +5145,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2017-01-01 00:00:04', 'breakpoint' => 0],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20160116183504 Foo\Bar\TestMigration2: reverted',
                 ],
 
@@ -5157,7 +5159,7 @@ class ManagerTest extends TestCase
                         '20150111235330' => ['version' => '20150111235330', 'start_time' => '2017-01-01 00:00:06', 'breakpoint' => 0],
                         '20150116183504' => ['version' => '20150116183504', 'start_time' => '2017-01-01 00:00:07', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20150116183504 Baz\TestMigration2: reverted',
                 ],
 
@@ -5172,7 +5174,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 0],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20160116183504 Foo\Bar\TestMigration2: reverted',
                 ],
 
@@ -5187,7 +5189,7 @@ class ManagerTest extends TestCase
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2017-01-01 00:00:07', 'breakpoint' => 0],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120116183504 TestMigration2: reverted',
                 ],
 
@@ -5203,7 +5205,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2017-01-01 00:00:04', 'breakpoint' => 0],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5217,7 +5219,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2017-01-01 00:00:04', 'breakpoint' => 1],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20160116183504 Foo\Bar\TestMigration2: reverted',
                 ],
 
@@ -5232,7 +5234,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 1],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5247,7 +5249,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 1],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5262,7 +5264,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 0],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     '== 20160116183504 Foo\Bar\TestMigration2: reverted',
                 ],
 
@@ -5277,7 +5279,7 @@ class ManagerTest extends TestCase
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2017-01-01 00:00:06', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted',
                 ],
 
@@ -5293,7 +5295,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2017-01-01 00:00:04', 'breakpoint' => 1],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5307,7 +5309,7 @@ class ManagerTest extends TestCase
                         '20160111235330' => ['version' => '20160111235330', 'start_time' => '2017-01-01 00:00:04', 'breakpoint' => 1],
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5322,7 +5324,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 1],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    Config::VERSION_ORDER_CREATION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
@@ -5337,7 +5339,7 @@ class ManagerTest extends TestCase
                         '20160116183504' => ['version' => '20160116183504', 'start_time' => '2017-01-01 00:00:05', 'breakpoint' => 1],
                         '20170101225232' => ['version' => '20170101225232', 'start_time' => '2017-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
+                    Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
             ];
@@ -6034,7 +6036,7 @@ class ManagerTest extends TestCase
         $adapter->disconnect();
 
         $this->manager->setConfig($config);
-        $this->manager->migrate('production', '20190928205056');
+        $this->manager->migrate('production', 20190928205056);
 
         $this->assertTrue($adapter->hasTable('table1'));
         $this->assertTrue($adapter->hasTable('table2'));
@@ -6097,7 +6099,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->setBreakpoint('mockenv', '20120133235330');
+        $this->manager->setBreakpoint('mockenv', 20120133235330);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -6123,12 +6125,12 @@ class ManagerTest extends TestCase
 
         // Run the migration with shouldExecute returning false: the table should not be created
         $this->manager->setConfig($config);
-        $this->manager->migrate('production', '20201207205056');
+        $this->manager->migrate('production', 20201207205056);
 
         $this->assertFalse($adapter->hasTable('info'));
 
         // Run the migration with shouldExecute returning true: the table should be created
-        $this->manager->migrate('production', '20201207205057');
+        $this->manager->migrate('production', 20201207205057);
 
         $this->assertTrue($adapter->hasTable('info'));
     }

--- a/tests/Phinx/TestCase.php
+++ b/tests/Phinx/TestCase.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Test\Phinx;

--- a/tests/Phinx/TestUtils.php
+++ b/tests/Phinx/TestUtils.php
@@ -3,6 +3,10 @@ declare(strict_types=1);
 
 namespace Test\Phinx;
 
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
 class TestUtils
 {
     /**
@@ -22,8 +26,8 @@ class TestUtils
 
             return;
         }
-        $dir = new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS);
-        $iter = new \RecursiveIteratorIterator($dir, \RecursiveIteratorIterator::CHILD_FIRST);
+        $dir = new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS);
+        $iter = new RecursiveIteratorIterator($dir, RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($iter as $file) {
             if ($file->isDir()) {
                 rmdir($file->getPathname());

--- a/tests/Phinx/Util/ExpressionTest.php
+++ b/tests/Phinx/Util/ExpressionTest.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Test\Phinx\Util;
 

--- a/tests/Phinx/Util/LiteralTest.php
+++ b/tests/Phinx/Util/LiteralTest.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Test\Phinx\Util;
 

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -1,7 +1,10 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx\Util;
 
+use DateTime;
+use DateTimeZone;
 use Phinx\Util\Util;
 use RuntimeException;
 use Test\Phinx\TestCase;
@@ -36,7 +39,7 @@ class UtilTest extends TestCase
 
     public function testGetCurrentTimestamp()
     {
-        $dt = new \DateTime('now', new \DateTimeZone('UTC'));
+        $dt = new DateTime('now', new DateTimeZone('UTC'));
         $expected = $dt->format(Util::DATE_FORMAT);
 
         $current = Util::getCurrentTimestamp();

--- a/tests/Phinx/Wrapper/TextWrapperTest.php
+++ b/tests/Phinx/Wrapper/TextWrapperTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Phinx\Wrapper;

--- a/tests/phpunit-bootstrap.php
+++ b/tests/phpunit-bootstrap.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**


### PR DESCRIPTION
cakephp-codesniffer 5 is meant to be paired with cakephp 5 code. One of the key changes is requiring native type declarations where possible.