### PR TITLE
Add config file path to docs example

### DIFF
--- a/docs/en/commands.rst
+++ b/docs/en/commands.rst
@@ -394,7 +394,8 @@ using the Manager class :
                 $pdo = new PDO('sqlite::memory:', null, null, [
                     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
                 ]);
-                $configArray = require 'phinx.php';
+                $configPath = __DIR__ . '/../phinx.php';
+                $configArray = require $configPath;
                 $configArray['environments']['test'] = [
                     'adapter'    => 'sqlite',
                     'connection' => $pdo,
@@ -402,7 +403,7 @@ using the Manager class :
                 ];
                 $config = new Config(
                     $configArray,
-                    __DIR__ . '/../phinx.php'
+                    $configPath
                  );
                 $manager = new Manager($config, new StringInput(' '), new NullOutput());
                 $manager->migrate('test');

--- a/docs/en/commands.rst
+++ b/docs/en/commands.rst
@@ -400,7 +400,10 @@ using the Manager class :
                     'connection' => $pdo,
                     'name' => ':memory:',
                 ];
-                $config = new Config($configArray);
+                $config = new Config(
+                    $configArray,
+                    __DIR__ . '/../phinx.php'
+                 );
                 $manager = new Manager($config, new StringInput(' '), new NullOutput());
                 $manager->migrate('test');
                 $manager->seed('test');


### PR DESCRIPTION
When initializing config manually, one must provide path to phinx config file, so variables such as `%%PHINX_CONFIG_DIR%%` are resolved properly.

See stack overflow > https://stackoverflow.com/a/50693483/1012616