### PR TITLE
Fix using schema option with connection option

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -70,11 +70,11 @@ class PostgresAdapter extends PdoAdapter
      */
     public function setOptions(array $options): AdapterInterface
     {
-        parent::setOptions($options);
-
         if (!empty($options['schema'])) {
             $this->schema = $options['schema'];
         }
+
+        parent::setOptions($options);
 
         return $this;
     }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -148,6 +148,21 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($adapter->hasTable('foo.' . $adapter->getSchemaTableName()));
     }
 
+    public function testConnectionWithSchemaAndConnection()
+    {
+        $this->adapter->connect();
+        $this->adapter->createSchema('foo');
+
+        $options = [
+            'schema' => 'foo',
+            'connection' => $this->adapter->getConnection(),
+            'name' => PGSQL_DB_CONFIG['name'],
+        ];
+        $adapter = new PostgresAdapter($options, new ArrayInput([]), new NullOutput());
+        $adapter->connect();
+        $this->assertTrue($adapter->hasTable('foo.' . $adapter->getSchemaTableName()));
+    }
+
     public function testCreatingTheSchemaTableOnConnect()
     {
         $this->adapter->connect();


### PR DESCRIPTION
Closes #2315 

Fixes a bug where if using the `connection` and `schema` options, the adapter would attempt to create the migrations log table in the default schema (`public`) vs the one in the `schema` option.

This was due to `PdoAdapter` calling `setConnection` if `connection` was set, and as part of that logic the migration log table is created. The fix is to just make sure we set `$schema` before we call `parent::setOptions` in the `PostgresAdapter`.