### PR TITLE
Fix using string primary_key value for sqlite

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -424,6 +424,9 @@ class SQLiteAdapter extends PdoAdapter
 
         $sql = 'CREATE TABLE ';
         $sql .= $this->quoteTableName($table->getName()) . ' (';
+        if (isset($options['primary_key'])) {
+            $options['primary_key'] = (array)$options['primary_key'];
+        }
         foreach ($columns as $column) {
             $sql .= $this->quoteColumnName($column->getName()) . ' ' . $this->getColumnSqlDefinition($column) . ', ';
 
@@ -446,9 +449,7 @@ class SQLiteAdapter extends PdoAdapter
         if (isset($options['primary_key'])) {
             $sql = rtrim($sql);
             $sql .= ' PRIMARY KEY (';
-            if (is_string($options['primary_key'])) { // handle primary_key => 'id'
-                $sql .= $this->quoteColumnName($options['primary_key']);
-            } elseif (is_array($options['primary_key'])) { // handle primary_key => array('tag_id', 'resource_id')
+            if (is_array($options['primary_key'])) { // handle primary_key => array('tag_id', 'resource_id')
                 $sql .= implode(',', array_map([$this, 'quoteColumnName'], $options['primary_key']));
             }
             $sql .= ')';

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -176,6 +176,22 @@ class SQLiteAdapterTest extends TestCase
 
         $this->assertTrue($this->adapter->hasTable('ntable'));
         $this->assertTrue($this->adapter->hasColumn('ntable', 'custom_id'));
+        $this->assertTrue($this->adapter->hasPrimaryKey('ntable', 'custom_id'));
+
+        /** @var \Phinx\Db\Table\Column $idColumn */
+        $idColumn = $this->adapter->getColumns('ntable')[0];
+        $this->assertTrue($idColumn->getIdentity());
+    }
+
+    public function testCreateTableIdentityIdColumnStringPrimaryKey()
+    {
+        $table = new Table('ntable', ['id' => false, 'primary_key' => 'custom_id'], $this->adapter);
+        $table->addColumn('custom_id', 'integer', ['identity' => true])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'custom_id'));
+        $this->assertTrue($this->adapter->hasPrimaryKey('ntable', 'custom_id'));
 
         /** @var \Phinx\Db\Table\Column $idColumn */
         $idColumn = $this->adapter->getColumns('ntable')[0];


### PR DESCRIPTION
Fixes #2283

PR fixes a bug for sqlite where if a string value was passed for the `primary_key` option, then following error would be thrown:

```
ArgumentCountError: Too few arguments to function Phinx\Db\Adapter\SQLiteAdapter::hasPrimaryKey(), 1 passed in /home/mpeveler/github/phinx/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php on line 179 and at least 2 expected
```

Surprisingly, this looks like it's been broken for 4+ years, though I guess not too many people use sqlite and use custom identity columns for primary keys.