### PR TITLE
Add count option to migrate

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -38,15 +38,17 @@ class Migrate extends AbstractCommand
         $this->setDescription('Migrate the database')
             ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to migrate to')
             ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to migrate to')
+            ->addOption('--count', '-k', InputOption::VALUE_REQUIRED, 'The number of migrations to run')
             ->addOption('--dry-run', '-x', InputOption::VALUE_NONE, 'Dump query to standard output instead of executing it')
             ->addOption('--fake', null, InputOption::VALUE_NONE, "Mark any migrations selected as run, but don't actually execute them")
             ->setHelp(
                 <<<EOT
-The <info>migrate</info> command runs all available migrations, optionally up to a specific version
+The <info>migrate</info> command runs all available migrations, optionally up to a specific version, date, or count.
 
 <info>phinx migrate -e development</info>
 <info>phinx migrate -e development -t 20110103081132</info>
 <info>phinx migrate -e development -d 20110103</info>
+<info>phinx migrate -e development -k 5</info>
 <info>phinx migrate -e development -v</info>
 
 EOT,
@@ -68,6 +70,7 @@ EOT,
         /** @var string|null $environment */
         $environment = $input->getOption('environment');
         $date = $input->getOption('date');
+        $count = $input->getOption('count') !== null ? (int)$input->getOption('count') : null;
         $fake = (bool)$input->getOption('fake');
 
         $success = $this->writeInformationOutput($environment, $output);
@@ -85,7 +88,9 @@ EOT,
         try {
             // run the migrations
             $start = microtime(true);
-            if ($date !== null) {
+            if ($count !== null) {
+                $this->getManager()->migrateToCount($environment, $count, $fake);
+            } elseif ($date !== null) {
                 $this->getManager()->migrateToDateTime($environment, new DateTime($date), $fake);
             } else {
                 $this->getManager()->migrate($environment, $version, $fake);

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -301,6 +301,22 @@ class Manager
         }
     }
 
+    public function migrateToCount(string $environment, int $count, bool $fake = false): void
+    {
+        $versions = array_keys($this->getMigrations($environment));
+        $env = $this->getEnvironment($environment);
+        $current = $env->getCurrentVersion();
+
+        if ($current === 0) {
+            $version = $versions[$count - 1];
+        } else {
+            $currentIdx = array_search($current, $versions, true);
+            $version = $versions[min($currentIdx + $count, count($versions) - 1)];
+        }
+
+        $this->migrate($environment, $version, $fake);
+    }
+
     /**
      * Migrate an environment to the specified version.
      *

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -301,6 +301,14 @@ class Manager
         }
     }
 
+    /**
+     * Migrate an environment to a specific number of migrations.
+     *
+     * @param string $environment Environment
+     * @param int $count Number of migrations to apply
+     * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
+     * @return void
+     */
     public function migrateToCount(string $environment, int $count, bool $fake = false): void
     {
         $versions = array_keys($this->getMigrations($environment));

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -332,6 +332,38 @@ class MigrateTest extends TestCase
         $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
     }
 
+    public function testExecuteWithCount(): void
+    {
+        $application = new PhinxApplication();
+        $application->add(new Migrate());
+
+        /** @var Migrate $command */
+        $command = $application->find('migrate');
+
+        // mock the manager class
+        /** @var Manager&MockObject $managerStub */
+        $managerStub = $this->getMockBuilder(Manager::class)
+            ->setConstructorArgs([$this->config, $this->input, $this->output])
+            ->getMock();
+        $managerStub->expects($this->never())
+            ->method('migrate');
+        $managerStub->expects($this->once())
+            ->method('migrateToCount')
+            ->with('development', 5, false);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute(
+            ['command' => $command->getName(), '--environment' => 'development', '--count' => 5],
+            ['decorated' => false],
+        );
+
+        $this->assertStringContainsString('using environment development', $commandTester->getDisplay());
+        $this->assertSame(AbstractCommand::CODE_SUCCESS, $exitCode);
+    }
+
     public function testExecuteWithError(): void
     {
         $exception = new RuntimeException('oops');

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -1362,6 +1362,24 @@ class ManagerTest extends TestCase
         }
     }
 
+    public function testMigrationByCount(): void
+    {
+        $adapter = $this->prepareEnvironment([
+            'migrations' => $this->getCorrectedPath(__DIR__ . '/_files/reversiblemigrations'),
+        ]);
+
+        $this->manager->migrateToCount('production', 2);
+
+        $this->assertTrue($adapter->hasTable('info'));
+        $this->assertFalse($adapter->hasTable('statuses'));
+        $this->assertTrue($adapter->hasTable('users'));
+
+        $this->manager->migrateToCount('production', 1);
+        $this->assertFalse($adapter->hasTable('info'));
+        $this->assertTrue($adapter->hasTable('statuses'));
+        $this->assertTrue($adapter->hasTable('users'));
+    }
+
     /**
      * Test that rollbacking to version chooses the correct
      * migration (with namespace) to point to.


### PR DESCRIPTION
Half does #258

PR adds a new `-k` / `--count` option to the migrate command which allows for running arbitrary number of migrations, without relying on target or date. Decided to use the `-k` shorthand as `-c`,  `-n`, and `-t` were already used, and it can stand for "kount" which I feel like other tools have done (vs `-o` as suggested in the issue, which feels more arbitrary).

I decided to deal with rollback in a follow-up PR as there's a workaround for this functionality there, which is just running the rollback command however many times you need.