### PR TITLE
Fix using test command with manual set config

### DIFF
--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -59,7 +59,10 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->loadConfig($input, $output);
+        if (!$this->hasConfig()) {
+            $this->loadConfig($input, $output);
+        }
+
         $this->loadManager($input, $output);
 
         // Verify the migrations path(s)


### PR DESCRIPTION
Fixes #2234 

PR fixes a bug where it was not possible to use the test command if you had manually done `->setConfig` on it, vs having an existing config file. This gets this command to operate similar to all the other commands, where they have the same check on running `->loadConfig` or not (via the `->bootstrap` method).