### PR TITLE
Fix renaming column with Extra info set

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -574,7 +574,7 @@ class MysqlAdapter extends PdoAdapter
 
                     return true;
                 });
-                $extra = implode(' ', $extras);
+                $extra = ' ' . implode(' ', $extras);
 
                 if (($row['Default'] !== null)) {
                     $extra .= $this->getDefaultValueDefinition($row['Default']);

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -927,6 +927,19 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
     }
 
+    public function testRenameNonNullColumnWithExtra()
+    {
+        // Extra = "AUTO_INCREMENT" for the id column
+        $table = new Table('t', [], $this->adapter);
+        $table->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'id'));
+        $this->assertFalse($this->adapter->hasColumn('t', 'new_id'));
+
+        $table->renameColumn('id', 'new_id')->save();
+        $this->assertFalse($this->adapter->hasColumn('t', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('t', 'new_id'));
+    }
+
     public function testRenameColumnPreserveComment()
     {
         $table = new Table('t', [], $this->adapter);


### PR DESCRIPTION
Closes #2269 

PR fixes a bug introduced in #2253 where we were no longer prepending a space on the `$extra` variable, and so if it had a value along with `$null`, then the two would be appended together without a space and cause a syntax error. I've re-introduced the space in front of `$extra` that used to be there, as well as added a test to validate the fix.