### PR TITLE
Improve collision handling on multiple create calls

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -167,10 +167,14 @@ class Create extends AbstractCommand
 
         $path = realpath($path);
         $className = $input->getArgument('name');
+        $offset = 0;
+        do {
+            $timestamp = Util::getCurrentTimestamp($offset++);
+        } while (!Util::isUniqueTimestamp($path, $timestamp));
+
         if ($className === null) {
-            $currentTimestamp = Util::getCurrentTimestamp();
-            $className = 'V' . $currentTimestamp;
-            $fileName = $currentTimestamp . '.php';
+            $className = 'V' . $timestamp;
+            $fileName = '';
         } else {
             if (!Util::isValidPhinxClassName($className)) {
                 throw new InvalidArgumentException(sprintf(
@@ -179,9 +183,9 @@ class Create extends AbstractCommand
                 ));
             }
 
-            // Compute the file path
-            $fileName = Util::mapClassNameToFileName($className);
+            $fileName = Util::toSnakeCase($className);
         }
+        $fileName = $timestamp . $fileName . '.php';
 
         if (!Util::isUniqueMigrationClassName($className, $path)) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -59,7 +59,7 @@ class Util
 
     public static function isUniqueTimestamp(string $path, string $timestamp): bool
     {
-        return !count(static::glob($path. DIRECTORY_SEPARATOR . $timestamp . '*\\.php'));
+        return !count(static::glob($path. DIRECTORY_SEPARATOR . $timestamp . '*.php'));
     }
 
     /**

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -66,7 +66,7 @@ class Util
      */
     public static function isUniqueTimestamp(string $path, string $timestamp): bool
     {
-        return !count(static::glob($path. DIRECTORY_SEPARATOR . $timestamp . '*.php'));
+        return !count(static::glob($path . DIRECTORY_SEPARATOR . $timestamp . '*.php'));
     }
 
     /**

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -47,11 +47,19 @@ class Util
      *
      * @return string
      */
-    public static function getCurrentTimestamp(): string
+    public static function getCurrentTimestamp(?int $offset = null): string
     {
         $dt = new DateTime('now', new DateTimeZone('UTC'));
+        if ($offset) {
+            $dt->modify('+' . $offset . ' seconds');
+        }
 
         return $dt->format(static::DATE_FORMAT);
+    }
+
+    public static function isUniqueTimestamp(string $path, string $timestamp): bool
+    {
+        return !count(static::glob($path. DIRECTORY_SEPARATOR . $timestamp . '*\\.php'));
     }
 
     /**
@@ -99,10 +107,20 @@ class Util
         return $value;
     }
 
+    public static function toSnakeCase(string $string): string
+    {
+        $snake = function ($matches) {
+            return '_' . strtolower($matches[0]);
+        };
+        return preg_replace_callback('/\d+|[A-Z]/', $snake, $string);
+    }
+
     /**
      * Turn migration names like 'CreateUserTable' into file names like
      * '12345678901234_create_user_table.php' or 'LimitResourceNamesTo30Chars' into
      * '12345678901234_limit_resource_names_to_30_chars.php'.
+     *
+     * @deprecated Will be removed in 0.17.0
      *
      * @param string $className Class Name
      * @return string

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -57,6 +57,13 @@ class Util
         return $dt->format(static::DATE_FORMAT);
     }
 
+    /**
+     * Checks that the given timestamp is a unique prefix for any files in the given path.
+     *
+     * @param string $path Path to check
+     * @param string $timestamp Timestamp to check
+     * @return bool
+     */
     public static function isUniqueTimestamp(string $path, string $timestamp): bool
     {
         return !count(static::glob($path. DIRECTORY_SEPARATOR . $timestamp . '*.php'));
@@ -107,11 +114,18 @@ class Util
         return $value;
     }
 
+    /**
+     * Given a string, convert it to snake_case.
+     *
+     * @param string $string String to convert
+     * @return string
+     */
     public static function toSnakeCase(string $string): string
     {
         $snake = function ($matches) {
             return '_' . strtolower($matches[0]);
         };
+
         return preg_replace_callback('/\d+|[A-Z]/', $snake, $string);
     }
 
@@ -121,7 +135,6 @@ class Util
      * '12345678901234_limit_resource_names_to_30_chars.php'.
      *
      * @deprecated Will be removed in 0.17.0
-     *
      * @param string $className Class Name
      * @return string
      */

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -51,6 +51,12 @@ class UtilTest extends TestCase
         $this->assertLessThanOrEqual($expected + 2, $current);
     }
 
+    public function testIsUniqueTimestamp(): void
+    {
+        $this->assertFalse(Util::isUniqueTimestamp(__DIR__ . '/_files/migrations', '20120111235330'));
+        $this->assertTrue(Util::isUniqueTimestamp(__DIR__ . '/_files/migrations', '20120111235301'));
+    }
+
     public function testGetVersionFromFileName(): void
     {
         $this->assertSame(20221130101652, Util::getVersionFromFileName('20221130101652_test.php'));
@@ -62,7 +68,7 @@ class UtilTest extends TestCase
         Util::getVersionFromFileName('foo.php');
     }
 
-    public function testGetVersionFromFileNameErrorZeroVersion(): VoidCommand
+    public function testGetVersionFromFileNameErrorZeroVersion(): void
     {
         $this->expectException(RuntimeException::class);
         Util::getVersionFromFileName('0_foo.php');


### PR DESCRIPTION
Closes #2324

PR adds logic for doing collision avoidance when calling the `create` command multiple times within the same second. Currently, all files would have the same timestamp, and then ordering would be based on the class name. With this PR, each subsequent call to `create` will increment the timestamp prefix by N seconds until we get a unique timestamp. This is useful for directions that might have a user run multiple `create` commands to scaffold their app.

This is technically a backwards breaking change if someone relied on multiple calls to `create` at the same time to be ordered by classname, but I don't think that's likely, and so I'm not going to worry about it much.