### PR TITLE
Remove cakephp/cakephp dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
     "require-dev": {
         "ext-json": "*",
         "ext-pdo": "*",
-        "cakephp/cakephp": "^5.0.2",
         "cakephp/cakephp-codesniffer": "^5.0",
         "phpunit/phpunit": "^9.5.19",
         "symfony/yaml": "^3.4|^4.0|^5.0|^6.0|^7.0"


### PR DESCRIPTION
The `cakephp/cakephp` dev dependency was added in 37307f8189b1ed307c4bd00235190b1a984c49e2, but to my knowledge we don't directly depend on it, so removing it as it's unnecessary bloat. I think it's also potentially allowing #2348 to not throw an exception as we don't directly rely on `cakephp/i15n`, but it's included from `cakephp/cakephp`.