### PR TITLE
Fix phpcs error in PDOAdapter

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -87,8 +87,13 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @param array<int, mixed> $options Connection options
      * @return \PDO
      */
-    protected function createPdoConnection(string $dsn, ?string $username = null, #[SensitiveParameter] ?string $password = null, array $options = []): PDO
-    {
+    protected function createPdoConnection(
+        string $dsn,
+        ?string $username = null,
+        #[SensitiveParameter]
+        ?string $password = null,
+        array $options = []
+    ): PDO {
         $adapterOptions = $this->getOptions() + [
             'attr_errmode' => PDO::ERRMODE_EXCEPTION,
         ];


### PR DESCRIPTION
PR fixes phpcs error in the `PDOAdapter` that was being reported by the latest version of `cakephp/cakephp-codesniffer`. Don't totally love how [`SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing`](https://github.com/slevomat/coding-standard/blob/master/doc/attributes.md#slevomatcodingstandardattributesattributeandtargetspacing-) sniff works here and would prefer to see it on the same line, but doesn't look like it's possible to have the rule not apply to function parameters vs functions or classes, which is why cakephp added it.