### PR TITLE
Remove ZH link for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Phinx makes it ridiculously easy to manage the database migrations for your PHP app. In less than 5 minutes, you can install Phinx and create your first database migration. Phinx is just about migrations without all the bloat of a database ORM system or framework.
 
-**Check out [book.cakephp.org/phinx](https://book.cakephp.org/phinx) ([EN](https://book.cakephp.org/phinx), [ZH](https://tsy12321.gitbooks.io/phinx-doc/)) for the comprehensive documentation.**
+**Check out [book.cakephp.org/phinx](https://book.cakephp.org/phinx) for the comprehensive documentation.**
 
 ![phinxterm](https://cloud.githubusercontent.com/assets/178939/3887559/e6b5e524-21f2-11e4-8256-0ba6040725fc.gif)
 


### PR DESCRIPTION
PR removes the ZH link for the docs in the README. The link hasn't been updated in 6 years and is definitely out of date, and so better to just not link to it I think. 

This is similar situation as #2074 when we removed all the other translations of the docs.