### PR TITLE
Add deprecation warning for Util::mapClassNameToFileName

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
     colors="true"
     columns="max"
     convertErrorsToExceptions="true"
-    convertDeprecationsToExceptions="true"
 >
 
     <!--

--- a/src/Phinx/Util/Util.php
+++ b/src/Phinx/Util/Util.php
@@ -140,6 +140,7 @@ class Util
      */
     public static function mapClassNameToFileName(string $className): string
     {
+        trigger_error('Util::mapClassNameToFileName is deprecated since 0.16.6, and will be removed in a future release.', E_USER_DEPRECATED);
         $snake = function ($matches) {
             return '_' . strtolower($matches[0]);
         };

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -4,6 +4,8 @@ namespace Test\Phinx\Config;
 
 use InvalidArgumentException;
 use Phinx\Config\Config;
+use Test\Phinx\DeprecationException;
+use Test\Phinx\TestUtils;
 use UnexpectedValueException;
 
 /**
@@ -126,11 +128,13 @@ class ConfigTest extends AbstractConfigTest
      */
     public function testDefaultDatabaseThrowsDeprecatedNotice()
     {
+        TestUtils::throwUserDeprecatedError();
+
         $configArray = $this->getConfigArray();
         $configArray['environments']['default_database'] = 'production';
         $config = new Config($configArray);
 
-        $this->expectDeprecation();
+        $this->expectException(DeprecationException::class);
         $this->expectExceptionMessage('default_database in the config has been deprecated since 0.12, use default_environment instead.');
         $config->getDefaultEnvironment();
     }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -8,6 +8,8 @@ use PDOException;
 use Phinx\Config\Config;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Test\Phinx\DeprecationException;
+use Test\Phinx\TestUtils;
 
 class PdoAdapterTest extends TestCase
 {
@@ -50,9 +52,11 @@ class PdoAdapterTest extends TestCase
 
     public function testOptionsSetDefaultMigrationTableThrowsDeprecation()
     {
+        TestUtils::throwUserDeprecatedError();
+
         $this->assertEquals('phinxlog', $this->adapter->getSchemaTableName());
 
-        $this->expectDeprecation();
+        $this->expectException(DeprecationException::class);
         $this->expectExceptionMessage('The default_migration_table setting for adapter has been deprecated since 0.13.0. Use `migration_table` instead.');
         $this->adapter->setOptions(['default_migration_table' => 'schema_table_test']);
         $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());

--- a/tests/Phinx/DeprecationException.php
+++ b/tests/Phinx/DeprecationException.php
@@ -1,5 +1,10 @@
 <?php
+declare(strict_types=1);
 
 namespace Test\Phinx;
 
-class DeprecationException extends \Exception {}
+use Exception;
+
+class DeprecationException extends Exception
+{
+}

--- a/tests/Phinx/DeprecationException.php
+++ b/tests/Phinx/DeprecationException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Test\Phinx;
+
+class DeprecationException extends \Exception {}

--- a/tests/Phinx/TestUtils.php
+++ b/tests/Phinx/TestUtils.php
@@ -37,4 +37,12 @@ class TestUtils
         }
         rmdir($path);
     }
+
+    public static function throwUserDeprecatedError(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr): void {
+            restore_error_handler();
+            throw new DeprecationException($errstr, $errno);
+        }, E_USER_DEPRECATED);
+    }
 }

--- a/tests/Phinx/Util/UtilTest.php
+++ b/tests/Phinx/Util/UtilTest.php
@@ -7,7 +7,9 @@ use DateTime;
 use DateTimeZone;
 use Phinx\Util\Util;
 use RuntimeException;
+use Test\Phinx\DeprecationException;
 use Test\Phinx\TestCase;
+use Test\Phinx\TestUtils;
 
 class UtilTest extends TestCase
 {
@@ -72,6 +74,13 @@ class UtilTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         Util::getVersionFromFileName('0_foo.php');
+    }
+
+    public function testMapClassNameToFileNameDeprecated(): void
+    {
+        TestUtils::throwUserDeprecatedError();
+        $this->expectException(DeprecationException::class);
+        Util::mapClassNameToFileName('Test');
     }
 
     public function providerMapClassNameToFileName(): array


### PR DESCRIPTION
PR adds an `E_USER_DEPRECATED` warning to the `Util::mapClassNameToFileName`. While I had added an annotation to indicate it was deprecated in #2325, adding the warning will help make it more explicit and is similar to how we've deprecated things in the past.

I also used this opportunity to fix the deprecation warning PHPUnit was showing on using `$this->expectDeprecation`, which should clear the way to upgrade to PHPUnit 10.