### PR TITLE
Error on using reserved keyword for migration name

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -36,6 +36,15 @@ class Create extends AbstractCommand
      */
     public const CREATION_INTERFACE = 'Phinx\Migration\CreationInterface';
 
+    // PHP keywords from https://www.php.net/manual/en/reserved.keywords.php
+    private array $keywords = [
+        'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch', 'class', 'clone', 'const',
+        'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor',
+        'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit', 'extends', 'final', 'finally', 'for', 'foreach',
+        'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface',
+        'isset', 'list', 'namespace', 'new', 'or', 'parent', 'private', 'protected', 'public', 'return','static',
+    ];
+
     /**
      * {@inheritDoc}
      *
@@ -167,6 +176,13 @@ class Create extends AbstractCommand
 
         $path = realpath($path);
         $className = $input->getArgument('name');
+        if ($className !== null && in_array(strtolower($className), $this->keywords)) {
+            throw new InvalidArgumentException(sprintf(
+                'The migration class name "%s" is a reserved PHP keyword. Please choose a different class name.',
+                $className
+            ));
+        }
+
         $offset = 0;
         do {
             $timestamp = Util::getCurrentTimestamp($offset++);

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -621,6 +621,7 @@ class CreateTest extends TestCase
 
         /** @var Create $command */
         $command = $application->find('create');
+        $command->setConfig($this->config);
 
         $commandTester = new CommandTester($command);
 

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -625,6 +625,7 @@ class CreateTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The migration class name "Class" is a reserved PHP keyword. Please choose a different class name.');
         $commandTester->execute(['command' => $command->getName(), 'name' => 'Class']);
     }
 }

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -613,4 +613,18 @@ class CreateTest extends TestCase
         $exitCode = $commandTester->execute(['command' => $command->getName(), '--style' => 'foo']);
         $this->assertSame(AbstractCommand::CODE_ERROR, $exitCode);
     }
+
+    public function testCreateWithKeywordNameThrows(): void
+    {
+        $application = new PhinxApplication();
+        $application->add(new Create());
+
+        /** @var Create $command */
+        $command = $application->find('create');
+
+        $commandTester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $commandTester->execute(['command' => $command->getName(), 'name' => 'Class']);
+    }
 }


### PR DESCRIPTION
Closes #2326 

PR makes it so that if using a reserved PHP keyword for a migration name, an error will now be raised for that command. Previously it would allow the migration to be created, but then fatal error on trying to parse that migration.

This is a port of https://github.com/cakephp/migrations/pull/780, though I opted out of asking the user a question as part of the flow and just have it error out altogether for simplicity sake.