### PR TITLE
Write CLI errors to stderr

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,12 @@
 
     <rule ref="CakePHP"/>
 
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+
     <arg value="nps"/>
 
     <file>src/</file>

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use UnexpectedValueException;
 
@@ -439,7 +440,7 @@ abstract class AbstractCommand extends Command
         }
 
         if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
+            self::getErrorOutput($output)->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
             return false;
         }
@@ -478,7 +479,7 @@ abstract class AbstractCommand extends Command
             }
             $output->writeln('<info>using database</info> ' . $name, $this->verbosityLevel);
         } else {
-            $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
+            self::getErrorOutput($output)->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
             return false;
         }
@@ -491,5 +492,16 @@ abstract class AbstractCommand extends Command
         }
 
         return true;
+    }
+
+    /**
+     * Returns the error output to use
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
+     * @return \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected static function getErrorOutput(OutputInterface $output): OutputInterface
+    {
+        return $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
     }
 }

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -72,13 +72,11 @@ class ListAliases extends AbstractCommand
             return self::CODE_SUCCESS;
         }
 
-        self::getErrorOutput($output)->writeln(
-            sprintf(
-                '<error>No aliases defined in %s</error>',
-                Util::relativePath($this->config->getConfigFilePath())
-            )
+        $output->writeln(
+            '<comment>warning</comment> no aliases defined in ' . Util::relativePath($this->config->getConfigFilePath()),
+            $this->verbosityLevel
         );
 
-        return self::CODE_ERROR;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -68,14 +68,14 @@ class ListAliases extends AbstractCommand
                 ),
                 $this->verbosityLevel
             );
-
-            return self::CODE_SUCCESS;
+        } else {
+            $output->writeln(
+                '<comment>warning</comment> no aliases defined in ' . Util::relativePath(
+                    $this->config->getConfigFilePath()
+                ),
+                $this->verbosityLevel
+            );
         }
-
-        $output->writeln(
-            '<comment>warning</comment> no aliases defined in ' . Util::relativePath($this->config->getConfigFilePath()),
-            $this->verbosityLevel
-        );
 
         return self::CODE_SUCCESS;
     }

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -68,15 +68,17 @@ class ListAliases extends AbstractCommand
                 ),
                 $this->verbosityLevel
             );
-        } else {
-            $output->writeln(
-                sprintf(
-                    '<error>No aliases defined in %s</error>',
-                    Util::relativePath($this->config->getConfigFilePath())
-                )
-            );
+
+            return self::CODE_SUCCESS;
         }
 
-        return self::CODE_SUCCESS;
+        self::getErrorOutput($output)->writeln(
+            sprintf(
+                '<error>No aliases defined in %s</error>',
+                Util::relativePath($this->config->getConfigFilePath())
+            )
+        );
+
+        return self::CODE_ERROR;
     }
 }

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Phinx\Console\Command;
 
 use DateTime;
-use Exception;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -92,12 +91,8 @@ EOT
                 $this->getManager()->migrate($environment, $version, $fake);
             }
             $end = microtime(true);
-        } catch (Exception $e) {
-            $output->writeln('<error>' . $e->__toString() . '</error>');
-
-            return self::CODE_ERROR;
         } catch (Throwable $e) {
-            $output->writeln('<error>' . $e->__toString() . '</error>');
+            self::getErrorOutput($output)->writeln('<error>' . $e->__toString() . '</error>');
 
             return self::CODE_ERROR;
         }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -204,7 +204,7 @@ class SQLiteAdapter extends PdoAdapter
      */
     public static function getSuffix(array $options): string
     {
-        if ($options['name'] === self::MEMORY) {
+        if (($options['name'] ?? '') === self::MEMORY) {
             return '';
         }
 

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -38,7 +38,8 @@ class ListAliasesTest extends TestCase
             ],
             ['decorated' => false]
         );
-        $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
+        $expectedExitCode = $hasAliases ? AbstractCommand::CODE_SUCCESS : AbstractCommand::CODE_ERROR;
+        $this->assertSame($expectedExitCode, $exitCode);
 
         $display = $commandTester->getDisplay(false);
 

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -38,19 +38,18 @@ class ListAliasesTest extends TestCase
             ],
             ['decorated' => false]
         );
-        $expectedExitCode = $hasAliases ? AbstractCommand::CODE_SUCCESS : AbstractCommand::CODE_ERROR;
-        $this->assertSame($expectedExitCode, $exitCode);
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
 
         $display = $commandTester->getDisplay(false);
 
         if ($hasAliases) {
-            $this->assertStringNotContainsString('No aliases defined in ', $display);
+            $this->assertStringNotContainsString('no aliases defined in ', $display);
             $this->assertStringContainsString('Alias            Class                                             ', $display);
             $this->assertStringContainsString('================ ==================================================', $display);
             $this->assertStringContainsString('MakePermission   Vendor\Package\Migration\Creation\MakePermission  ', $display);
             $this->assertStringContainsString('RemovePermission Vendor\Package\Migration\Creation\RemovePermission', $display);
         } else {
-            $this->assertStringContainsString('No aliases defined in ', $display);
+            $this->assertStringContainsString('no aliases defined in ', $display);
         }
     }
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -3,31 +3,29 @@ declare(strict_types=1);
 
 namespace Test\Phinx\Console\Command;
 
+use DateTime;
 use Phinx\Config\Config;
+use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Console\Command\Migrate;
 use Phinx\Console\PhinxApplication;
+use Phinx\Migration\Manager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class MigrateTest extends TestCase
 {
-    /**
-     * @var ConfigInterface|array
-     */
-    protected $config = [];
+    private ConfigInterface $config;
 
-    /**
-     * @var InputInterface $input
-     */
-    protected $input;
+    private InputInterface $input;
 
-    /**
-     * @var OutputInterface $output
-     */
-    protected $output;
+    private OutputInterface $output;
 
     protected function setUp(): void
     {
@@ -50,7 +48,7 @@ class MigrateTest extends TestCase
         ]);
 
         $this->input = new ArrayInput([]);
-        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
+        $this->output = new StreamOutput(fopen('php://memory', 'ab'));
     }
 
     public function testExecute()
@@ -62,8 +60,8 @@ class MigrateTest extends TestCase
         $command = $application->find('migrate');
 
         // mock the manager class
-        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
@@ -103,8 +101,8 @@ class MigrateTest extends TestCase
         ]);
 
         // mock the manager class
-        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
@@ -131,8 +129,8 @@ class MigrateTest extends TestCase
         $command = $application->find('migrate');
 
         // mock the manager class
-        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
@@ -157,8 +155,8 @@ class MigrateTest extends TestCase
         $command = $application->find('migrate');
 
         // mock the manager class
-        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->never())
@@ -184,8 +182,8 @@ class MigrateTest extends TestCase
         $command = $application->find('migrate');
 
         // mock the manager class
-        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
@@ -210,8 +208,8 @@ class MigrateTest extends TestCase
         $command = $application->find('migrate');
 
         // mock the manager class
-        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
@@ -238,8 +236,8 @@ class MigrateTest extends TestCase
         $command = $application->find('migrate');
 
         // mock the manager class
-        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
@@ -280,8 +278,8 @@ class MigrateTest extends TestCase
         $command = $application->find('migrate');
 
         // mock the manager class
-        /** @var Manager|\PHPUnit\Framework\MockObject\MockObject $managerStub */
-        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
             ->setConstructorArgs([$config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
@@ -300,5 +298,70 @@ class MigrateTest extends TestCase
             'ordering by creation time',
         ]) . PHP_EOL, $commandTester->getDisplay());
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
+    }
+
+    public function testExecuteWithDate(): void
+    {
+        $application = new PhinxApplication();
+        $application->add(new Migrate());
+
+        /** @var Migrate $command */
+        $command = $application->find('migrate');
+
+        // mock the manager class
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+        $managerStub->expects($this->never())
+            ->method('migrate');
+        $managerStub->expects($this->once())
+            ->method('migrateToDateTime')
+            ->with('development', new DateTime('yesterday'), false);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute(
+            ['command' => $command->getName(), '--environment' => 'development', '--date' => 'yesterday'],
+            ['decorated' => false]
+        );
+
+        $this->assertStringContainsString('using environment development', $commandTester->getDisplay());
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
+    }
+
+    public function testExecuteWithError(): void
+    {
+        $exception = new RuntimeException('oops');
+
+        $application = new PhinxApplication();
+        $application->add(new Migrate());
+
+        /** @var Migrate $command */
+        $command = $application->find('migrate');
+
+        // mock the manager class
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+        $managerStub->expects($this->once())
+            ->method('migrate')
+            ->willThrowException($exception);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute(
+            ['command' => $command->getName(), '--environment' => 'development'],
+            ['decorated' => false, 'capture_stderr_separately' => true]
+        );
+
+        $this->assertStringContainsString('using environment development', $commandTester->getDisplay());
+        $this->assertStringContainsString('RuntimeException: oops', $commandTester->getErrorOutput());
+        $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
 }


### PR DESCRIPTION
Fixes #2270.

In the end I chose to copy/adapt OutputStyle::getErrorOutput as a new protected method on the abstract command rather than using SymfonyStyle because:

1. creating SymfonyStyle requires both $input and $output, but some existing methods only receive $output
2. SymfonyStyle behaves differently than the plain OutputStyle, which might introduce new issues

I also fixed the exit code for the case where no aliases exist, applying the rule "error output -> exit code 1".