### PR TITLE
Reword null option description

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -778,7 +778,7 @@ Option  Description
 limit   set maximum length for strings, also hints column types in adapters (see note below)
 length  alias for ``limit``
 default set default value or action
-null    allow ``NULL`` values, defaults to false if `identity` option is set to true, else defaults to true
+null    allow ``NULL`` values, defaults to ``true`` (setting ``identity`` will override default to ``false``)
 after   specify the column that a new column should be placed after, or use ``\Phinx\Db\Adapter\MysqlAdapter::FIRST`` to place the column at the start of the table *(only applies to MySQL)*
 comment set a text comment on the column
 ======= ===========
@@ -806,7 +806,7 @@ For ``smallinteger``, ``integer`` and ``biginteger`` columns:
 ======== ===========
 Option   Description
 ======== ===========
-identity enable or disable automatic incrementing
+identity enable or disable automatic incrementing (if enabled, will set ``null: false`` if ``null`` is not set)
 signed   enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ======== ===========
 

--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -806,7 +806,7 @@ For ``smallinteger``, ``integer`` and ``biginteger`` columns:
 ======== ===========
 Option   Description
 ======== ===========
-identity enable or disable automatic incrementing (if enabled, will set ``null: false`` if ``null`` is not set)
+identity enable or disable automatic incrementing (if enabled, will set ``null: false`` if ``null`` option is not set)
 signed   enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ======== ===========
 


### PR DESCRIPTION
Closes #2207 

This rewords the `null` option so that it's hopefully more clear on how it functions, where it's `true` by default except when `identity` is set, in which case it'll be `false`.