### PR TITLE
Trim trailing semicolon before executing query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
             n=$((n+1))
             sleep 2
           done
-          mysql -h 127.0.0.1 -u root -proot -D phinx -e 'SELECT 1;'
+          mysql -h 127.0.0.1 -u root -proot -D phinx -e 'SELECT 1'
         fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then psql -c 'CREATE DATABASE phinx;' postgresql://postgres:postgres@127.0.0.1; fi
 

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -181,8 +181,8 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function execute(string $sql, array $params = []): int
     {
-        $sql = rtrim($sql, "; \t\n\r\0\x0B") . ';';
-        $this->verboseLog($sql);
+        $sql = rtrim($sql, "; \t\n\r\0\x0B");
+        $this->verboseLog($sql . ';');
 
         if ($this->isDryRunEnabled()) {
             return 0;

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -182,7 +182,7 @@ class PdoAdapterTest extends TestCase
     {
         /** @var \PDO&\PHPUnit\Framework\MockObject\MockObject $pdo */
         $pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->onlyMethods(['exec'])->getMock();
-        $pdo->expects($this->once())->method('exec')->with('SELECT 1;')->will($this->returnValue(1));
+        $pdo->expects($this->once())->method('exec')->with('SELECT 1')->will($this->returnValue(1));
 
         $this->adapter->setConnection($pdo);
         $this->adapter->execute('SELECT 1');
@@ -192,7 +192,7 @@ class PdoAdapterTest extends TestCase
     {
         /** @var \PDO&\PHPUnit\Framework\MockObject\MockObject $pdo */
         $pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->onlyMethods(['exec'])->getMock();
-        $pdo->expects($this->once())->method('exec')->with('SELECT 1;')->will($this->returnValue(1));
+        $pdo->expects($this->once())->method('exec')->with('SELECT 1')->will($this->returnValue(1));
 
         $this->adapter->setConnection($pdo);
         $this->adapter->execute('SELECT 1;;');


### PR DESCRIPTION
Closes #2340 

(Currently writing an OCI Adapter)
OCI doesn't allow a trailing semicolon.

Still output the semicolon, so that output can be easily copy/pasted