### PR TITLE
Append sqlite suffix to name on info output

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
 use Phinx\Db\Adapter\AdapterInterface;
+use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Migration\Manager;
 use Phinx\Util\Util;
 use RuntimeException;
@@ -465,7 +466,11 @@ abstract class AbstractCommand extends Command
         }
 
         if (isset($envOptions['name'])) {
-            $output->writeln('<info>using database</info> ' . $envOptions['name'], $this->verbosityLevel);
+            $name = $envOptions['name'];
+            if ($envOptions['adapter'] === 'sqlite') {
+                $name .= SQLiteAdapter::getSuffix($envOptions);
+            }
+            $output->writeln('<info>using database</info> ' . $name, $this->verbosityLevel);
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -31,6 +31,8 @@ class SQLiteAdapter extends PdoAdapter
 {
     public const MEMORY = ':memory:';
 
+    public const DEFAULT_SUFFIX = '.sqlite3';
+
     /**
      * List of supported Phinx column types with their SQL equivalents
      * some types have an affinity appended to ensure they do not receive NUMERIC affinity
@@ -117,8 +119,6 @@ class SQLiteAdapter extends PdoAdapter
         'NATIVE CHARACTER',
         'NVARCHAR',
     ];
-
-    const DEFAULT_SUFFIX = '.sqlite3';
 
     /**
      * @var string
@@ -217,6 +217,7 @@ class SQLiteAdapter extends PdoAdapter
         if ($suffix !== '' && strpos($suffix, '.') !== 0) {
             $suffix = '.' . $suffix;
         }
+
         return $suffix;
     }
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -118,10 +118,12 @@ class SQLiteAdapter extends PdoAdapter
         'NVARCHAR',
     ];
 
+    const DEFAULT_SUFFIX = '.sqlite3';
+
     /**
      * @var string
      */
-    protected string $suffix = '.sqlite3';
+    protected string $suffix = self::DEFAULT_SUFFIX;
 
     /**
      * Indicates whether the database library version is at least the specified version
@@ -195,20 +197,36 @@ class SQLiteAdapter extends PdoAdapter
     }
 
     /**
+     * Get the suffix to use for the SQLite database file.
+     *
+     * @param array $options Environment options
+     * @return string
+     */
+    public static function getSuffix(array $options): string
+    {
+        if ($options['name'] === self::MEMORY) {
+            return '';
+        }
+
+        $suffix = self::DEFAULT_SUFFIX;
+        if (isset($options['suffix'])) {
+            $suffix = $options['suffix'];
+        }
+        //don't "fix" the file extension if it is blank, some people
+        //might want a SQLITE db file with absolutely no extension.
+        if ($suffix !== '' && strpos($suffix, '.') !== 0) {
+            $suffix = '.' . $suffix;
+        }
+        return $suffix;
+    }
+
+    /**
      * @inheritDoc
      */
     public function setOptions(array $options): AdapterInterface
     {
         parent::setOptions($options);
-
-        if (isset($options['suffix'])) {
-            $this->suffix = $options['suffix'];
-        }
-        //don't "fix" the file extension if it is blank, some people
-        //might want a SQLITE db file with absolutely no extension.
-        if ($this->suffix !== '' && strpos($this->suffix, '.') !== 0) {
-            $this->suffix = '.' . $this->suffix;
-        }
+        $this->suffix = self::getSuffix($options);
 
         return $this;
     }


### PR DESCRIPTION
Closes #2298 

PR makes it so that the database name informational output will contain the suffix for sqlite connections, e.g.:

```
 $ bin/phinx migrate
Phinx by CakePHP - https://phinx.org. 0.x-dev

using config file phinx.yaml
using config parser yml
using migration paths
 - /home/mpeveler/github/phinx/db/migrations
using seed paths
 - /home/mpeveler/github/phinx/db/seeds
warning no environment specified, defaulting to: testing
using adapter sqlite
using database phinx_test.sqlite3
ordering by creation time

 == 20240906173954 Foo: migrating
 == 20240906173954 Foo: migrated 0.0158s

All Done. Took 0.0184s
```

This should make the info more informational on what's happening. Working on this, I am definitely leaning increasingly towards deprecating/removing the `suffix` option altogether and require that users only use the `name` option instead, which is similar to how most ORMs handle it.