### PR TITLE
Fix --dry-run option when values to insert are booleans

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -391,6 +391,10 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
             return $value;
         }
 
+        if (is_bool($value)) {
+            return $this->castToBool($value);
+        }
+
         if ($value === null) {
             return 'null';
         }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -7,10 +7,10 @@ use PDO;
 use PDOException;
 use Phinx\Config\Config;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use RuntimeException;
 use Test\Phinx\DeprecationException;
 use Test\Phinx\TestUtils;
-use ReflectionMethod;
 
 class PdoAdapterTest extends TestCase
 {


### PR DESCRIPTION
Related to: #2357 