### PR TITLE
Add docs about namespaces for paths

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -76,6 +76,16 @@ You can also provide multiple migration paths by using an array in your configur
             - application/module1/migrations
             - application/module2/migrations
 
+Class namespaces may be specified by adding a key to each migration path:
+
+.. code-block:: yaml
+
+    paths:
+        migrations:
+            App\Module1\Migrations: application/module1/migrations
+            App\Module2\Migrations: application/module2/migrations
+
+
 
 You can also use the ``%%PHINX_CONFIG_DIR%%`` token in your path.
 

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -149,6 +149,16 @@ You can also use the ``%%PHINX_CONFIG_DIR%%`` token in your path.
     paths:
         seeds: '%%PHINX_CONFIG_DIR%%/your/relative/path'
 
+Class namespaces may be specified by adding a key to each seed path:
+
+.. code-block:: yaml
+
+    paths:
+        seeds:
+            App\Module1\Seeds: application/module1/seeds
+            App\Module2\Seeds: application/module2/seeds
+
+
 Custom Seeder Base
 ---------------------
 


### PR DESCRIPTION
Hello, I didn't find any references to namespaces in the docs when creating migrations, so, after debugging the code, I found out how it could be done.
This PR adds instructions for specifying namespaces in migration paths.