### PR TITLE
Make Abstract{Migration,Seed}::getAdapter return non-null

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -103,8 +103,12 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * @inheritDoc
      */
-    public function getAdapter(): ?AdapterInterface
+    public function getAdapter(): AdapterInterface
     {
+        if (!isset($this->adapter)) {
+            throw new RuntimeException('Cannot access `adapter` it has not been set');
+        }
+
         return $this->adapter;
     }
 

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -10,6 +10,7 @@ namespace Phinx\Seed;
 
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -98,6 +99,10 @@ abstract class AbstractSeed implements SeedInterface
      */
     public function getAdapter(): AdapterInterface
     {
+        if (!isset($this->adapter)) {
+            throw new RuntimeException('Cannot access `adapter` it has not been set');
+        }
+
         return $this->adapter;
     }
 

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -19,7 +19,8 @@ class AbstractMigrationTest extends TestCase
             ->getMock();
 
         // test methods
-        $this->assertNull($migrationStub->getAdapter());
+        $this->expectException(RuntimeException::class);
+        $migrationStub->getAdapter();
         $migrationStub->setAdapter($adapterStub);
         $this->assertInstanceOf(
             'Phinx\Db\Adapter\AdapterInterface',

--- a/tests/Phinx/Seed/AbstractSeedTest.php
+++ b/tests/Phinx/Seed/AbstractSeedTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Test\Phinx\Seed;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class AbstractSeedTest extends TestCase
+{
+    public function testAdapterMethods()
+    {
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Seed\AbstractSeed', ['mockenv', 20230102030405]);
+
+        // stub adapter
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs([[]])
+            ->getMock();
+
+        // test methods
+        $this->expectException(RuntimeException::class);
+        $migrationStub->getAdapter();
+        $migrationStub->setAdapter($adapterStub);
+        $this->assertInstanceOf(
+            'Phinx\Db\Adapter\AdapterInterface',
+            $migrationStub->getAdapter()
+        );
+    }
+}


### PR DESCRIPTION
Closes #2200 

Modifies the `getAdapter` method for the `AbstractMigration` and `AbstractSeed` classes to always return an adapter, or error if there is not one available. This is a change of behavior for `AbstractMigration` as it was documented as nullable before, while `AbstractSeed` would throw a fatal error if the adapter was not set. Now both will return a `\RuntimeException` if this method is called before an adapter has been set, but it's not expected that this should happen in user code unless they modify the constructor method to call it, but at that point it'd always be null so not sure why anyone would. As such, not considering this a BC break.