### PR TITLE
Unpin version of slevomat/coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "stan": "phpstan analyse",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:~1.9.0 && composer require --dev slevomat/coding-standard:8.18.1 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:~1.9.0 && mv composer.backup composer.json",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "test": "phpunit --colors=always"


### PR DESCRIPTION
slevomat/coding-standard has fixed https://github.com/slevomat/coding-standard/issues/1760 with 8.19.1, so we should be able to unpin the version we were testing against.