### PR TITLE
Add SQLiteAdapter::isMemory helper function

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -179,7 +179,7 @@ class Config implements ConfigInterface, NamespaceAwareInterface
             if (
                 isset($environments[$name]['adapter'])
                 && $environments[$name]['adapter'] === 'sqlite'
-                && !empty($environments[$name]['memory'])
+                && SQLiteAdapter::isMemory($environments[$name])
             ) {
                 $environments[$name]['name'] = SQLiteAdapter::MEMORY;
             }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -139,6 +139,17 @@ class SQLiteAdapter extends PdoAdapter
     }
 
     /**
+     * Check if the given options represent a memory database
+     *
+     * @param array $options Options to check
+     * @return bool
+     */
+    public static function isMemory(array $options): bool
+    {
+        return !empty($options['memory']) || ($options['name'] ?? '') === static::MEMORY;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @throws \RuntimeException
@@ -171,7 +182,7 @@ class SQLiteAdapter extends PdoAdapter
                 $dsn = 'sqlite:file:' . ($options['name'] ?? '') . '?' . implode('&', $params);
             } else {
                 // use a memory database if the option was specified
-                if (!empty($options['memory']) || $options['name'] === static::MEMORY) {
+                if (SQLiteAdapter::isMemory($options)) {
                     $dsn = 'sqlite:' . static::MEMORY;
                 } else {
                     $dsn = 'sqlite:' . $options['name'] . $this->suffix;
@@ -204,7 +215,7 @@ class SQLiteAdapter extends PdoAdapter
      */
     public static function getSuffix(array $options): string
     {
-        if (($options['name'] ?? '') === self::MEMORY) {
+        if (SQLiteAdapter::isMemory($options)) {
             return '';
         }
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -3481,4 +3481,23 @@ INPUT;
         $adapter = new SQLiteAdapter(SQLITE_DB_CONFIG);
         $this->assertFalse($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
     }
+
+    public function isMemoryProvider(): array
+    {
+        return [
+            [['name' => ':memory:'], true],
+            [['memory' => true], true],
+            [['name' => 'foo', 'memory' => true], true],
+            [['name' => 'bar'], false],
+            [['memory' => false], false],
+        ];
+    }
+
+    /**
+     * @dataProvider isMemoryProvider
+     */
+    public function testIsMemory(array $config, bool $expected): void
+    {
+        $this->assertSame($expected, SQLiteAdapter::isMemory($config));
+    }
 }


### PR DESCRIPTION
PR adds a `SQLiteAdapter::isMemory` helper function to check if we are using an in-memory database, unifying the three places we check to have same logic.

This does also "fix" a potential warning (as shown in #2335) where if you leave off `name` and `memory`, but did provide `pdo`, you'd get a warning about `$options['name']` being empty. Won't hit that anymore, though I think it's still good to encourage people to always use `name` as it is important for other adapters.