### PR TITLE
Loosen psr/container version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require": {
         "php-64bit": ">=8.1",
         "cakephp/database": "^5.0",
-        "psr/container": "^2.0",
+        "psr/container": "^1.1|^2.0",
         "symfony/console": "^6.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0"
     },


### PR DESCRIPTION
Closes #2227 

cakephp/cakephp@5.0.2 loosened their version constraint of `psr/container` when then allows us to loosen it as well, allowing both `^1.1` or `^2.0` to be used based on other things you might install alongside phinx.