### PR TITLE
Fixing errors when migration name is null

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -126,7 +126,7 @@ class Manager
             $versions = $env->getVersionLog();
 
             $maxNameLength = $versions ? max(array_map(function ($version) {
-                return strlen($version['migration_name']);
+                return strlen($version['migration_name'] ?? '');
             }, $versions)) : 0;
 
             $missingVersions = array_diff_key($versions, $migrations);
@@ -268,7 +268,7 @@ class Manager
             $version['version'],
             $version['start_time'],
             $version['end_time'],
-            str_pad($version['migration_name'], $maxNameLength, ' ')
+            str_pad($version['migration_name'] ?? '', $maxNameLength, ' ')
         ));
 
         if ($version && $version['breakpoint']) {


### PR DESCRIPTION
Upgraded PHP (to 8.1) and Phinx (to latest) an ran into some PHP TypeErrors when running our migrations.

We've been using Phinx for a very long time, and have some migration versions in our `phinxlog` that have a `null` migration_name since they were ran before there was a migration name column, and apparently that column is nullable.

This PR just adds a null coalescing operator in a couple of places that the TypeError was thrown. I've also added a test (based on another existing test, just with the migration_name changed to null) that did hit these TypeErrors (and don't with the code change in place).

We could just update our migrations to use an empty string, or populate the migration names, but figured this might benefit other Phinx users.