### PR TITLE
Mark password as a SensitiveParameter

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -41,6 +41,7 @@ use Phinx\Migration\MigrationInterface;
 use Phinx\Util\Literal;
 use ReflectionProperty;
 use RuntimeException;
+use SensitiveParameter;
 use Symfony\Component\Console\Output\OutputInterface;
 use UnexpectedValueException;
 
@@ -86,7 +87,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param array<int, mixed> $options Connection options
      * @return \PDO
      */
-    protected function createPdoConnection(string $dsn, ?string $username = null, ?string $password = null, array $options = []): PDO
+    protected function createPdoConnection(string $dsn, ?string $username = null, #[SensitiveParameter] ?string $password = null, array $options = []): PDO
     {
         $adapterOptions = $this->getOptions() + [
             'attr_errmode' => PDO::ERRMODE_EXCEPTION,


### PR DESCRIPTION
Mark the `$password` parameter as sensitive, so its value is redacted if present in a stack trace.  This already happens for PDO but not for this method:

```
#0 /src/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/PdoAdapter.php(96):
  PDO->__construct('pgsql:dbname=aa...', 'my-username', Object(SensitiveParameterValue), Array)
#1 /src/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/PostgresAdapter.php(115):
  Phinx\Db\Adapter\PdoAdapter->createPdoConnection('pgsql:dbname=aa...', 'my-username', 'my password leaked...', Array)
```