### PR TITLE
Fix docs example for migrate create

### DIFF
--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -21,7 +21,7 @@ command:
         $ vendor/bin/phinx create MyNewMigration
 
 This will create a new migration in the format
-``YYYYMMDDHHMMSS_MyNewMigration.php``, where the first 14 characters are
+``YYYYMMDDHHMMSS_my_new_migration.php``, where the first 14 characters are
 replaced with the current timestamp down to the second.
 
 If you have specified multiple migration paths, you will be asked to select


### PR DESCRIPTION
This reverts commit 1187a5b179ca080d228a7efc53167f4be5643a1a.

From https://github.com/cakephp/phinx/pull/2263#issuecomment-1919585724:

> When you provide a class name, then we hit this line to get the filename:
> 
> https://github.com/cakephp/phinx/blob/5c28445848a1daba6883dd94f77c0feef0db3d28/src/Phinx/Console/Command/Create.php#L183
> 
> which per the comment:
> 
> https://github.com/cakephp/phinx/blob/5c28445848a1daba6883dd94f77c0feef0db3d28/src/Phinx/Util/Util.php#L103-L105

The tests for this function also back up the behavior here:

https://github.com/cakephp/phinx/blob/5c28445848a1daba6883dd94f77c0feef0db3d28/tests/Phinx/Util/UtilTest.php#L71-L86

I think the capitalization that the docs was changed to might be a cakephp/migrations thing and not what phinx itself does?