### PR TITLE
📝 Update docs to reflect current PHP requirements.

### DIFF
--- a/docs/en/install.rst
+++ b/docs/en/install.rst
@@ -10,7 +10,7 @@ website for more information.
 
 .. note::
 
-    Phinx requires at least PHP 7.2 (or later).
+    Phinx requires at least PHP 8.1 (or later).
 
 To install Phinx, simply require it using Composer:
 


### PR DESCRIPTION
Spent a while trying to get things working on 7.4 before I realized this was just out of date. Looks like 8.1 is required as of 0.15 when things were moved to Cake 5?