### PR TITLE
2288 - Add name and version to pending actions error and apply 2272 to 0.13.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,29 +13,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
-          - php-version: '7.2'
+          - php-version: '7.4'
             db-type: mysql
             prefer-lowest: prefer-lowest
 
     steps:
     - name: Setup MySQL latest
-      if: matrix.db-type == 'mysql' && matrix.php-version != '7.2'
-      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql --default-authentication-plugin=mysql_native_password
+      if: matrix.db-type == 'mysql' && matrix.php-version != '7.4'
+      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:8.3 --default-authentication-plugin=mysql_native_password
 
     - name: Setup MySQL 5.6
-      if: matrix.db-type == 'mysql' && matrix.php-version == '7.2'
+      if: matrix.db-type == 'mysql' && matrix.php-version == '7.4'
       run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:5.6 --character-set-server=utf8
 
     - name: Setup PostgreSQL latest
-      if: matrix.db-type == 'pgsql' && matrix.php-version != '7.2'
+      if: matrix.db-type == 'pgsql' && matrix.php-version != '7.4'
       run: docker run --rm --name=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=cakephp -p 5432:5432 -d postgres
 
     - name: Setup PostgreSQL 9.4
-      if: matrix.db-type == 'pgsql' && matrix.php-version == '7.2'
+      if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4'
       run: docker run --rm --name=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=cakephp -p 5432:5432 -d postgres:9.4
 
     - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
         fi
 
     - name: Setup problem matchers for PHPUnit
-      if: matrix.php-version == '7.2' && matrix.db-type == 'mysql'
+      if: matrix.php-version == '7.4' && matrix.db-type == 'mysql'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Setup Database
@@ -109,11 +109,11 @@ jobs:
 
   testsuite-windows:
     runs-on: windows-2019
-    name: Windows - PHP 7.2 & SQL Server
+    name: Windows - PHP 7.4 & SQL Server
 
     env:
       EXTENSIONS: pdo_sqlsrv
-      PHP_VERSION: '7.2'
+      PHP_VERSION: '7.4'
 
     steps:
     - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4.0",
         "cakephp/database": "^4.0",
         "psr/container": "^1.0 || ^2.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -317,7 +317,7 @@ abstract class AbstractMigration implements MigrationInterface
     {
         foreach ($this->tables as $table) {
             if ($table->hasPendingActions()) {
-                throw new RuntimeException('Migration has pending actions after execution!');
+                throw new RuntimeException(sprintf('Migration %s_%s has pending actions after execution!', $this->getVersion(), $this->getName()));
             }
         }
     }

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -110,17 +110,17 @@ class Environment
             } else {
                 $migration->{$direction}();
             }
-
-            // commit the transaction if the adapter supports it
-            if ($this->getAdapter()->hasTransactions()) {
-                $this->getAdapter()->commitTransaction();
-            }
         }
-
-        $migration->postFlightCheck();
 
         // Record it in the database
         $this->getAdapter()->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
+
+        $migration->postFlightCheck();
+
+        // commit the transaction if the adapter supports it
+        if ($this->getAdapter()->hasTransactions()) {
+            $this->getAdapter()->commitTransaction();
+        }
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2070,6 +2070,11 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
+        if (method_exists(\Cake\Database\Connection::class, 'selectQuery')) {
+            $this->expectDeprecation();
+            $this->expectExceptionMessage('As of 4.5.0, using newQuery() is deprecated. Instead, use `insertQuery()`, `deleteQuery()`, `selectQuery()` or `updateQuery()`. The query objects returned by these methods will emit deprecations that will become fatal errors in 5.0.See https://book.cakephp.org/4/en/appendices/4-5-migration-guide.html for more information');
+        }
+
         $builder = $this->adapter->getQueryBuilder();
         $stm = $builder
             ->insert(['string_col', 'int_col'])

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2415,6 +2415,11 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
+        if (method_exists(\Cake\Database\Connection::class, 'selectQuery')) {
+            $this->expectDeprecation();
+            $this->expectExceptionMessage('As of 4.5.0, using newQuery() is deprecated. Instead, use `insertQuery()`, `deleteQuery()`, `selectQuery()` or `updateQuery()`. The query objects returned by these methods will emit deprecations that will become fatal errors in 5.0.See https://book.cakephp.org/4/en/appendices/4-5-migration-guide.html for more information');
+        }
+
         $builder = $this->adapter->getQueryBuilder();
         $stm = $builder
             ->insert(['string_col', 'int_col'])

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1274,6 +1274,11 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
+        if (method_exists(\Cake\Database\Connection::class, 'selectQuery')) {
+            $this->expectDeprecation();
+            $this->expectExceptionMessage('As of 4.5.0, using newQuery() is deprecated. Instead, use `insertQuery()`, `deleteQuery()`, `selectQuery()` or `updateQuery()`. The query objects returned by these methods will emit deprecations that will become fatal errors in 5.0.See https://book.cakephp.org/4/en/appendices/4-5-migration-guide.html for more information');
+        }
+
         $builder = $this->adapter->getQueryBuilder();
         $stm = $builder
             ->insert(['string_col', 'int_col'])

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -1130,6 +1130,11 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
+        if (method_exists(\Cake\Database\Connection::class, 'selectQuery')) {
+            $this->expectDeprecation();
+            $this->expectExceptionMessage('As of 4.5.0, using newQuery() is deprecated. Instead, use `insertQuery()`, `deleteQuery()`, `selectQuery()` or `updateQuery()`. The query objects returned by these methods will emit deprecations that will become fatal errors in 5.0.See https://book.cakephp.org/4/en/appendices/4-5-migration-guide.html for more information');
+        }
+
         $builder = $this->adapter->getQueryBuilder();
         $stm = $builder
             ->insert(['string_col', 'int_col'])

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -277,7 +277,7 @@ class AbstractMigrationTest extends TestCase
         $table->addColumn('column1', 'integer', ['null' => true]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Migration has pending actions after execution!');
+        $this->expectExceptionMessage(sprintf('Migration %s_%s has pending actions after execution!', $migrationStub->getVersion(), $migrationStub->getName()));
 
         $migrationStub->postFlightCheck();
     }

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -262,7 +262,7 @@ class AbstractMigrationTest extends TestCase
     public function testPostFlightCheckFail()
     {
         // stub migration
-        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 0]);
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', ['mockenv', 20230102030405], 'PostFlightCheck');
 
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
             ->setConstructorArgs([[]])
@@ -277,7 +277,7 @@ class AbstractMigrationTest extends TestCase
         $table->addColumn('column1', 'integer', ['null' => true]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(sprintf('Migration %s_%s has pending actions after execution!', $migrationStub->getVersion(), $migrationStub->getName()));
+        $this->expectExceptionMessage('Migration 20230102030405_PostFlightCheck has pending actions after execution!');
 
         $migrationStub->postFlightCheck();
     }


### PR DESCRIPTION
Fixes #2288 (originally https://github.com/cakephp/migrations/issues/719) and applies #2272 to 0.13.x (CakePHP Migrations 3.x - CakePHP 4)