### PR TITLE
Fix setting faked migrations as migrated

### DIFF
--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -86,12 +86,12 @@ class Environment
             $migration->{MigrationInterface::INIT}();
         }
 
-        if (!$fake) {
-            // begin the transaction if the adapter supports it
-            if ($this->getAdapter()->hasTransactions()) {
-                $this->getAdapter()->beginTransaction();
-            }
+        // begin the transaction if the adapter supports it
+        if ($this->getAdapter()->hasTransactions()) {
+            $this->getAdapter()->beginTransaction();
+        }
 
+        if (!$fake) {
             // Run the migration
             if (method_exists($migration, MigrationInterface::CHANGE)) {
                 if ($direction === MigrationInterface::DOWN) {
@@ -111,15 +111,16 @@ class Environment
             } else {
                 $migration->{$direction}();
             }
-
-            // Record it in the database
-            $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
-
-            // commit the transaction if the adapter supports it
-            if ($this->getAdapter()->hasTransactions()) {
-                $this->getAdapter()->commitTransaction();
-            }
         }
+
+        // Record it in the database
+        $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
+
+        // commit the transaction if the adapter supports it
+        if ($this->getAdapter()->hasTransactions()) {
+            $this->getAdapter()->commitTransaction();
+        }
+
         $migration->postFlightCheck();
     }
 

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -256,6 +256,29 @@ class EnvironmentTest extends TestCase
         $this->environment->executeMigration($migration, MigrationInterface::DOWN);
     }
 
+    public function testExecutingAFakeMigration()
+    {
+        // stub adapter
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+                    ->method('migrated')
+                    ->willReturn($adapterStub);
+
+        $this->environment->setAdapter($adapterStub);
+
+        // migration
+        $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+            ->setConstructorArgs(['mockenv', '20130301080000'])
+            ->setMethods(['change'])
+            ->getMock();
+        $migration->expects($this->never())
+                  ->method('change');
+
+        $this->environment->executeMigration($migration, MigrationInterface::UP, true);
+    }
+
     public function testGettingInputObject()
     {
         $mock = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')


### PR DESCRIPTION
PR fixes #2229 and includes a test for this functionality. There is a _slight_ change of functionality here where we will open/commit a DB transaction when running a fake migration, though I don't think that's at all a problem, and it makes the code much simpler.