### PR TITLE
Ensure PostgresAdapter::useIdentity is always initialized

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -134,6 +134,9 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     {
         $this->connection = $connection;
 
+        // always set here since connect() isn't always called
+        $this->useIdentity = (float)$connection->getAttribute(PDO::ATTR_SERVER_VERSION) >= 10;
+
         // Create the schema table if it doesn't already exist
         if (!$this->hasTable($this->getSchemaTableName())) {
             $this->createSchemaTable();

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -115,8 +115,6 @@ class PostgresAdapter extends PdoAdapter
                 );
             }
 
-            $this->useIdentity = (float)$db->getAttribute(PDO::ATTR_SERVER_VERSION) >= 10;
-
             $this->setConnection($db);
         }
     }


### PR DESCRIPTION
Wrapper package would call setConection() without connect() causing useIdentity to not be set.