### PR TITLE
Show version in CLI

### DIFF
--- a/box.json
+++ b/box.json
@@ -5,6 +5,7 @@
         "KevinGH\\Box\\Compactor\\Php"
     ],
     "directories": ["src", "app", "data", "vendor/symfony/console/Resources"],
+    "exclude-composer-files": false,
     "files": [
         "LICENSE"
     ],
@@ -24,6 +25,6 @@
             "in": "vendor"
         }
     ],
-    "output": "phinx.phar",
-    "exclude-composer-files": false
+    "git-tag": "git_tag",
+    "output": "phinx.phar"
 }

--- a/composer.json
+++ b/composer.json
@@ -37,17 +37,18 @@
     ],
     "require": {
         "php-64bit": ">=8.1",
+        "composer-runtime-api": "^2.0",
         "cakephp/database": "^5.0.2",
         "psr/container": "^1.1|^2.0",
-        "symfony/console": "^6.0|^7.0",
-        "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0"
+        "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",
+        "symfony/console": "^6.0|^7.0"
     },
     "require-dev": {
         "ext-json": "*",
         "ext-pdo": "*",
-        "phpunit/phpunit": "^9.5.19",
         "cakephp/cakephp": "^5.0.2",
         "cakephp/cakephp-codesniffer": "^5.0",
+        "phpunit/phpunit": "^9.5.19",
         "symfony/yaml": "^3.4|^4.0|^5.0|^6.0|^7.0"
     },
     "autoload": {

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Phinx\Console;
 
+use Composer\InstalledVersions;
 use Phinx\Console\Command\Breakpoint;
 use Phinx\Console\Command\Create;
 use Phinx\Console\Command\Init;
@@ -28,11 +29,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 class PhinxApplication extends Application
 {
     /**
+     * @var string The current application version as determined by the getVersion() function.
+     */
+    private string $version;
+
+    /**
      * Initialize the Phinx console application.
      */
     public function __construct()
     {
-        parent::__construct('Phinx by CakePHP - https://phinx.org.');
+        parent::__construct('Phinx by CakePHP - https://phinx.org.', $this->getVersion());
 
         $this->addCommands([
             new Init(),
@@ -67,5 +73,27 @@ class PhinxApplication extends Application
         }
 
         return parent::doRun($input, $output);
+    }
+
+    /**
+     * Get the current application version.
+     *
+     * @return string The application version if it could be found, otherwise 'UNKNOWN'
+     */
+    public function getVersion(): string
+    {
+        if (isset($this->version)) {
+            return $this->version;
+        }
+
+        // humbug/box will replace this with actual version when building
+        // so use that if available
+        $gitTag = '@git_tag@';
+        if (!str_starts_with($gitTag, '@')) {
+            return $this->version = $gitTag;
+        }
+
+        // Otherwise fallback to the version as reported by composer
+        return $this->version = InstalledVersions::getPrettyVersion('robmorgan/phinx') ?? 'UNKNOWN';
     }
 }

--- a/tests/Phinx/Console/PhinxApplicationTest.php
+++ b/tests/Phinx/Console/PhinxApplicationTest.php
@@ -25,7 +25,10 @@ class PhinxApplicationTest extends TestCase
         $stream = $appTester->getOutput()->getStream();
         rewind($stream);
 
-        $this->assertStringContainsString($result, stream_get_contents($stream));
+        $contents = stream_get_contents($stream);
+
+        $this->assertMatchesRegularExpression('/^Phinx by CakePHP - https:\/\/phinx.org\. .+\n/', $contents);
+        $this->assertStringContainsString($result, $contents);
     }
 
     public function provider()


### PR DESCRIPTION
Closes #2266 

PR makes it so that the version will now show up in the CLI.

For people using composer to install phinx, the version is automatically fetched from the composer installation via the [`composer-runtime-api`](https://getcomposer.org/doc/07-runtime.md) so that we don't need to worry about changing anything within our code per version. The only downside is that this does mean phinx relies on having `composer:^2.0` installed, but given that came out 10/2020, and the version of PHP we support came out on 11/2021, I think this is a safe assumption to make. If you clone the repo, then the version will display as `0.x-dev`, but I think that's fine.

For people using the phar, then that uses the [`git-tag`](https://github.com/box-project/box/blob/main/doc/configuration.md#git-tag-placeholder-git-tag) placeholder that's replaced at compile time.