### PR TITLE
Docs: Use `require` without brackets

### DIFF
--- a/docs/en/commands.rst
+++ b/docs/en/commands.rst
@@ -394,7 +394,7 @@ using the Manager class :
                 $pdo = new PDO('sqlite::memory:', null, null, [
                     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
                 ]);
-                $configArray = require('phinx.php');
+                $configArray = require 'phinx.php';
                 $configArray['environments']['test'] = [
                     'adapter'    => 'sqlite',
                     'connection' => $pdo,


### PR DESCRIPTION
Because brackets with require is not necessary and implies it's a function, while it's a statement.

In phinx code, require is used without brackets:

https://github.com/cakephp/phinx/blob/6f0ec12268568d993e81410c4d5fdff2ce510dd8/app/phinx.php#L26

https://github.com/cakephp/phinx/blob/6f0ec12268568d993e81410c4d5fdff2ce510dd8/app/web.php#L42