### PR TITLE
Fix for MySQL 8 DEFAULT_GENERATED extra

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -567,8 +567,10 @@ class MysqlAdapter extends PdoAdapter
                 $comment = isset($row['Comment']) ? ' COMMENT ' . '\'' . addslashes($row['Comment']) . '\'' : '';
 
                 // create the extra string by also filtering out the DEFAULT_GENERATED option (MySQL 8 fix)
-                $extras = array_filter(explode(' ', strtoupper($row['Extra'])), function($value) {
-                    if ($value == 'DEFAULT_GENERATED') return false;
+                $extras = array_filter(explode(' ', strtoupper($row['Extra'])), function ($value) {
+                    if ($value == 'DEFAULT_GENERATED') {
+                        return false;
+                    }
                     return true;
                 });
                 $extra = implode(' ', $extras);

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -568,9 +568,9 @@ class MysqlAdapter extends PdoAdapter
 
                 // create the extra string by also filtering out the DEFAULT_GENERATED option (MySQL 8 fix)
                 $extras = array_filter(explode(' ', strtoupper($row['Extra'])), function ($value) {
-                    if ($value == 'DEFAULT_GENERATED') {
-                        return false;
-                    }
+                    // if ($value == 'DEFAULT_GENERATED') {
+                    //     return false;
+                    // }
 
                     return true;
                 });

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -571,6 +571,7 @@ class MysqlAdapter extends PdoAdapter
                     if ($value == 'DEFAULT_GENERATED') {
                         return false;
                     }
+
                     return true;
                 });
                 $extra = implode(' ', $extras);

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -573,14 +573,6 @@ class MysqlAdapter extends PdoAdapter
                 });
                 $extra = implode(' ', $extras);
 
-                if (is_array($extras)) {
-                    foreach ($extras as $e) {
-                        if ($e != 'DEFAULT_GENERATED') {
-                            $extra .= ' ' . $e;
-                        }
-                    }
-                }
-
                 if (($row['Default'] !== null)) {
                     $extra .= $this->getDefaultValueDefinition($row['Default']);
                 }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -568,9 +568,9 @@ class MysqlAdapter extends PdoAdapter
 
                 // create the extra string by also filtering out the DEFAULT_GENERATED option (MySQL 8 fix)
                 $extras = array_filter(explode(' ', strtoupper($row['Extra'])), function ($value) {
-                    // if ($value == 'DEFAULT_GENERATED') {
-                    //     return false;
-                    // }
+                    if ($value == 'DEFAULT_GENERATED') {
+                        return false;
+                    }
 
                     return true;
                 });

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -566,7 +566,7 @@ class MysqlAdapter extends PdoAdapter
                 $null = $row['Null'] === 'NO' ? 'NOT NULL' : 'NULL';
                 $comment = isset($row['Comment']) ? ' COMMENT ' . '\'' . addslashes($row['Comment']) . '\'' : '';
 
-                // create the extra string and filter out the DEFAULT_GENERATED option (MySQL 8 fix)
+                // create the extra string by also filtering out the DEFAULT_GENERATED option (MySQL 8 fix)
                 $extras = array_filter(explode(' ', strtoupper($row['Extra'])), function($value) {
                     if ($value == 'DEFAULT_GENERATED') return false;
                     return true;

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -929,6 +929,19 @@ class MysqlAdapterTest extends TestCase
         $this->assertEquals('comment1', $columns[1]['Comment']);
     }
 
+    public function testRenameColumnWithDefaultGeneratedExtra()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn('last_changed'));
+        $table->addColumn('last_changed', 'datetime', ['default' => 'CURRENT_TIMESTAMP', 'null' => false])
+              ->save();
+        $this->assertTrue($table->hasColumn('last_changed'));
+        $table->renameColumn('last_changed', 'last_changed2')->save();
+        $this->assertFalse($this->adapter->hasColumn('t', 'last_changed'));
+        $this->assertTrue($this->adapter->hasColumn('t', 'last_changed2'));
+    }
+
     public function testRenamingANonExistentColumn()
     {
         $table = new Table('t', [], $this->adapter);


### PR DESCRIPTION
Fix for MySQL 8 DEFAULT_GENERATED extra handling. 

DEFAULT_GENERATED in MySQL 8 appears automatically for columns that have an expression default value (e.g. default date). This is only a cosmetic/informational extra, that should NOT be used for recreating queries (CREATE or ALTER) and/or other database structures.

Fixes https://github.com/cakephp/phinx/issues/2138.