### PR TITLE
Option for addTimeStamps() to use datetime

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -521,6 +521,11 @@ For some breaking changes, Phinx offers a way to opt-out of new behavior. The fo
 * ``unsigned_primary_keys``: Should Phinx create primary keys as unsigned integers? (default: ``true``)
 * ``column_null_default``: Should Phinx create columns as null by default? (default: ``true``)
 
+Since MySQL ``TIMESTAMP`` fields do not support dates past 2038-01-19, you have the option to use ``DATETIME`` field
+types for fields created by the ``addTimestamps()`` function:
+
+* ``add_timestamps_use_datetime``: Should Phinx create created_at and updated_at fields as datetime? (default: ``false``)
+
 .. code-block:: yaml
 
     feature_flags:

--- a/src/Phinx/Config/FeatureFlags.php
+++ b/src/Phinx/Config/FeatureFlags.php
@@ -22,6 +22,10 @@ class FeatureFlags
      * @var bool Should Phinx create columns NULL by default?
      */
     public static bool $columnNullDefault = true;
+    /**
+     * @var bool Should Phinx create datetime columns for addTimestamps instead of timestamp?
+     */
+    public static bool $addTimestampsUseDateTime = false;
 
     /**
      * Set the feature flags from the `feature_flags` section of the overall
@@ -36,6 +40,9 @@ class FeatureFlags
         }
         if (isset($config['column_null_default'])) {
             self::$columnNullDefault = (bool)$config['column_null_default'];
+        }
+        if (isset($config['add_timestamps_use_datetime'])) {
+            self::$addTimestampsUseDateTime = (bool)$config['add_timestamps_use_datetime'];
         }
     }
 }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -472,6 +472,10 @@ class MysqlAdapter extends PdoAdapter
                 $column->setIdentity(true);
             }
 
+            if ($columnInfo['Extra'] === 'on update CURRENT_TIMESTAMP') {
+                $column->setUpdate('CURRENT_TIMESTAMP');
+            }
+
             if (isset($phinxType['values'])) {
                 $column->setValues($phinxType['values']);
             }

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Phinx\Db;
 
 use InvalidArgumentException;
+use Phinx\Config\FeatureFlags;
 use Phinx\Db\Action\AddColumn;
 use Phinx\Db\Action\AddForeignKey;
 use Phinx\Db\Action\AddIndex;
@@ -542,8 +543,10 @@ class Table
             throw new RuntimeException('Cannot set both created_at and updated_at columns to false');
         }
 
+        $columnType = FeatureFlags::$addTimestampsUseDateTime ? 'datetime' : 'timestamp';
+
         if ($createdAt) {
-            $this->addColumn($createdAt, 'timestamp', [
+            $this->addColumn($createdAt, $columnType, [
                 'null' => false,
                 'default' => 'CURRENT_TIMESTAMP',
                 'update' => '',
@@ -551,7 +554,7 @@ class Table
             ]);
         }
         if ($updatedAt) {
-            $this->addColumn($updatedAt, 'timestamp', [
+            $this->addColumn($updatedAt, $columnType, [
                 'null' => true,
                 'default' => null,
                 'update' => 'CURRENT_TIMESTAMP',

--- a/tests/Phinx/Config/FeatureFlagsTest.php
+++ b/tests/Phinx/Config/FeatureFlagsTest.php
@@ -15,11 +15,14 @@ class FeatureFlagsTest extends TestCase
         $config = [
             'unsigned_primary_keys' => false,
             'column_null_default' => false,
+            'add_timestamps_use_datetime' => true,
         ];
         $this->assertTrue(FeatureFlags::$unsignedPrimaryKeys);
         $this->assertTrue(FeatureFlags::$columnNullDefault);
+        $this->assertFalse(FeatureFlags::$addTimestampsUseDateTime);
         FeatureFlags::setFlagsFromConfig($config);
         $this->assertFalse(FeatureFlags::$unsignedPrimaryKeys);
         $this->assertFalse(FeatureFlags::$columnNullDefault);
+        $this->assertTrue(FeatureFlags::$addTimestampsUseDateTime);
     }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -509,6 +509,36 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($columns[0]->getSigned());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAddTimestampsFeatureFlag()
+    {
+        $this->adapter->connect();
+
+        FeatureFlags::$addTimestampsUseDateTime = true;
+
+        $table = new Table('table1', [], $this->adapter);
+        $table->addTimestamps();
+        $table->create();
+
+        $columns = $this->adapter->getColumns('table1');
+
+        $this->assertCount(3, $columns);
+        $this->assertSame('id', $columns[0]->getName());
+
+        $this->assertEquals('created_at', $columns[1]->getName());
+        $this->assertEquals('datetime', $columns[1]->getType());
+        $this->assertEquals('CURRENT_TIMESTAMP', $columns[1]->getDefault());
+        $this->assertEquals('', $columns[1]->getUpdate());
+
+        $this->assertEquals('updated_at', $columns[2]->getName());
+        $this->assertEquals('datetime', $columns[2]->getType());
+        $this->assertEquals('CURRENT_TIMESTAMP', $columns[2]->getUpdate());
+        $this->assertTrue($columns[2]->isNull());
+        $this->assertNull($columns[2]->getDefault());
+    }
+
     public function testCreateTableWithLimitPK()
     {
         $table = new Table('ntable', ['id' => 'id', 'limit' => 4], $this->adapter);


### PR DESCRIPTION
Adds a feature flag to use datetime on MySQL for addTimestamps() function instead of timestamp.

Implements #1635 

timestamp columns do not support dates past 2038-01-19 on MySQL