### PR TITLE
Fix SQLiteAdapter::getColumns with Literal column

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -712,7 +712,8 @@ PCRE_PATTERN;
         foreach ($rows as $columnInfo) {
             $column = new Column();
             $type = $this->getPhinxType($columnInfo['type']);
-            $default = $this->parseDefaultValue($columnInfo['dflt_value'], $type['name']);
+            // $type['name'] is string|Literal, convert it to be a string
+            $default = $this->parseDefaultValue($columnInfo['dflt_value'], (string)$type['name']);
 
             $column->setName($columnInfo['name'])
                 // SQLite on PHP 8.1 returns int for notnull, older versions return a string

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2438,7 +2438,7 @@ INPUT;
         $this->assertCount(1, $columns);
         $column = array_pop($columns);
         $this->assertSame('real_col', $column->getName());
-        $this->assertEquals('Phinx\Util\Literal', get_class($column->getType()));
+        $this->assertInstanceOf(Literal::class, $column->getType());
         $this->assertEquals(Literal::from('FOO'), $column->getType());
     }
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2430,13 +2430,16 @@ OUTPUT;
     public function testLiteralSupport()
     {
         $createQuery = <<<'INPUT'
-CREATE TABLE `test` (`real_col` DECIMAL)
+CREATE TABLE `test` (`real_col` FOO)
 INPUT;
         $this->adapter->execute($createQuery);
         $table = new Table('test', [], $this->adapter);
         $columns = $table->getColumns();
         $this->assertCount(1, $columns);
-        $this->assertEquals(Literal::from('decimal'), array_pop($columns)->getType());
+        $column = array_pop($columns);
+        $this->assertSame('real_col', $column->getName());
+        $this->assertEquals('Phinx\Util\Literal', get_class($column->getType()));
+        $this->assertEquals(Literal::from('FOO'), $column->getType());
     }
 
     /**
@@ -3229,6 +3232,7 @@ INPUT;
             'Arbitrary expression' => ['create table t(a float default ((2) + (2)))', Expression::from('(2) + (2)')],
             'Pathological case 1' => ['create table t(a float default (\'/*\' || \'*/\'))', Expression::from('\'/*\' || \'*/\'')],
             'Pathological case 2' => ['create table t(a float default (\'--\' || \'stuff\'))', Expression::from('\'--\' || \'stuff\'')],
+            'Literal' => ['create table t(a foo default \'bar\')', Literal::from('bar')],
         ];
     }
 


### PR DESCRIPTION
Fixes #2330

PR fixes a bug where `SQLiteAdapter::getColumns` would throw an exception if the table had a column with a `Literal` type. This was due to a type error when passing the type of `SQLiteAdapter::parseDefaultValue` which requires the type be a string. While I could have modified `parseDefaultValue` to accept a `string|Literal`, as the function is defined as `protected`, this would have been a BC break, and so I went with converting the `$type['name']` to a string in the caller (`getColumns`) instead.