### PR TITLE
Consolidate insert/bulkInsert implementations

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -324,7 +324,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
             $this->quoteTableName($table->getName())
         );
         $columns = array_keys($row);
-        $sql .= '(' . implode(', ', array_map([$this, 'quoteColumnName'], $columns)) . ')';
+        $sql .= '(' . implode(', ', array_map([$this, 'quoteColumnName'], $columns)) . ') ' . $this->getInsertOverride() . 'VALUES ';
 
         foreach ($row as $column => $value) {
             if (is_bool($value)) {
@@ -333,10 +333,10 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         }
 
         if ($this->isDryRunEnabled()) {
-            $sql .= ' VALUES (' . implode(', ', array_map([$this, 'quoteValue'], $row)) . ');';
+            $sql .= '(' . implode(', ', array_map([$this, 'quoteValue'], $row)) . ');';
             $this->output->writeln($sql);
         } else {
-            $sql .= ' VALUES (' . implode(', ', array_fill(0, count($columns), '?')) . ')';
+            $sql .= '(' . implode(', ', array_fill(0, count($columns), '?')) . ')';
             $stmt = $this->getConnection()->prepare($sql);
             $stmt->execute(array_values($row));
         }
@@ -383,7 +383,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         );
         $current = current($rows);
         $keys = array_keys($current);
-        $sql .= '(' . implode(', ', array_map([$this, 'quoteColumnName'], $keys)) . ') VALUES ';
+        $sql .= '(' . implode(', ', array_map([$this, 'quoteColumnName'], $keys)) . ') ' . $this->getInsertOverride() . 'VALUES ';
 
         if ($this->isDryRunEnabled()) {
             $values = array_map(function ($row) {
@@ -412,6 +412,16 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
 
             $stmt->execute($vals);
         }
+    }
+
+    /**
+     * Returns override clause for insert operations, to be befort `VALUES` keyword.
+     *
+     * @return string
+     */
+    protected function getInsertOverride(): string
+    {
+        return '';
     }
 
     /**


### PR DESCRIPTION
PR consolidates the `insert` and `bulkInsert` implementations between `PdoAdapter` and `PostgresAdapter` so that we once again only have the functions implemented in `PdoAdapter`, while retaining the override behavior added in #2195. Doing this as a precursor to #2297 so that it's easier to fix the bug where only need to change the functions in `PdoAdapter` and not in other places as well.