### PR TITLE
Fix tests for MySQL 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2']
+        php-version: ['8.1', '8.2', '8.3']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
@@ -27,8 +27,12 @@ jobs:
 
     steps:
     - name: Setup MySQL latest
-      if: matrix.db-type == 'mysql' && matrix.php-version != '8.1'
-      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:8.3
+      if: matrix.db-type == 'mysql' && matrix.php-version == '8.3'
+      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:8.4
+
+    - name: Setup MySQL 8.0
+      if: matrix.db-type == 'mysql' && matrix.php-version == '8.2'
+      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:8.0
 
     - name: Setup MySQL 5.6
       if: matrix.db-type == 'mysql' && matrix.php-version == '8.1'

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1808,7 +1808,7 @@ class MysqlAdapterTest extends TestCase
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
             ->addColumn('field1', 'string', ['limit' => 8])
-            ->addIndex(['id', 'field1'])
+            ->addIndex(['id', 'field1'], ['unique' => true])
             ->save();
 
         $table = new Table('table', [], $this->adapter);
@@ -1897,7 +1897,7 @@ class MysqlAdapterTest extends TestCase
     public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec('CREATE TABLE other(a int, b int, c int, key(a), key(b), key(a,b), key(a,b,c));');
+        $conn->exec('CREATE TABLE other(a int, b int, c int, unique key(a), unique key(b), unique key(a,b), unique key(a,b,c));');
         $conn->exec($tableDef);
         $this->assertSame($exp, $this->adapter->hasForeignKey('t', $key));
     }


### PR DESCRIPTION
Fixes #2277 

The issue is caused by  a new behavior in Mysql 8.4 that throws an error when you create a FK in table A to table B if Table B does not have a unique constraint. 

```
SQLSTATE[HY000]: General error: 6125 Failed to add the foreign key constraint. Missing unique key for constraint 'FOREIGN_KEY' in the referenced table 'TABLE' 
```

There is a workaround setting variable RESTRICT_FK_ON_NON_STANDARD_KEY to OFF (ON by default) but in the case of the unit tests it would be enough to create keys as unique.

The report: https://bugs.mysql.com/bug.php?id=114838

@MasterOdin please let me know your thoughts