### PR TITLE
Fix quoting DB name when creating/dropping

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1301,13 +1301,13 @@ class MysqlAdapter extends PdoAdapter
 
         if (isset($options['collation'])) {
             $this->execute(sprintf(
-                'CREATE DATABASE `%s` DEFAULT CHARACTER SET `%s` COLLATE `%s`',
-                $name,
+                'CREATE DATABASE %s DEFAULT CHARACTER SET `%s` COLLATE `%s`',
+                $this->quoteColumnName($name),
                 $charset,
                 $options['collation']
             ));
         } else {
-            $this->execute(sprintf('CREATE DATABASE `%s` DEFAULT CHARACTER SET `%s`', $name, $charset));
+            $this->execute(sprintf('CREATE DATABASE %s DEFAULT CHARACTER SET `%s`', $this->quoteColumnName($name), $charset));
         }
     }
 
@@ -1337,7 +1337,7 @@ class MysqlAdapter extends PdoAdapter
      */
     public function dropDatabase(string $name): void
     {
-        $this->execute(sprintf('DROP DATABASE IF EXISTS `%s`', $name));
+        $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $this->quoteColumnName($name)));
         $this->createdTables = [];
     }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1178,7 +1178,7 @@ class PostgresAdapter extends PdoAdapter
     public function createDatabase(string $name, array $options = []): void
     {
         $charset = $options['charset'] ?? 'utf8';
-        $this->execute(sprintf("CREATE DATABASE %s WITH ENCODING = '%s'", $name, $charset));
+        $this->execute(sprintf("CREATE DATABASE %s WITH ENCODING = '%s'", $this->quoteColumnName($name), $charset));
     }
 
     /**
@@ -1198,7 +1198,7 @@ class PostgresAdapter extends PdoAdapter
     public function dropDatabase($name): void
     {
         $this->disconnect();
-        $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $name));
+        $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $this->quoteColumnName($name)));
         $this->createdTables = [];
         $this->connect();
     }

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1174,12 +1174,13 @@ ORDER BY T.[name], I.[index_id];";
      */
     public function createDatabase(string $name, array $options = []): void
     {
+        $databaseName = $this->quoteColumnName($name);
         if (isset($options['collation'])) {
-            $this->execute(sprintf('CREATE DATABASE [%s] COLLATE [%s]', $name, $options['collation']));
+            $this->execute(sprintf('CREATE DATABASE %s COLLATE [%s]', $databaseName, $options['collation']));
         } else {
-            $this->execute(sprintf('CREATE DATABASE [%s]', $name));
+            $this->execute(sprintf('CREATE DATABASE %s', $databaseName));
         }
-        $this->execute(sprintf('USE [%s]', $name));
+        $this->execute(sprintf('USE %s', $databaseName));
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2035,6 +2035,24 @@ class MysqlAdapterTest extends TestCase
         $this->adapter->dropDatabase('phinx_temp_database');
     }
 
+    public function testDatabaseNameWithEscapedCharacter()
+    {
+        $databaseName = MYSQL_DB_CONFIG['name'] . '-`test`';
+        $this->adapter->dropDatabase($databaseName);
+        $this->adapter->createDatabase($databaseName);
+        $this->assertTrue($this->adapter->hasDatabase($databaseName));
+        $this->adapter->dropDatabase($databaseName);
+    }
+
+    public function testDatabaseNameWithEscapedCharacterWithCollation()
+    {
+        $databaseName = MYSQL_DB_CONFIG['name'] . '-`test`';
+        $this->adapter->dropDatabase($databaseName);
+        $this->adapter->createDatabase($databaseName, ['charset' => 'utf8mb4', 'collation' => 'utf8mb4_unicode_ci']);
+        $this->assertTrue($this->adapter->hasDatabase($databaseName));
+        $this->adapter->dropDatabase($databaseName);
+    }
+
     public function testAddColumnWithComment()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1895,6 +1895,15 @@ class PostgresAdapterTest extends TestCase
         $this->adapter->dropDatabase('phinx_temp_database');
     }
 
+    public function testDatabaseNameWithEscapedCharacter()
+    {
+        $databaseName = PGSQL_DB_CONFIG['name'] . '-test';
+        $this->adapter->dropDatabase($databaseName);
+        $this->adapter->createDatabase($databaseName);
+        $this->assertTrue($this->adapter->hasDatabase($databaseName));
+        $this->adapter->dropDatabase($databaseName);
+    }
+
     public function testCreateSchema()
     {
         $this->adapter->createSchema('foo');

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -1127,6 +1127,24 @@ WHERE t.name='ntable'");
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'my_constraint2'));
     }
 
+    public function testDatabaseNameWithEscapedCharacter()
+    {
+        $databaseName = SQLSRV_DB_CONFIG['name'] . '-[test]';
+        $this->adapter->dropDatabase($databaseName);
+        $this->adapter->createDatabase($databaseName);
+        $this->assertTrue($this->adapter->hasDatabase($databaseName));
+        $this->adapter->dropDatabase($databaseName);
+    }
+
+    public function testDatabaseNameWithEscapedCharacterWithCollation()
+    {
+        $databaseName = SQLSRV_DB_CONFIG['name'] . '-[test]';
+        $this->adapter->dropDatabase($databaseName);
+        $this->adapter->createDatabase($databaseName, ['collation' => 'SQL_Latin1_General_CP1_CS_AS']);
+        $this->assertTrue($this->adapter->hasDatabase($databaseName));
+        $this->adapter->dropDatabase($databaseName);
+    }
+
     public function testHasDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('fake_database_name'));


### PR DESCRIPTION
Port of https://github.com/cakephp/migrations/pull/717 to phinx which fixed using values that needed being escaped for mysql, but did not fix it for postgres or sqlserver.

I think there is still issues in some other places the DB name can be referenced in being quoted, but they're used within `WHERE` clauses within a SQL statement, and the fix there is to rework the queries to be parameterized vs using `sprintf`, which can be done in a follow-up PR.