### PR TITLE
Drop symfony 3.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "composer-runtime-api": "^2.0",
         "cakephp/database": "^5.0.2",
         "psr/container": "^1.1|^2.0",
-        "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",
+        "symfony/config": "^4.0|^5.0|^6.0|^7.0",
         "symfony/console": "^6.0|^7.0"
     },
     "require-dev": {
@@ -48,7 +48,7 @@
         "ext-pdo": "*",
         "cakephp/cakephp-codesniffer": "^5.0",
         "phpunit/phpunit": "^9.5.19",
-        "symfony/yaml": "^3.4|^4.0|^5.0|^6.0|^7.0"
+        "symfony/yaml": "^4.0|^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Composer states for this repo as min requirement: `"php-64bit": ">=8.1"`

symfony/config Version | Min PHP Version | Max PHP Version (tested/stable)
-- | -- | --
3.4 | 5.5.9 | 7.4 (not compatible with 8.1)
4.x | 7.1.3 | 7.4 / 8.0 (partial support)
5.x | 7.2.5 | 8.0+ (5.4+ supports 8.1)
6.x | 8.0 | 8.1+ ✅
7.x | 8.1 | 8.1+ ✅

I would at least drop the 3.x support here, maybe even 4.x.
PR is for 3.x only for now.

Does not make sense to have that huge range supported at this time.

PS: PHPUnit should be upgreaded to v10 or 11 by the way, but thats a separate topic.