### PR TITLE
Fix fatal errors when calling get methods

### DIFF
--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -212,6 +212,10 @@ class Column
      */
     public function getType(): string|Literal
     {
+        if (!isset($this->type)) {
+            throw new RuntimeException('Cannot access `type` it has not been set');
+        }
+
         return $this->type;
     }
 

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -96,6 +96,10 @@ class ForeignKey
      */
     public function getReferencedTable(): Table
     {
+        if (!isset($this->referencedTable)) {
+            throw new RuntimeException('Cannot access `referencedTable` it has not been set');
+        }
+
         return $this->referencedTable;
     }
 

--- a/tests/Phinx/Db/Table/ColumnTest.php
+++ b/tests/Phinx/Db/Table/ColumnTest.php
@@ -20,6 +20,13 @@ class ColumnTest extends TestCase
         $column->setOptions(['identity']);
     }
 
+    public function testGetType()
+    {
+        $column = new Column();
+        $this->expectException(RuntimeException::class);
+        $column->getType();
+    }
+
     public function testSetOptionsIdentity()
     {
         $column = new Column();

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -34,6 +34,12 @@ class ForeignKeyTest extends TestCase
         $this->assertNull($this->fk->getOnUpdate());
     }
 
+    public function testRefrencedTableUndefined()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->fk->getReferencedTable();
+    }
+
     /**
      * @param string $dirtyValue
      * @param string $valueOfConstant


### PR DESCRIPTION
Replacing fatal errors with runtime exceptions. Fatal errors are tricky to catch and exceptions are much simpler to work with.