### PR TITLE
Fix using Cake\I18n\Date and DateTime in insert dry-run

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -403,6 +403,12 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
             return (string)$value;
         }
 
+        if ($value instanceof DateTime) {
+            $value = $value->toDateTimeString();
+        } elseif ($value instanceof Date) {
+            $value = $value->toDateString();
+        }
+
         return $this->getConnection()->quote($value);
     }
 

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -3,9 +3,12 @@ declare(strict_types=1);
 
 namespace Test\Phinx\Db\Adapter;
 
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
 use PDO;
 use PDOException;
 use Phinx\Config\Config;
+use Phinx\Util\Literal;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use RuntimeException;
@@ -205,31 +208,42 @@ class PdoAdapterTest extends TestCase
         $this->adapter->execute('SELECT 1;;');
     }
 
-    public function testQuoteValueNumeric()
+    public function quoteValueDataProvider(): array
     {
-        $method = new ReflectionMethod($this->adapter, 'quoteValue');
-        $this->assertSame(1.0, $method->invoke($this->adapter, 1.0));
-        $this->assertSame(2, $method->invoke($this->adapter, 2));
+        return [
+            [1.0, 1.0],
+            [2, 2],
+            [true, 1],
+            [false, 0],
+            [null, 'null'],
+            [Literal::from('CURRENT_TIMESTAMP'), 'CURRENT_TIMESTAMP'],
+        ];
     }
 
-    public function testQuoteValueBoolean()
+    /**
+     * @dataProvider quoteValueDataProvider
+     */
+    public function testQuoteValue($input, $expected): void
     {
         $method = new ReflectionMethod($this->adapter, 'quoteValue');
-        $this->assertSame(1, $method->invoke($this->adapter, true));
-        $this->assertSame(0, $method->invoke($this->adapter, false));
+        $this->assertSame($expected, $method->invoke($this->adapter, $input));
     }
 
-    public function testQuoteValueNull()
+    public function quoteValueStringDataProvider(): array
     {
-        $method = new ReflectionMethod($this->adapter, 'quoteValue');
-        $this->assertSame('null', $method->invoke($this->adapter, null));
+        return [
+            ['mockvalue', "'mockvalue'"],
+            [new Date('2023-01-01'), "'2023-01-01'"],
+            [new DateTime('2023-01-01 12:00:00'), "'2023-01-01 12:00:00'"],
+        ];
     }
 
-    public function testQuoteValueString()
-    {
-        $mockValue = 'mockvalue';
-        $expectedValue = 'mockvalueexpected';
+    /**
+     * @dataProvider quoteValueStringDataProvider
+     */
 
+    public function testQuoteValueString($input, $expected): void
+    {
         /** @var \PDO&\PHPUnit\Framework\MockObject\MockObject $pdo */
         $pdo = $this->getMockBuilder(PDO::class)
             ->disableOriginalConstructor()
@@ -238,12 +252,13 @@ class PdoAdapterTest extends TestCase
 
         $pdo->expects($this->once())
             ->method('quote')
-            ->with($mockValue)
-            ->willReturn($expectedValue);
+            ->willReturnCallback(function (string $input) {
+                return "'$input'";
+            });
 
         $this->adapter->setConnection($pdo);
 
         $method = new ReflectionMethod($this->adapter, 'quoteValue');
-        $this->assertSame($expectedValue, $method->invoke($this->adapter, $mockValue));
+        $this->assertSame($expected, $method->invoke($this->adapter, $input));
     }
 }


### PR DESCRIPTION
While #2348 added support for `Cake\I18n\Date` and `Cake\I18n\DateTime` in inserts, we didn't add support for it when using the `--dry-run` flag, and so using the flag with those types would produce an exception (ame as the one shown in #2357).

This PR fixes that bug.

PR also reworks the tests added in #2358 to use data providers to reduce repetition. I also added a test case for Literal values which was missing.