### PR TITLE
Fix inconsistencies with hasPrimaryKey

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -766,14 +766,13 @@ class MysqlAdapter extends PdoAdapter
 
         if ($constraint) {
             return $primaryKey['constraint'] === $constraint;
-        } else {
-            if (is_string($columns)) {
-                $columns = [$columns]; // str to array
-            }
-            $missingColumns = array_diff($columns, $primaryKey['columns']);
-
-            return empty($missingColumns);
         }
+
+        // Normalize the columns for comparison
+        $primaryKeyColumns = array_map('mb_strtolower', $primaryKey['columns']);
+        $columns = array_map('mb_strtolower', (array)$columns);
+
+        return $primaryKeyColumns === $columns;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -870,11 +870,7 @@ class PostgresAdapter extends PdoAdapter
             return $primaryKey['constraint'] === $constraint;
         }
 
-        // Normalize the columns for comparison
-        $primaryKeyColumns = array_map('mb_strtolower', $primaryKey['columns']);
-        $columns = array_map('mb_strtolower', (array)$columns);
-
-        return $primaryKeyColumns === $columns;
+        return $primaryKey['columns'] === (array)$columns;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -868,14 +868,13 @@ class PostgresAdapter extends PdoAdapter
 
         if ($constraint) {
             return $primaryKey['constraint'] === $constraint;
-        } else {
-            if (is_string($columns)) {
-                $columns = [$columns]; // str to array
-            }
-            $missingColumns = array_diff($columns, $primaryKey['columns']);
-
-            return empty($missingColumns);
         }
+
+        // Normalize the columns for comparison
+        $primaryKeyColumns = array_map('mb_strtolower', $primaryKey['columns']);
+        $columns = array_map('mb_strtolower', (array)$columns);
+
+        return $primaryKeyColumns === $columns;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -894,11 +894,7 @@ ORDER BY T.[name], I.[index_id];";
             return $primaryKey['constraint'] === $constraint;
         }
 
-        // Normalize the columns for comparison
-        $primaryKeyColumns = array_map('mb_strtolower', $primaryKey['columns']);
-        $columns = array_map('mb_strtolower', (array)$columns);
-
-        return $primaryKeyColumns === $columns;
+        return $primaryKey['columns'] === (array)$columns;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -894,12 +894,11 @@ ORDER BY T.[name], I.[index_id];";
             return $primaryKey['constraint'] === $constraint;
         }
 
-        if (is_string($columns)) {
-            $columns = [$columns]; // str to array
-        }
-        $missingColumns = array_diff($columns, $primaryKey['columns']);
+        // Normalize the columns for comparison
+        $primaryKeyColumns = array_map('mb_strtolower', $primaryKey['columns']);
+        $columns = array_map('mb_strtolower', (array)$columns);
 
-        return empty($missingColumns);
+        return $primaryKeyColumns === $columns;
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -587,6 +587,17 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($table->hasPrimaryKey(['column1', 'column2', 'column3', 'column4']));
     }
 
+    public function testHasPrimaryKeyCaseInsensitivity()
+    {
+        $table = new Table('table', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer', ['null' => false])
+            ->save();
+        
+        $this->assertTrue($table->hasPrimaryKey('column1'));
+        $this->assertTrue($table->hasPrimaryKey('cOlUmN1'));
+    }
+
     public function testAddComment()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -593,7 +593,7 @@ class MysqlAdapterTest extends TestCase
         $table
             ->addColumn('column1', 'integer', ['null' => false])
             ->save();
-        
+
         $this->assertTrue($table->hasPrimaryKey('column1'));
         $this->assertTrue($table->hasPrimaryKey('cOlUmN1'));
     }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -573,6 +573,20 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
     }
 
+    public function testHasPrimaryKeyMultipleColumns()
+    {
+        $table = new Table('table1', ['id' => false, 'primary_key' => ['column1', 'column2', 'column3']], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer', ['null' => false])
+            ->addColumn('column2', 'integer', ['null' => false])
+            ->addColumn('column3', 'integer', ['null' => false])
+            ->save();
+
+        $this->assertFalse($table->hasPrimaryKey(['column1', 'column2']));
+        $this->assertTrue($table->hasPrimaryKey(['column1', 'column2', 'column3']));
+        $this->assertFalse($table->hasPrimaryKey(['column1', 'column2', 'column3', 'column4']));
+    }
+
     public function testAddComment()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -446,6 +446,17 @@ class PostgresAdapterTest extends TestCase
         $this->assertFalse($table->hasPrimaryKey(['column1', 'column2', 'column3', 'column4']));
     }
 
+    public function testHasPrimaryKeyCaseSensitivity()
+    {
+        $table = new Table('table', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer', ['null' => false])
+            ->save();
+        
+        $this->assertTrue($table->hasPrimaryKey('column1'));
+        $this->assertFalse($table->hasPrimaryKey('cOlUmN1'));
+    }
+
     public function testAddComment()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -452,7 +452,7 @@ class PostgresAdapterTest extends TestCase
         $table
             ->addColumn('column1', 'integer', ['null' => false])
             ->save();
-        
+
         $this->assertTrue($table->hasPrimaryKey('column1'));
         $this->assertFalse($table->hasPrimaryKey('cOlUmN1'));
     }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -431,6 +431,21 @@ class PostgresAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
     }
 
+    public function testHasPrimaryKeyMultipleColumns()
+    {
+        $table = new Table('table1', ['id' => false, 'primary_key' => ['column1', 'column2', 'column3']], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer', ['null' => false])
+            ->addColumn('column2', 'integer', ['null' => false])
+            ->addColumn('column3', 'integer', ['null' => false])
+            ->addColumn('column4', 'integer', ['null' => false])
+            ->save();
+
+        $this->assertFalse($table->hasPrimaryKey(['column1', 'column2']));
+        $this->assertTrue($table->hasPrimaryKey(['column1', 'column2', 'column3']));
+        $this->assertFalse($table->hasPrimaryKey(['column1', 'column2', 'column3', 'column4']));
+    }
+
     public function testAddComment()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -429,6 +429,17 @@ class SQLiteAdapterTest extends TestCase
         $this->assertFalse($table->hasPrimaryKey(['column1', 'column2', 'column3', 'column4']));
     }
 
+    public function testHasPrimaryKeyCaseInsensitivity()
+    {
+        $table = new Table('table', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer', ['null' => false])
+            ->save();
+        
+        $this->assertTrue($table->hasPrimaryKey('column1'));
+        $this->assertTrue($table->hasPrimaryKey('cOlUmN1'));
+    }
+
     public function testAddMultipleColumnPrimaryKeyFails()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -435,7 +435,7 @@ class SQLiteAdapterTest extends TestCase
         $table
             ->addColumn('column1', 'integer', ['null' => false])
             ->save();
-        
+
         $this->assertTrue($table->hasPrimaryKey('column1'));
         $this->assertTrue($table->hasPrimaryKey('cOlUmN1'));
     }

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -415,6 +415,20 @@ class SQLiteAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
     }
 
+    public function testHasPrimaryKeyMultipleColumns()
+    {
+        $table = new Table('table1', ['id' => false, 'primary_key' => ['column1', 'column2', 'column3']], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer', ['null' => false])
+            ->addColumn('column2', 'integer', ['null' => false])
+            ->addColumn('column3', 'integer', ['null' => false])
+            ->save();
+
+        $this->assertFalse($table->hasPrimaryKey(['column1', 'column2']));
+        $this->assertTrue($table->hasPrimaryKey(['column1', 'column2', 'column3']));
+        $this->assertFalse($table->hasPrimaryKey(['column1', 'column2', 'column3', 'column4']));
+    }
+
     public function testAddMultipleColumnPrimaryKeyFails()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -372,6 +372,17 @@ WHERE t.name='ntable'");
         $this->assertFalse($table->hasPrimaryKey(['column1', 'column2', 'column3', 'column4']));
     }
 
+    public function testHasPrimaryKeyCaseSensitivity()
+    {
+        $table = new Table('table', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer', ['null' => false])
+            ->save();
+        
+        $this->assertTrue($table->hasPrimaryKey('column1'));
+        $this->assertFalse($table->hasPrimaryKey('cOlUmN1'));
+    }
+
     public function testChangeCommentFails()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -378,7 +378,7 @@ WHERE t.name='ntable'");
         $table
             ->addColumn('column1', 'integer', ['null' => false])
             ->save();
-        
+
         $this->assertTrue($table->hasPrimaryKey('column1'));
         $this->assertFalse($table->hasPrimaryKey('cOlUmN1'));
     }

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -358,6 +358,20 @@ WHERE t.name='ntable'");
         $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
     }
 
+    public function testHasPrimaryKeyMultipleColumns()
+    {
+        $table = new Table('table1', ['id' => false, 'primary_key' => ['column1', 'column2', 'column3']], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer', ['null' => false])
+            ->addColumn('column2', 'integer', ['null' => false])
+            ->addColumn('column3', 'integer', ['null' => false])
+            ->save();
+
+        $this->assertFalse($table->hasPrimaryKey(['column1', 'column2']));
+        $this->assertTrue($table->hasPrimaryKey(['column1', 'column2', 'column3']));
+        $this->assertFalse($table->hasPrimaryKey(['column1', 'column2', 'column3', 'column4']));
+    }
+
     public function testChangeCommentFails()
     {
         $table = new Table('table1', [], $this->adapter);


### PR DESCRIPTION
The `array_diff()` function was previously used incorrectly, which led to unexpected behavior. In the given scenario:

```
$primaryKey['columns'] = ['column1', 'column2', 'column3'];
$columns = ['column1', 'column2'];

$missingColumns = array_diff($columns, $primaryKey['columns']);

return empty($missingColumns);
```

The code would incorrectly return true because the existing primary key columns from `$primaryKey['columns']` were not used as the source (or "from" argument) in the `array_diff()` function.

To address this issue, the proposed changes ensure that the existing primary key columns from `$primaryKey['columns']` are correctly compared against the `$columns` method argument. This modification resolves the bug, making the comparison functionally correct.

This bug would not become apparent when removing one of the existing keys. It would only manifest when retaining the same columns and adding additional columns to the existing primary key.