### PR TITLE
fix warning in info when using connection config

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace Phinx\Console\Command;
 
 use InvalidArgumentException;
+use PDO;
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Migration\Manager;
 use Phinx\Util\Util;
-use PDO;
 use RuntimeException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Command\Command;

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -15,6 +15,7 @@ use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Migration\Manager;
 use Phinx\Util\Util;
+use PDO;
 use RuntimeException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Command\Command;
@@ -467,7 +468,12 @@ abstract class AbstractCommand extends Command
 
         if (isset($envOptions['name'])) {
             $name = $envOptions['name'];
-            if ($envOptions['adapter'] === 'sqlite') {
+            // We do error handling for missing adapter or connection is invalid later on running a command
+            $adapter = $envOptions['adapter'] ?? null;
+            if (isset($envOptions['connection']) && $envOptions['connection'] instanceof PDO) {
+                $adapter = $envOptions['connection']->getAttribute(PDO::ATTR_DRIVER_NAME);
+            }
+            if ($adapter === 'sqlite') {
                 $name .= SQLiteAdapter::getSuffix($envOptions);
             }
             $output->writeln('<info>using database</info> ' . $name, $this->verbosityLevel);


### PR DESCRIPTION
Closes #2311 

PR fixes a warning/error that was getting shown when a user uses the `connection` config option for setting up their DB, where `$envOptions['adapter']` is not set in that case, but we can get the adapter name via the PDO configuration option.