### PR TITLE
Add declare strict_types to seed template

### DIFF
--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -198,7 +198,7 @@ class SeedCreate extends AbstractCommand
 
         $namespace = $config instanceof NamespaceAwareInterface ? $config->getSeedNamespaceByPath($path) : null;
         $classes = [
-            '$namespaceDefinition' => $namespace !== null ? ('namespace ' . $namespace . ';') : '',
+            '$namespaceDefinition' => $namespace !== null ? (PHP_EOL . 'namespace ' . $namespace . ';' . PHP_EOL) : '',
             '$namespace' => $namespace,
             '$useClassName' => $config->getSeedBaseClassName(false),
             '$className' => $className,

--- a/src/Phinx/Seed/Seed.template.php.dist
+++ b/src/Phinx/Seed/Seed.template.php.dist
@@ -1,6 +1,7 @@
 <?php
-$namespaceDefinition
 
+declare(strict_types=1);
+$namespaceDefinition
 use $useClassName;
 
 class $className extends $baseClassName


### PR DESCRIPTION
PR adds a `declare(strict_types=1);` to the seed template, which brings it inline with how our migrations template file works, where declare was added in https://github.com/cakephp/phinx/pull/1819. We should be highly forcing people to have correct types usage when interacting with their database to prevent any sort of unexpected data loss/corruption, such as talked about in the linked PR.