### PR TITLE
DRY info output for console commands

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -427,7 +427,7 @@ abstract class AbstractCommand extends Command
     /**
      * Write out environment information to the OutputInterface
      */
-    protected function writeEnvironmentOutput(?string $environment, OutputInterface $output): bool
+    protected function writeEnvironmentOutput(?string &$environment, OutputInterface $output): bool
     {
         if ($environment === null) {
             $environment = $this->getConfig()->getDefaultEnvironment();
@@ -448,15 +448,11 @@ abstract class AbstractCommand extends Command
     /**
      * Write out options information to the OutputInterface
      */
-    protected function writeInformationOutput(?string $environment, OutputInterface $output): bool
+    protected function writeInformationOutput(?string &$environment, OutputInterface $output): bool
     {
         $success = $this->writeEnvironmentOutput($environment, $output);
         if (!$success) {
             return false;
-        }
-
-        if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
         }
 
         $envOptions = $this->getConfig()->getEnvironment($environment);

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -455,6 +455,10 @@ abstract class AbstractCommand extends Command
             return false;
         }
 
+        if ($environment === null) {
+            $environment = $this->getConfig()->getDefaultEnvironment();
+        }
+
         $envOptions = $this->getConfig()->getEnvironment($environment);
         if (isset($envOptions['adapter'])) {
             $output->writeln('<info>using adapter</info> ' . $envOptions['adapter'], $this->verbosityLevel);

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -424,6 +424,9 @@ abstract class AbstractCommand extends Command
         return __DIR__ . self::DEFAULT_SEED_TEMPLATE;
     }
 
+    /**
+     * Write out environment information to the OutputInterface
+     */
     protected function writeEnvironmentOutput(?string $environment, OutputInterface $output): bool
     {
         if ($environment === null) {
@@ -438,8 +441,13 @@ abstract class AbstractCommand extends Command
 
             return false;
         }
+
+        return true;
     }
 
+    /**
+     * Write out options information to the OutputInterface
+     */
     protected function writeInformationOutput(?string $environment, OutputInterface $output): bool
     {
         $success = $this->writeEnvironmentOutput($environment, $output);

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -423,4 +423,54 @@ abstract class AbstractCommand extends Command
     {
         return __DIR__ . self::DEFAULT_SEED_TEMPLATE;
     }
+
+    protected function writeEnvironmentOutput(?string $environment, OutputInterface $output): bool
+    {
+        if ($environment === null) {
+            $environment = $this->getConfig()->getDefaultEnvironment();
+            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
+        } else {
+            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
+        }
+
+        if (!$this->getConfig()->hasEnvironment($environment)) {
+            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
+
+            return false;
+        }
+    }
+
+    protected function writeInformationOutput(?string $environment, OutputInterface $output): bool
+    {
+        $success = $this->writeEnvironmentOutput($environment, $output);
+        if (!$success) {
+            return false;
+        }
+
+        $envOptions = $this->getConfig()->getEnvironment($environment);
+        if (isset($envOptions['adapter'])) {
+            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter'], $this->verbosityLevel);
+        }
+
+        if (isset($envOptions['wrapper'])) {
+            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper'], $this->verbosityLevel);
+        }
+
+        if (isset($envOptions['name'])) {
+            $output->writeln('<info>using database</info> ' . $envOptions['name'], $this->verbosityLevel);
+        } else {
+            $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
+
+            return false;
+        }
+
+        if (isset($envOptions['table_prefix'])) {
+            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix'], $this->verbosityLevel);
+        }
+        if (isset($envOptions['table_suffix'])) {
+            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix'], $this->verbosityLevel);
+        }
+
+        return true;
+    }
 }

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -71,16 +71,8 @@ EOT
         $set = $input->getOption('set');
         $unset = $input->getOption('unset');
 
-        if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
+        $success = $this->writeEnvironmentOutput($environment, $output);
+        if (!$success) {
             return self::CODE_ERROR;
         }
 

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -71,41 +71,9 @@ EOT
         $date = $input->getOption('date');
         $fake = (bool)$input->getOption('fake');
 
-        if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
+        $success = $this->writeInformationOutput($environment, $output);
+        if (!$success) {
             return self::CODE_ERROR;
-        }
-
-        $envOptions = $this->getConfig()->getEnvironment($environment);
-        if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter'], $this->verbosityLevel);
-        }
-
-        if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper'], $this->verbosityLevel);
-        }
-
-        if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name'], $this->verbosityLevel);
-        } else {
-            $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
-
-            return self::CODE_ERROR;
-        }
-
-        if (isset($envOptions['table_prefix'])) {
-            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix'], $this->verbosityLevel);
-        }
-        if (isset($envOptions['table_suffix'])) {
-            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix'], $this->verbosityLevel);
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -79,32 +79,9 @@ EOT
         $force = (bool)$input->getOption('force');
         $fake = (bool)$input->getOption('fake');
 
-        $config = $this->getConfig();
-
-        if ($environment === null) {
-            $environment = $config->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
+        $success = $this->writeInformationOutput($environment, $output);
+        if (!$success) {
             return self::CODE_ERROR;
-        }
-
-        $envOptions = $config->getEnvironment($environment);
-        if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter'], $this->verbosityLevel);
-        }
-
-        if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper'], $this->verbosityLevel);
-        }
-
-        if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name'], $this->verbosityLevel);
         }
 
         $versionOrder = $this->getConfig()->getVersionOrder();

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -65,41 +65,9 @@ EOT
         /** @var string|null $environment */
         $environment = $input->getOption('environment');
 
-        if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
+        $success = $this->writeInformationOutput($environment, $output);
+        if (!$success) {
             return self::CODE_ERROR;
-        }
-
-        $envOptions = $this->getConfig()->getEnvironment($environment);
-        if (isset($envOptions['adapter'])) {
-            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter'], $this->verbosityLevel);
-        }
-
-        if (isset($envOptions['wrapper'])) {
-            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper'], $this->verbosityLevel);
-        }
-
-        if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name'], $this->verbosityLevel);
-        } else {
-            $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
-
-            return self::CODE_ERROR;
-        }
-
-        if (isset($envOptions['table_prefix'])) {
-            $output->writeln('<info>using table prefix</info> ' . $envOptions['table_prefix'], $this->verbosityLevel);
-        }
-        if (isset($envOptions['table_suffix'])) {
-            $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix'], $this->verbosityLevel);
         }
 
         $start = microtime(true);

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -63,16 +63,8 @@ EOT
         /** @var string|null $environment */
         $format = $input->getOption('format');
 
-        if ($environment === null) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
-            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment, $this->verbosityLevel);
-        } else {
-            $output->writeln('<info>using environment</info> ' . $environment, $this->verbosityLevel);
-        }
-
-        if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
-
+        $success = $this->writeEnvironmentOutput($environment, $output);
+        if (!$success) {
             return self::CODE_ERROR;
         }
 


### PR DESCRIPTION
PR consolidates generating the information output you see when running certain console commands into a singular place, instead of having it repeated across all adapters. This will make it easier to tweak anything about this output going forward as it'll only require changing one place instead of potentially 5 places.

Putting this up as a prerequisite for tackling #2298 so that I only need to do the suffix logic in one place.