### PR TITLE
Fix Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,16 +250,14 @@ $ vendor/bin/phinx migrate -e development
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XMQP628TX6"></script>
 <script>
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-35733044-1']);
-  _gaq.push(['_trackPageview']);
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+  gtag('config', 'G-XMQP628TX6');
 </script>
 <script src="js/jquery.min.js"></script>
 <script src="js/bootstrap.js"></script>


### PR DESCRIPTION
Phinx.org used an older version of Google Analytics (Universal), so this PR migrates it to the latest version - GA4.