### PR TITLE
Docs: Set config name to `:memory:` in docs example

### DIFF
--- a/docs/en/commands.rst
+++ b/docs/en/commands.rst
@@ -397,7 +397,8 @@ using the Manager class :
                 $configArray = require('phinx.php');
                 $configArray['environments']['test'] = [
                     'adapter'    => 'sqlite',
-                    'connection' => $pdo
+                    'connection' => $pdo,
+                    'name' => ':memory:',
                 ];
                 $config = new Config($configArray);
                 $manager = new Manager($config, new StringInput(' '), new NullOutput());


### PR DESCRIPTION
Without this:

```diff
  $configArray['environments']['test'] = [
      'adapter'    => 'sqlite',
      'connection' => $pdo,
+     'name' => ':memory:',
  ];
```

I'm getting error: `Undefined array key "name" in vendor/robmorgan/phinx/src/Phinx/Db/Adapter/SQLiteAdapter.php:207` here:

https://github.com/cakephp/phinx/blob/31d837c17d6dc294d44f0b17331066548ac8c032/src/Phinx/Db/Adapter/SQLiteAdapter.php#L207-L209

as mentioned [here](https://github.com/cakephp/phinx/blob/0.16.5/docs/en/commands.rst#configuration-file-parameter):

> ... It is also important to pass the database name too, as Phinx requires this for certain methods such as `hasTable()`:

and [here](https://github.com/cakephp/phinx/blob/0.16.5/docs/en/configuration.rst#configuration):

> ... However remember to also pass the database name as Phinx cannot infer this from the PDO connection.