### PR TITLE
Fix escaping database name for SqlServerAdapter::dropDatabase

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -211,7 +211,7 @@ class SqlServerAdapter extends PdoAdapter
      */
     public function quoteColumnName(string $columnName): string
     {
-        return '[' . str_replace(']', '\]', $columnName) . ']';
+        return '[' . str_replace(']', ']]', $columnName) . ']';
     }
 
     /**
@@ -1176,7 +1176,7 @@ ORDER BY T.[name], I.[index_id];";
     {
         $databaseName = $this->quoteColumnName($name);
         if (isset($options['collation'])) {
-            $this->execute(sprintf('CREATE DATABASE %s COLLATE [%s]', $databaseName, $options['collation']));
+            $this->execute(sprintf('CREATE DATABASE %s COLLATE %s', $databaseName, $options['collation']));
         } else {
             $this->execute(sprintf('CREATE DATABASE %s', $databaseName));
         }
@@ -1206,7 +1206,7 @@ ORDER BY T.[name], I.[index_id];";
     {
         $sql = sprintf(
             'USE master;
-            IF EXISTS(select * from sys.databases where name=N\'$name\')
+            IF EXISTS(select * from sys.databases where name=N\'' . $name .'\')
             ALTER DATABASE %1$s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
             DROP DATABASE %1$s;',
             $this->quoteColumnName($name),

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1204,12 +1204,13 @@ ORDER BY T.[name], I.[index_id];";
      */
     public function dropDatabase(string $name): void
     {
-        $sql = <<<SQL
-USE master;
-IF EXISTS(select * from sys.databases where name=N'$name')
-ALTER DATABASE [$name] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
-DROP DATABASE [$name];
-SQL;
+        $sql = sprintf(
+            'USE master;
+            IF EXISTS(select * from sys.databases where name=N\'$name\')
+            ALTER DATABASE %1$s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+            DROP DATABASE %1$s;',
+            $this->quoteColumnName($name),
+        );
         $this->execute($sql);
         $this->createdTables = [];
     }

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1206,7 +1206,7 @@ ORDER BY T.[name], I.[index_id];";
     {
         $sql = sprintf(
             'USE master;
-            IF EXISTS(select * from sys.databases where name=N\'' . $name .'\')
+            IF EXISTS(select * from sys.databases where name=N\'' . $name . '\')
             ALTER DATABASE %1$s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
             DROP DATABASE %1$s;',
             $this->quoteColumnName($name),

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -129,9 +129,20 @@ class SqlServerAdapterTest extends TestCase
         $this->assertEquals('[test_table]', $this->adapter->quoteTableName('test_table'));
     }
 
-    public function testQuoteColumnName()
+    public function columnNameDataProvider(): array
     {
-        $this->assertEquals('[test_column]', $this->adapter->quoteColumnName('test_column'));
+        return [
+            ['test_column', '[test_column]'],
+            ['test_col[u]mn', '[test_col[u]]mn]'],
+        ];
+    }
+
+    /**
+     * @dataProvider columnNameDataProvider
+     */
+    public function testQuoteColumnName(string $columnName, string $expected)
+    {
+        $this->assertEquals($expected, $this->adapter->quoteColumnName($columnName));
     }
 
     public function testCreateTable()


### PR DESCRIPTION
PR fixes a bug introduced in #2286 that broke dropping databases in sqlserver. I've fixed the syntax so that it actually works for database names that need escaping, discovering as well that the escaping of column names was also broken. Per https://learn.microsoft.com/en-us/previous-versions/sql/sql-server-2008-r2/ms176027(v=sql.105)?redirectedfrom=MSDN, to escape an identifier that has brackets, need to double up the brackets, not use `\`.