### PR TITLE
Add "nativeuuid" type for databases with native uuid support

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -53,6 +53,7 @@ interface AdapterInterface
     public const PHINX_TYPE_JSON = 'json';
     public const PHINX_TYPE_JSONB = 'jsonb';
     public const PHINX_TYPE_UUID = 'uuid';
+    public const PHINX_TYPE_NATIVEUUID = 'nativeuuid';
     public const PHINX_TYPE_FILESTREAM = 'filestream';
 
     // Geospatial database types

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1104,6 +1104,8 @@ class MysqlAdapter extends PdoAdapter
                 return ['name' => 'tinyint', 'limit' => 1];
             case static::PHINX_TYPE_UUID:
                 return ['name' => 'char', 'limit' => 36];
+            case static::PHINX_TYPE_NATIVEUUID:
+                return ['name' => 'uuid'];
             case static::PHINX_TYPE_YEAR:
                 if (!$limit || in_array($limit, [2, 4])) {
                     $limit = 4;
@@ -1221,6 +1223,10 @@ class MysqlAdapter extends PdoAdapter
                 if ($limit === 16) {
                     $type = static::PHINX_TYPE_BINARYUUID;
                 }
+                break;
+            case 'uuid':
+                $type = static::PHINX_TYPE_NATIVEUUID;
+                $limit = null;
                 break;
         }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1090,6 +1090,8 @@ class PostgresAdapter extends PdoAdapter
                 return ['name' => 'geography', 'type' => 'linestring', 'srid' => 4326];
             case static::PHINX_TYPE_POLYGON:
                 return ['name' => 'geography', 'type' => 'polygon', 'srid' => 4326];
+            case static::PHINX_TYPE_NATIVEUUID:
+                return ['name' => 'uuid'];
             default:
                 if ($this->isArrayType($type)) {
                     return ['name' => $type];

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1072,6 +1072,7 @@ class PostgresAdapter extends PdoAdapter
             case static::PHINX_TYPE_DATETIME:
                 return ['name' => 'timestamp'];
             case static::PHINX_TYPE_BINARYUUID:
+            case static::PHINX_TYPE_NATIVEUUID:
                 return ['name' => 'uuid'];
             case static::PHINX_TYPE_BLOB:
             case static::PHINX_TYPE_BINARY:
@@ -1090,8 +1091,6 @@ class PostgresAdapter extends PdoAdapter
                 return ['name' => 'geography', 'type' => 'linestring', 'srid' => 4326];
             case static::PHINX_TYPE_POLYGON:
                 return ['name' => 'geography', 'type' => 'polygon', 'srid' => 4326];
-            case static::PHINX_TYPE_NATIVEUUID:
-                return ['name' => 'uuid'];
             default:
                 if ($this->isArrayType($type)) {
                     return ['name' => $type];

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1092,6 +1092,7 @@ ORDER BY T.[name], I.[index_id];";
                 return ['name' => 'bit'];
             case static::PHINX_TYPE_BINARYUUID:
             case static::PHINX_TYPE_UUID:
+            case static::PHINX_TYPE_NATIVEUUID:
                 return ['name' => 'uniqueidentifier'];
             case static::PHINX_TYPE_FILESTREAM:
                 return ['name' => 'varbinary', 'limit' => 'max'];

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -36,6 +36,7 @@ class Column
     public const TIMESTAMP = AdapterInterface::PHINX_TYPE_TIMESTAMP;
     public const UUID = AdapterInterface::PHINX_TYPE_UUID;
     public const BINARYUUID = AdapterInterface::PHINX_TYPE_BINARYUUID;
+    public const NATIVEUUID = AdapterInterface::PHINX_TYPE_NATIVEUUID;
     /** MySQL-only column type */
     public const MEDIUMINTEGER = AdapterInterface::PHINX_TYPE_MEDIUM_INTEGER;
     /** MySQL-only column type */


### PR DESCRIPTION
This is to allow the use of the native uuid for mariadb 10.7+ users. For other database it's simply an alias to the existing uuid type. Sqlite is explicitly not supported because it doesnt have a native type.

Related Issue: https://github.com/cakephp/phinx/issues/2256

Note: To test this you need an to add 'nativeuuid' to Cake\Database\TypeFactory $_types.

Once this is accepted I can also do the change in CakePHP.
