### PR TITLE
Move schema to class property for PostgresAdapter

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -364,6 +364,26 @@ Phinx currently supports the following database adapters natively:
 * `SQLite <https://www.sqlite.org/>`_: specify the ``sqlite`` adapter.
 * `SQL Server <https://www.microsoft.com/sqlserver>`_: specify the ``sqlsrv`` adapter.
 
+The following settings are available for the adapters:
+
+adapter
+    The name of the adapter to use, e.g. ``pgsql``.
+host
+    The database server's hostname (or IP address).
+port
+    The database server's TCP port number.
+user
+    The username for the database.
+pass
+    The password for the database.
+name
+    The name of the database for this environment. For SQLite, it's recommended to use an absolute path,
+    without the file extension.
+suffix
+    The suffix to use for the SQLite database file. Defaults to ``.sqlite3``.
+schema
+    For PostgreSQL, allows specifying the schema to use for the database. Defaults to ``public``.
+
 For each adapter, you may configure the behavior of the underlying PDO object by setting in your
 config object the lowercase version of the constant name. This works for both PDO options
 (e.g. ``\PDO::ATTR_CASE`` would be ``attr_case``) and adapter specific options (e.g. for MySQL

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -136,6 +136,18 @@ class PostgresAdapterTest extends TestCase
         $this->assertInstanceOf('\PDO', $this->adapter->getConnection());
     }
 
+    public function testConnectionWithSchema()
+    {
+        $this->adapter->connect();
+        $this->adapter->createSchema('foo');
+
+        $options = PGSQL_DB_CONFIG;
+        $options['schema'] = 'foo';
+        $adapter = new PostgresAdapter($options, new ArrayInput([]), new NullOutput());
+        $adapter->connect();
+        $this->assertTrue($adapter->hasTable('foo.'. $adapter->getSchemaTableName()));
+    }
+
     public function testCreatingTheSchemaTableOnConnect()
     {
         $this->adapter->connect();
@@ -150,7 +162,6 @@ class PostgresAdapterTest extends TestCase
     public function testSchemaTableIsCreatedWithPrimaryKey()
     {
         $this->adapter->connect();
-        new Table($this->adapter->getSchemaTableName(), [], $this->adapter);
         $this->assertTrue($this->adapter->hasIndex($this->adapter->getSchemaTableName(), ['version']));
     }
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -145,7 +145,7 @@ class PostgresAdapterTest extends TestCase
         $options['schema'] = 'foo';
         $adapter = new PostgresAdapter($options, new ArrayInput([]), new NullOutput());
         $adapter->connect();
-        $this->assertTrue($adapter->hasTable('foo.'. $adapter->getSchemaTableName()));
+        $this->assertTrue($adapter->hasTable('foo.' . $adapter->getSchemaTableName()));
     }
 
     public function testCreatingTheSchemaTableOnConnect()


### PR DESCRIPTION
PR removes the `PostgresAdapter::getGlobalSchemaName` function in favor of having a `$schema` class property, which is more inline with how other adapter specific settings work for other adapters. This is a bit of prep work for figuring out how to accomplish #2304.

I also documented the various settings for the adapters in the docs as well to make it more obvious how to configure things.