### PR TITLE
Allow Table::addColumn() to use type from Column object again

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -293,13 +293,14 @@ class Table
      * Valid options can be: limit, default, null, precision or scale.
      *
      * @param string|\Phinx\Db\Table\Column $columnName Column Name
-     * @param string|\Phinx\Util\Literal $type Column Type
+     * @param string|\Phinx\Util\Literal|null $type Column Type
      * @param array<string, mixed> $options Column Options
      * @throws \InvalidArgumentException
      * @return $this
      */
-    public function addColumn(string|Column $columnName, string|Literal $type, array $options = [])
+    public function addColumn(string|Column $columnName, string|Literal|null $type, array $options = [])
     {
+        assert($columnName instanceof Column || $type !== null);
         if ($columnName instanceof Column) {
             $action = new AddColumn($this->table, $columnName);
         } elseif ($type instanceof Literal) {
@@ -312,7 +313,7 @@ class Table
         if (!$this->getAdapter()->isValidColumnType($action->getColumn())) {
             throw new InvalidArgumentException(sprintf(
                 'An invalid column type "%s" was specified for column "%s".',
-                $type,
+                $action->getColumn()->getType(),
                 $action->getColumn()->getName()
             ));
         }


### PR DESCRIPTION
refs https://github.com/cakephp/phinx/pull/2218#discussion_r1333812072

I think this was removed after fixing a test that passed an invalid null, but we should allow the Column to define the type.