### PR TITLE
Move postFlighCheck to be called before commit transaction

### DIFF
--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -116,12 +116,12 @@ class Environment
         // Record it in the database
         $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
 
+        $migration->postFlightCheck();
+
         // commit the transaction if the adapter supports it
         if ($this->getAdapter()->hasTransactions()) {
             $this->getAdapter()->commitTransaction();
         }
-
-        $migration->postFlightCheck();
     }
 
     /**


### PR DESCRIPTION
`postFlightCheck` method throws an exception if there is any pending action. But calling it after commit transaction does not make sense because even when you get the exception the damage is already done since the actual action was not executed.

Moving it before commit transaction ensures that if you get an exception you will be able to run it again