### PR TITLE
Fix mysql latest CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Setup MySQL latest
       if: matrix.db-type == 'mysql' && matrix.php-version != '8.1'
-      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql
+      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:8.3
 
     - name: Setup MySQL 5.6
       if: matrix.db-type == 'mysql' && matrix.php-version == '8.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Setup MySQL latest
       if: matrix.db-type == 'mysql' && matrix.php-version != '8.1'
-      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql --default-authentication-plugin=mysql_native_password
+      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql
 
     - name: Setup MySQL 5.6
       if: matrix.db-type == 'mysql' && matrix.php-version == '8.1'


### PR DESCRIPTION
PR fixes the latest mysql CI workflow where:
* Removed the `default-authentication-plugin` flag, where this was removed in MySQL 8.4 in favor of a new `mysql-native-password`. However, given that PHP has supported the new auth scheme for 6 years, no real reason to keep using it.
* Pinned the workflow to use MySQL 8.3 right now, as something about 8.4 has introduced a break in the tests, and want to investigate that without blocking other work for now. Fixing this will be addressed as part of #2277.