### PR TITLE
Fix performance degradation for bulk inserts

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -324,12 +324,11 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * Get the parameters array for prepared insert statement
      *
+     * @param array $params Parameters array to be filled
      * @param array $row Row to be inserted into DB
-     * @return array
      */
-    protected function getInsertParameters(array $row): array
+    protected function getInsertParameters(array &$params, array $row): void
     {
-        $params = [];
         foreach ($row as $value) {
             if ($value instanceof Literal) {
                 continue;
@@ -343,8 +342,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
                 $params[] = $value;
             }
         }
-
-        return $params;
     }
 
     /**
@@ -374,7 +371,8 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
             foreach ($row as $value) {
                 $values[] = $value instanceof Literal ? (string)$value : '?';
             }
-            $params = $this->getInsertParameters($row);
+            $params = [];
+            $this->getInsertParameters($params, $row);
             $sql .= implode(', ', $values) . ')';
             $stmt = $this->getConnection()->prepare($sql);
             $stmt->execute($params);
@@ -445,10 +443,10 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
             }
             $sql .= implode(',', $queries);
             $stmt = $this->getConnection()->prepare($sql);
-            $params = [];
 
+            $params = [];
             foreach ($rows as $row) {
-                $params = array_merge($params, $this->getInsertParameters($row));
+                $this->getInsertParameters($params, $row);
             }
 
             $stmt->execute($params);


### PR DESCRIPTION
PR fixes performance degradation for bulk inserts that was introduced in #2348. The issue was that for the new function I introduced (`getInsertParameters`), we were doing an `array_merge` to append its return value to our building list of parameters. While this worked, as we were making a copy of the `$params` array for each row to be inserted, for enough rows, it would become very slow. By using pass by reference, and just appending to the same array throughout, managed to achieve a great speed-up, while maintaining the DRY intention of `getInsertParameters`.

By moving to a pass by reference setup, given the following migration:

```php
<?php

declare(strict_types=1);

use Phinx\Migration\AbstractMigration;

final class Numbers extends AbstractMigration
{
    /**
     * Change Method.
     *
     * Write your reversible migrations using this method.
     *
     * More information on writing migrations is available here:
     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
     *
     * Remember to call "create()" or "update()" and NOT "save()" when working
     * with the Table class.
     */
    public function change(): void
    {
        $table = $this->table('numbers')
            ->addColumn('key', 'integer')
            ->addColumn('value', 'integer');
        $table->create();

        if ($this->isMigratingUp) {
            for ($i = 1; $i < 120000; $i++) {
                $table->insert([
                    'key' => $i,
                    'value' => $i
                ]);
            }
            $table->saveData();
        }
    }
}
```

I was able to reduce the time it took for sqlite to run this from 41.8165s to 0.3525s.