### PR TITLE
Introduce getQueryBuilder aliases for specific database actions

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -65,7 +65,7 @@ EOT
     {
         $this->bootstrap($input, $output);
 
-        $version = is_null($input->getOption('target')) ? null : (int)$input->getOption('target');
+        $version = $input->getOption('target') !== null ? (int)$input->getOption('target'): null;
         /** @var string|null $environment */
         $environment = $input->getOption('environment');
         $date = $input->getOption('date');

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -65,7 +65,7 @@ EOT
     {
         $this->bootstrap($input, $output);
 
-        $version = is_null($input->getOption('target')) ? null : (int) $input->getOption('target');
+        $version = is_null($input->getOption('target')) ? null : (int)$input->getOption('target');
         /** @var string|null $environment */
         $environment = $input->getOption('environment');
         $date = $input->getOption('date');

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -65,7 +65,7 @@ EOT
     {
         $this->bootstrap($input, $output);
 
-        $version = $input->getOption('target');
+        $version = is_null($input->getOption('target')) ? null : (int) $input->getOption('target');
         /** @var string|null $environment */
         $environment = $input->getOption('environment');
         $date = $input->getOption('date');

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -65,7 +65,7 @@ EOT
     {
         $this->bootstrap($input, $output);
 
-        $version = $input->getOption('target') !== null ? (int)$input->getOption('target'): null;
+        $version = $input->getOption('target') !== null ? (int)$input->getOption('target') : null;
         /** @var string|null $environment */
         $environment = $input->getOption('environment');
         $date = $input->getOption('date');

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -9,6 +9,12 @@ declare(strict_types=1);
 namespace Phinx\Db\Adapter;
 
 use Cake\Database\Query;
+use Cake\Database\Query\{
+    DeleteQuery,
+    InsertQuery,
+    SelectQuery,
+    UpdateQuery
+};
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
 use Phinx\Migration\MigrationInterface;
@@ -286,6 +292,34 @@ interface AdapterInterface
      * @return \Cake\Database\Query
      */
     public function getQueryBuilder(string $type): Query;
+
+    /**
+     * Return a new SelectQuery object
+     * 
+     * @return \Cake\Database\Query\SelectQuery 
+     */
+    public function getSelectBuilder(): SelectQuery;
+
+    /**
+     * Return a new InsertQuery object
+     * 
+     * @return \Cake\Database\Query\InsertQuery 
+     */
+    public function getInsertBuilder(): InsertQuery;
+
+    /**
+     * Return a new UpdateQuery object
+     * 
+     * @return \Cake\Database\Query\UpdateQuery 
+     */
+    public function getUpdateBuilder(): UpdateQuery;
+
+    /**
+     * Return a new DeleteQuery object
+     * 
+     * @return \Cake\Database\Query\DeleteQuery 
+     */
+    public function getDeleteBuilder(): DeleteQuery;
 
     /**
      * Executes a SQL statement.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -9,12 +9,10 @@ declare(strict_types=1);
 namespace Phinx\Db\Adapter;
 
 use Cake\Database\Query;
-use Cake\Database\Query\{
-    DeleteQuery,
-    InsertQuery,
-    SelectQuery,
-    UpdateQuery
-};
+use Cake\Database\Query\DeleteQuery;
+use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\Query\UpdateQuery;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
 use Phinx\Migration\MigrationInterface;
@@ -295,29 +293,29 @@ interface AdapterInterface
 
     /**
      * Return a new SelectQuery object
-     * 
-     * @return \Cake\Database\Query\SelectQuery 
+     *
+     * @return \Cake\Database\Query\SelectQuery
      */
     public function getSelectBuilder(): SelectQuery;
 
     /**
      * Return a new InsertQuery object
-     * 
-     * @return \Cake\Database\Query\InsertQuery 
+     *
+     * @return \Cake\Database\Query\InsertQuery
      */
     public function getInsertBuilder(): InsertQuery;
 
     /**
      * Return a new UpdateQuery object
-     * 
-     * @return \Cake\Database\Query\UpdateQuery 
+     *
+     * @return \Cake\Database\Query\UpdateQuery
      */
     public function getUpdateBuilder(): UpdateQuery;
 
     /**
      * Return a new DeleteQuery object
-     * 
-     * @return \Cake\Database\Query\DeleteQuery 
+     *
+     * @return \Cake\Database\Query\DeleteQuery
      */
     public function getDeleteBuilder(): DeleteQuery;
 

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -9,12 +9,10 @@ declare(strict_types=1);
 namespace Phinx\Db\Adapter;
 
 use Cake\Database\Query;
-use Cake\Database\Query\{
-    SelectQuery,
-    InsertQuery,
-    UpdateQuery,
-    DeleteQuery
-};
+use Cake\Database\Query\DeleteQuery;
+use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\Query\UpdateQuery;
 use PDO;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
@@ -492,7 +490,6 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
         return $this->getAdapter()->getQueryBuilder($type);
     }
 
-
     /**
      * @inheritDoc
      */
@@ -523,5 +520,5 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     public function getDeleteBuilder(): DeleteQuery
     {
         return $this->getAdapter()->getDeleteBuilder();
-    }    
+    }
 }

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -9,6 +9,12 @@ declare(strict_types=1);
 namespace Phinx\Db\Adapter;
 
 use Cake\Database\Query;
+use Cake\Database\Query\{
+    SelectQuery,
+    InsertQuery,
+    UpdateQuery,
+    DeleteQuery
+};
 use PDO;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Table;
@@ -485,4 +491,37 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     {
         return $this->getAdapter()->getQueryBuilder($type);
     }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getSelectBuilder(): SelectQuery
+    {
+        return $this->getAdapter()->getSelectBuilder();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInsertBuilder(): InsertQuery
+    {
+        return $this->getAdapter()->getInsertBuilder();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUpdateBuilder(): UpdateQuery
+    {
+        return $this->getAdapter()->getUpdateBuilder();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDeleteBuilder(): DeleteQuery
+    {
+        return $this->getAdapter()->getDeleteBuilder();
+    }    
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -10,7 +10,14 @@ namespace Phinx\Db\Adapter;
 
 use BadMethodCallException;
 use Cake\Database\Connection;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Query;
+use Cake\Database\Query\{
+    SelectQuery,
+    InsertQuery,
+    UpdateQuery,
+    DeleteQuery
+};
 use InvalidArgumentException;
 use PDO;
 use PDOException;
@@ -242,6 +249,38 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                 'Query type must be one of: `select`, `insert`, `update`, `delete`.'
             )
         };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSelectBuilder(): SelectQuery
+    {
+        return $this->getDecoratedConnection()->selectQuery();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInsertBuilder(): InsertQuery
+    {
+        return $this->getDecoratedConnection()->insertQuery();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUpdateBuilder(): UpdateQuery
+    {
+        return $this->getDecoratedConnection()->updateQuery();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDeleteBuilder(): DeleteQuery
+    {
+        return $this->getDecoratedConnection()->deleteQuery();
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -10,14 +10,11 @@ namespace Phinx\Db\Adapter;
 
 use BadMethodCallException;
 use Cake\Database\Connection;
-use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Query;
-use Cake\Database\Query\{
-    SelectQuery,
-    InsertQuery,
-    UpdateQuery,
-    DeleteQuery
-};
+use Cake\Database\Query\DeleteQuery;
+use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\Query\UpdateQuery;
 use InvalidArgumentException;
 use PDO;
 use PDOException;

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -9,6 +9,12 @@ declare(strict_types=1);
 namespace Phinx\Migration;
 
 use Cake\Database\Query;
+use Cake\Database\Query\{
+    SelectQuery,
+    InsertQuery,
+    UpdateQuery,
+    DeleteQuery
+};
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
 use RuntimeException;
@@ -213,6 +219,38 @@ abstract class AbstractMigration implements MigrationInterface
     {
         return $this->getAdapter()->getQueryBuilder($type);
     }
+
+    /**
+     * @inheritDoc
+     */    
+    public function getSelectBuilder(): SelectQuery
+    {
+        return $this->getAdapter()->getSelectBuilder();
+    }
+
+    /**
+     * @inheritDoc
+     */    
+    public function getInsertBuilder(): InsertQuery
+    {
+        return $this->getAdapter()->getInsertBuilder();
+    }
+
+    /**
+     * @inheritDoc
+     */    
+    public function getUpdateBuilder(): UpdateQuery
+    {
+        return $this->getAdapter()->getUpdateBuilder();
+    }
+
+    /**
+     * @inheritDoc
+     */    
+    public function getDeleteBuilder(): DeleteQuery
+    {
+        return $this->getAdapter()->getDeleteBuilder();
+    }    
 
     /**
      * @inheritDoc

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -9,12 +9,10 @@ declare(strict_types=1);
 namespace Phinx\Migration;
 
 use Cake\Database\Query;
-use Cake\Database\Query\{
-    SelectQuery,
-    InsertQuery,
-    UpdateQuery,
-    DeleteQuery
-};
+use Cake\Database\Query\DeleteQuery;
+use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\Query\UpdateQuery;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
 use RuntimeException;
@@ -222,7 +220,7 @@ abstract class AbstractMigration implements MigrationInterface
 
     /**
      * @inheritDoc
-     */    
+     */
     public function getSelectBuilder(): SelectQuery
     {
         return $this->getAdapter()->getSelectBuilder();
@@ -230,7 +228,7 @@ abstract class AbstractMigration implements MigrationInterface
 
     /**
      * @inheritDoc
-     */    
+     */
     public function getInsertBuilder(): InsertQuery
     {
         return $this->getAdapter()->getInsertBuilder();
@@ -238,7 +236,7 @@ abstract class AbstractMigration implements MigrationInterface
 
     /**
      * @inheritDoc
-     */    
+     */
     public function getUpdateBuilder(): UpdateQuery
     {
         return $this->getAdapter()->getUpdateBuilder();
@@ -246,11 +244,11 @@ abstract class AbstractMigration implements MigrationInterface
 
     /**
      * @inheritDoc
-     */    
+     */
     public function getDeleteBuilder(): DeleteQuery
     {
         return $this->getAdapter()->getDeleteBuilder();
-    }    
+    }
 
     /**
      * @inheritDoc

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -9,12 +9,10 @@ declare(strict_types=1);
 namespace Phinx\Migration;
 
 use Cake\Database\Query;
-use Cake\Database\Query\{
-    SelectQuery,
-    InsertQuery,
-    UpdateQuery,
-    DeleteQuery
-};
+use Cake\Database\Query\DeleteQuery;
+use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\Query\UpdateQuery;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -172,47 +170,47 @@ interface MigrationInterface
     public function getQueryBuilder(string $type): Query;
 
     /**
-     * Returns a new SelectQuery object that can be used to build complex 
+     * Returns a new SelectQuery object that can be used to build complex
      * SELECT queries and execute them against the current database.
      *
      * Queries executed through the query builder are always sent to the database, regardless of the
      * the dry-run settings.
      *
-     * @return \Cake\Database\SelectQuery
-     */    
+     * @return \Cake\Database\Query\SelectQuery
+     */
     public function getSelectBuilder(): SelectQuery;
 
     /**
-     * Returns a new InsertQuery object that can be used to build complex 
+     * Returns a new InsertQuery object that can be used to build complex
      * INSERT queries and execute them against the current database.
      *
      * Queries executed through the query builder are always sent to the database, regardless of the
      * the dry-run settings.
      *
-     * @return \Cake\Database\InsertQuery
-     */     
+     * @return \Cake\Database\Query\InsertQuery
+     */
     public function getInsertBuilder(): InsertQuery;
 
     /**
-     * Returns a new UpdateQuery object that can be used to build complex 
+     * Returns a new UpdateQuery object that can be used to build complex
      * UPDATE queries and execute them against the current database.
      *
      * Queries executed through the query builder are always sent to the database, regardless of the
      * the dry-run settings.
      *
-     * @return \Cake\Database\UpdateQuery
-     */      
+     * @return \Cake\Database\Query\UpdateQuery
+     */
     public function getUpdateBuilder(): UpdateQuery;
 
     /**
-     * Returns a new DeleteQuery object that can be used to build complex 
+     * Returns a new DeleteQuery object that can be used to build complex
      * DELETE queries and execute them against the current database.
      *
      * Queries executed through the query builder are always sent to the database, regardless of the
      * the dry-run settings.
      *
-     * @return \Cake\Database\DeleteQuery
-     */      
+     * @return \Cake\Database\Query\DeleteQuery
+     */
     public function getDeleteBuilder(): DeleteQuery;
 
     /**

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -9,6 +9,12 @@ declare(strict_types=1);
 namespace Phinx\Migration;
 
 use Cake\Database\Query;
+use Cake\Database\Query\{
+    SelectQuery,
+    InsertQuery,
+    UpdateQuery,
+    DeleteQuery
+};
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -164,6 +170,50 @@ interface MigrationInterface
      * @return \Cake\Database\Query
      */
     public function getQueryBuilder(string $type): Query;
+
+    /**
+     * Returns a new SelectQuery object that can be used to build complex 
+     * SELECT queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @return \Cake\Database\SelectQuery
+     */    
+    public function getSelectBuilder(): SelectQuery;
+
+    /**
+     * Returns a new InsertQuery object that can be used to build complex 
+     * INSERT queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @return \Cake\Database\InsertQuery
+     */     
+    public function getInsertBuilder(): InsertQuery;
+
+    /**
+     * Returns a new UpdateQuery object that can be used to build complex 
+     * UPDATE queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @return \Cake\Database\UpdateQuery
+     */      
+    public function getUpdateBuilder(): UpdateQuery;
+
+    /**
+     * Returns a new DeleteQuery object that can be used to build complex 
+     * DELETE queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @return \Cake\Database\DeleteQuery
+     */      
+    public function getDeleteBuilder(): DeleteQuery;
 
     /**
      * Executes a query and returns only one row as an array.


### PR DESCRIPTION
Create action-specific methods which return specific data types for the query builder, rather than the parent \Cake\Database\Query object returned by getQueryBuilder().

Retain getQueryBuilder for BC.

Ref https://github.com/cakephp/phinx/issues/2238