### PR TITLE
:recycle: default to null for type of column in addColumn

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -298,7 +298,7 @@ class Table
      * @throws \InvalidArgumentException
      * @return $this
      */
-    public function addColumn(string|Column $columnName, string|Literal|null $type, array $options = [])
+    public function addColumn(string|Column $columnName, string|Literal|null $type = null, array $options = [])
     {
         assert($columnName instanceof Column || $type !== null);
         if ($columnName instanceof Column) {

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -69,7 +69,7 @@ class TableTest extends TestCase
         $column->setName('email')
                ->setType('integer');
         $table = new Table('ntable', [], $adapter);
-        $table->addColumn($column, 'int');
+        $table->addColumn($column);
         $actions = $this->getPendingActions($table);
         $this->assertInstanceOf('Phinx\Db\Action\AddColumn', $actions[0]);
         $this->assertSame($column, $actions[0]->getColumn());


### PR DESCRIPTION
As accepting `null` for `$type` parameter was rollbacked in #2224, I think it is more consistent to default to null value after its removal in #2218. Passing `Column` object in first argument makes the `$type` parameter useless. So, the PR simplifies a bit the adding of a new column (modified in the unit test).