### PR TITLE
Rework sqlite fk pragma handling

### DIFF
--- a/src/Phinx/Db/Adapter/AbstractAdapter.php
+++ b/src/Phinx/Db/Adapter/AbstractAdapter.php
@@ -410,4 +410,19 @@ abstract class AbstractAdapter implements AdapterInterface
 
         return in_array($tableName, $this->createdTables, true);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function preExecuteActions(array $updateSequences): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postExecuteActions(array $tableNames, array $preOptions): void
+    {
+    }
 }

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -276,6 +276,13 @@ interface AdapterInterface
     public function execute(string $sql, array $params = []): int;
 
     /**
+     * Function to be called before executing any migration actions.
+     *
+     * @return array
+     */
+    public function preExecuteActions(): array;
+
+    /**
      * Executes a list of migration actions for the given table
      *
      * @param \Phinx\Db\Table\Table $table The table to execute the actions for
@@ -283,6 +290,15 @@ interface AdapterInterface
      * @return void
      */
     public function executeActions(Table $table, array $actions): void;
+
+    /**
+     * Function to be called after executing any migration actions.
+     *
+     * @param array $tableNames List of table names that were affected by the actions
+     * @param array $preOptions Options that were set before executing the actions
+     * @return void
+     */
+    public function postExecuteActions(array $tableNames, array $preOptions): void;
 
     /**
      * Returns a new Query object

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -278,9 +278,10 @@ interface AdapterInterface
     /**
      * Function to be called before executing any migration actions.
      *
+     * @param \Phinx\Db\Plan\AlterTable[][] $updateSequences List of update sequences to be executed
      * @return array
      */
-    public function preExecuteActions(): array;
+    public function preExecuteActions(array $updateSequences): array;
 
     /**
      * Executes a list of migration actions for the given table

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -477,9 +477,9 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritDoc}
      */
-    public function preExecuteActions(): array
+    public function preExecuteActions(array $updateSequences): array
     {
-        return $this->getAdapter()->preExecuteActions();
+        return $this->getAdapter()->preExecuteActions($updateSequences);
     }
 
     /**

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -475,11 +475,27 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function preExecuteActions(): array
+    {
+        return $this->getAdapter()->preExecuteActions();
+    }
+
+    /**
      * @inheritDoc
      */
     public function executeActions(Table $table, array $actions): void
     {
         $this->getAdapter()->executeActions($table, $actions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postExecuteActions(array $tableNames, array $preOptions): void
+    {
+        $this->getAdapter()->postExecuteActions($tableNames, $preOptions);
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -1003,14 +1003,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
 
     /**
      * {@inheritDoc}
-     */
-    public function preExecuteActions(array $updateSequences): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritDoc}
      *
      * @throws \InvalidArgumentException
      * @return void
@@ -1133,12 +1125,5 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         }
 
         $this->executeAlterSteps($table->getName(), $instructions);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function postExecuteActions(array $tableNames, array $preOptions): void
-    {
     }
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -1003,6 +1003,14 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
 
     /**
      * {@inheritDoc}
+     */
+    public function preExecuteActions(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * @throws \InvalidArgumentException
      * @return void
@@ -1125,5 +1133,13 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         }
 
         $this->executeAlterSteps($table->getName(), $instructions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postExecuteActions(array $tableNames, array $preOptions): void
+    {
+
     }
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -1140,6 +1140,5 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function postExecuteActions(array $tableNames, array $preOptions): void
     {
-
     }
 }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -1004,7 +1004,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * {@inheritDoc}
      */
-    public function preExecuteActions(): array
+    public function preExecuteActions(array $updateSequences): array
     {
         return [];
     }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1035,7 +1035,7 @@ PCRE_PATTERN;
      * targeting it.
      *
      * @param string|array<string> $tableName The name of the table for which to check constraints.
-     * @return \Phinx\Db\Util\AlterInstructions
+     * @return void
      */
     protected function validateForeignKeys(string|array $tableNames): void
     {
@@ -1225,8 +1225,6 @@ PCRE_PATTERN;
      * @param ?string $renamedOrRemovedColumnName The name of the renamed or removed column when part of a column
      *  rename/drop operation.
      * @param ?string $newColumnName The new column name when part of a column rename operation.
-     * @param bool $validateForeignKeys Whether to validate foreign keys after the copy and drop operations. Note that
-     *  enabling this option only has an effect when the `foreign_keys` PRAGMA is set to `ON`!
      * @return \Phinx\Db\Util\AlterInstructions
      */
     protected function endAlterByCopyTable(

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -14,6 +14,7 @@ use Cake\Database\Driver\Sqlite as SqliteDriver;
 use InvalidArgumentException;
 use PDO;
 use PDOException;
+use Phinx\Db\Action\AddForeignKey;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\ForeignKey;
 use Phinx\Db\Table\Index;
@@ -1648,7 +1649,6 @@ PCRE_PATTERN;
 
         $tableName = $table->getName();
         $instructions->addPostStep(function ($state) use ($foreignKey, $tableName) {
-            $this->execute('pragma foreign_keys = ON');
             $sql = substr($state['createSQL'], 0, -1) . ',' . $this->getForeignKeySqlDefinition($foreignKey) . '); ';
 
             //Delete indexes from original table and recreate them in temporary table
@@ -1992,9 +1992,22 @@ PCRE_PATTERN;
     /**
      * {@inheritDoc}
      */
-    public function preExecuteActions(): array
+    public function preExecuteActions(array $updateSequences): array
     {
         $foreignKeysEnabled = (bool)$this->fetchRow('PRAGMA foreign_keys')['foreign_keys'];
+
+        if (!$foreignKeysEnabled) {
+            foreach ($updateSequences as $updates) {
+                foreach ($updates as $update) {
+                    foreach ($update->getActions() as $action) {
+                        if ($action instanceof AddForeignKey) {
+                            $foreignKeysEnabled = true;
+                            break 3;
+                        }
+                    }
+                }
+            }
+        }
 
         if ($foreignKeysEnabled) {
             $this->execute('PRAGMA foreign_keys = OFF');

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1048,8 +1048,8 @@ PCRE_PATTERN;
 
         $otherTables = $this
             ->query(
-                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT IN (" . implode(',',array_fill(0, count($tableNames), '?')) . ')',
-                $tableNames
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT IN (" . implode(',', array_fill(0, count($tableNames), '?')) . ')',
+                $tableNames,
             )
             ->fetchAll();
 

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1035,7 +1035,7 @@ PCRE_PATTERN;
      * the given table, and of those tables whose constraints are
      * targeting it.
      *
-     * @param string|array<string> $tableName The name of the table for which to check constraints.
+     * @param string|array<string> $tableNames The name of the table for which to check constraints.
      * @return void
      */
     protected function validateForeignKeys(string|array $tableNames): void

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1034,57 +1034,52 @@ PCRE_PATTERN;
      * the given table, and of those tables whose constraints are
      * targeting it.
      *
-     * @param \Phinx\Db\Util\AlterInstructions $instructions The instructions to process
-     * @param string $tableName The name of the table for which to check constraints.
+     * @param string|array<string> $tableName The name of the table for which to check constraints.
      * @return \Phinx\Db\Util\AlterInstructions
      */
-    protected function validateForeignKeys(AlterInstructions $instructions, string $tableName): AlterInstructions
+    protected function validateForeignKeys(string|array $tableNames): void
     {
-        $instructions->addPostStep(function ($state) use ($tableName) {
-            $tablesToCheck = [
-                $tableName,
-            ];
+        if (!is_array($tableNames)) {
+            $tableNames = [$tableNames];
+        }
 
-            $otherTables = $this
-                ->query(
-                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name != ?",
-                    [$tableName],
-                )
-                ->fetchAll();
+        $tablesToCheck = $tableNames;
 
-            foreach ($otherTables as $otherTable) {
-                $foreignKeyList = $this->getTableInfo($otherTable['name'], 'foreign_key_list');
-                foreach ($foreignKeyList as $foreignKey) {
-                    if (strcasecmp($foreignKey['table'], $tableName) === 0) {
-                        $tablesToCheck[] = $otherTable['name'];
-                        break;
-                    }
+        $otherTables = $this
+            ->query(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT IN (" . implode(',',array_fill(0, count($tableNames), '?')) . ')',
+                $tableNames
+            )
+            ->fetchAll();
+
+        foreach ($otherTables as $otherTable) {
+            $foreignKeyList = $this->getTableInfo($otherTable['name'], 'foreign_key_list');
+            foreach ($foreignKeyList as $foreignKey) {
+                if (in_array(strtolower($foreignKey['table']), $tableNames)) {
+                    $tablesToCheck[] = $otherTable['name'];
+                    break;
                 }
             }
+        }
 
-            $tablesToCheck = array_unique(array_map('strtolower', $tablesToCheck));
+        $tablesToCheck = array_unique(array_map('strtolower', $tablesToCheck));
 
-            foreach ($tablesToCheck as $tableToCheck) {
-                $schema = $this->getSchemaName($tableToCheck, true)['schema'];
+        foreach ($tablesToCheck as $tableToCheck) {
+            $schema = $this->getSchemaName($tableToCheck, true)['schema'];
 
-                $stmt = $this->query(
-                    sprintf('PRAGMA %sforeign_key_check(%s)', $schema, $this->quoteTableName($tableToCheck)),
-                );
-                $row = $stmt->fetch();
-                $stmt->closeCursor();
+            $stmt = $this->query(
+                sprintf('PRAGMA %sforeign_key_check(%s)', $schema, $this->quoteTableName($tableToCheck)),
+            );
+            $row = $stmt->fetch();
+            $stmt->closeCursor();
 
-                if (is_array($row)) {
-                    throw new RuntimeException(sprintf(
-                        'Integrity constraint violation: FOREIGN KEY constraint on `%s` failed.',
-                        $tableToCheck,
-                    ));
-                }
+            if (is_array($row)) {
+                throw new RuntimeException(sprintf(
+                    'Integrity constraint violation: FOREIGN KEY constraint on `%s` failed.',
+                    $tableToCheck,
+                ));
             }
-
-            return $state;
-        });
-
-        return $instructions;
+        }
     }
 
     /**
@@ -1239,7 +1234,6 @@ PCRE_PATTERN;
         string $tableName,
         ?string $renamedOrRemovedColumnName = null,
         ?string $newColumnName = null,
-        bool $validateForeignKeys = true,
     ): AlterInstructions {
         $instructions = $this->bufferIndicesAndTriggers($instructions, $tableName);
 
@@ -1251,25 +1245,8 @@ PCRE_PATTERN;
             }
         }
 
-        $foreignKeysEnabled = (bool)$this->fetchRow('PRAGMA foreign_keys')['foreign_keys'];
-
-        if ($foreignKeysEnabled) {
-            $instructions->addPostStep('PRAGMA foreign_keys = OFF');
-        }
-
         $instructions = $this->copyAndDropTmpTable($instructions, $tableName);
         $instructions = $this->recreateIndicesAndTriggers($instructions);
-
-        if ($foreignKeysEnabled) {
-            $instructions->addPostStep('PRAGMA foreign_keys = ON');
-        }
-
-        if (
-            $foreignKeysEnabled &&
-            $validateForeignKeys
-        ) {
-            $instructions = $this->validateForeignKeys($instructions, $tableName);
-        }
 
         return $instructions;
     }
@@ -1661,7 +1638,7 @@ PCRE_PATTERN;
             return $newState + $state;
         });
 
-        return $this->endAlterByCopyTable($instructions, $tableName, null, null, false);
+        return $this->endAlterByCopyTable($instructions, $tableName, null, null);
     }
 
     /**
@@ -2012,5 +1989,32 @@ PCRE_PATTERN;
         }
 
         return $this->decoratedConnection = $this->buildConnection(SqliteDriver::class, $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function preExecuteActions(): array
+    {
+        $foreignKeysEnabled = (bool)$this->fetchRow('PRAGMA foreign_keys')['foreign_keys'];
+
+        if ($foreignKeysEnabled) {
+            $this->execute('PRAGMA foreign_keys = OFF');
+        }
+
+        return [
+            'foreignKeysEnabled' => $foreignKeysEnabled,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postExecuteActions(array $tableNames, array $preOptions): void
+    {
+        if ($preOptions['foreignKeysEnabled']) {
+            $this->execute('PRAGMA foreign_keys = ON');
+            $this->validateForeignKeys($tableNames);
+        }
     }
 }

--- a/src/Phinx/Db/Plan/Plan.php
+++ b/src/Phinx/Db/Plan/Plan.php
@@ -143,14 +143,15 @@ class Plan
      */
     public function execute(AdapterInterface $executor): void
     {
-        $preOptions = $executor->preExecuteActions();
+        $updatesSequence = $this->updatesSequence();
+        $preOptions = $executor->preExecuteActions($updatesSequence);
 
         foreach ($this->tableCreates as $newTable) {
             $executor->createTable($newTable->getTable(), $newTable->getColumns(), $newTable->getIndexes());
         }
 
         $tables = [];
-        foreach ($this->updatesSequence() as $updates) {
+        foreach ($updatesSequence as $updates) {
             foreach ($updates as $update) {
                 $tables[] = $update->getTable()->getName();
                 $executor->executeActions($update->getTable(), $update->getActions());
@@ -168,7 +169,7 @@ class Plan
      */
     public function executeInverse(AdapterInterface $executor): void
     {
-        $preOptions = $executor->preExecuteActions();
+        $preOptions = $executor->preExecuteActions($this->inverseUpdatesSequence());
         $tables = [];
 
         foreach ($this->inverseUpdatesSequence() as $updates) {
@@ -178,11 +179,11 @@ class Plan
             }
         }
 
-        $executor->postExecuteActions(array_unique($tables), $preOptions);
-
         foreach ($this->tableCreates as $newTable) {
             $executor->createTable($newTable->getTable(), $newTable->getColumns(), $newTable->getIndexes());
         }
+
+        $executor->postExecuteActions(array_unique($tables), $preOptions);
     }
 
     /**

--- a/src/Phinx/Db/Plan/Plan.php
+++ b/src/Phinx/Db/Plan/Plan.php
@@ -168,11 +168,17 @@ class Plan
      */
     public function executeInverse(AdapterInterface $executor): void
     {
+        $preOptions = $executor->preExecuteActions();
+        $tables = [];
+
         foreach ($this->inverseUpdatesSequence() as $updates) {
             foreach ($updates as $update) {
+                $tables[] = $update->getTable()->getName();
                 $executor->executeActions($update->getTable(), $update->getActions());
             }
         }
+
+        $executor->postExecuteActions(array_unique($tables), $preOptions);
 
         foreach ($this->tableCreates as $newTable) {
             $executor->createTable($newTable->getTable(), $newTable->getColumns(), $newTable->getIndexes());

--- a/src/Phinx/Db/Plan/Plan.php
+++ b/src/Phinx/Db/Plan/Plan.php
@@ -143,15 +143,21 @@ class Plan
      */
     public function execute(AdapterInterface $executor): void
     {
+        $preOptions = $executor->preExecuteActions();
+
         foreach ($this->tableCreates as $newTable) {
             $executor->createTable($newTable->getTable(), $newTable->getColumns(), $newTable->getIndexes());
         }
 
+        $tables = [];
         foreach ($this->updatesSequence() as $updates) {
             foreach ($updates as $update) {
+                $tables[] = $update->getTable()->getName();
                 $executor->executeActions($update->getTable(), $update->getActions());
             }
         }
+
+        $executor->postExecuteActions(array_unique($tables), $preOptions);
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2387,6 +2387,7 @@ OUTPUT;
      */
     public function testAlterTableDoesViolateForeignKeyConstraintOnSourceTableChange()
     {
+        /** @var \Phinx\Db\Adapter\AdapterInterface&\PHPUnit\Framework\MockObject\MockObject */
         $adapter = $this
             ->getMockBuilder(SQLiteAdapter::class)
             ->setConstructorArgs([SQLITE_DB_CONFIG, new ArrayInput([]), new NullOutput()])

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2397,14 +2397,19 @@ OUTPUT;
         $adapterReflection = new ReflectionObject($adapter);
         $queryReflection = $adapterReflection->getParentClass()->getMethod('query');
 
+        $count = 0;
         $adapter
             ->expects($this->atLeastOnce())
             ->method('query')
-            ->willReturnCallback(function (string $sql, array $params = []) use ($adapter, $queryReflection) {
+            ->willReturnCallback(function (string $sql, array $params = []) use ($adapter, &$count, $queryReflection) {
                 if ($sql === 'PRAGMA foreign_key_check(`comments`)') {
-                    $adapter->execute('PRAGMA foreign_keys = OFF');
-                    $adapter->execute('DELETE FROM articles');
-                    $adapter->execute('PRAGMA foreign_keys = ON');
+                    $count++;
+
+                    if ($count > 1) {
+                        $adapter->execute('PRAGMA foreign_keys = OFF');
+                        $adapter->execute('DELETE FROM articles');
+                        $adapter->execute('PRAGMA foreign_keys = ON');
+                    }
                 }
 
                 return $queryReflection->invoke($adapter, $sql, $params);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2387,7 +2387,7 @@ OUTPUT;
      */
     public function testAlterTableDoesViolateForeignKeyConstraintOnSourceTableChange()
     {
-        /** @var \Phinx\Db\Adapter\AdapterInterface&\PHPUnit\Framework\MockObject\MockObject */
+        /** @var \Phinx\Db\Adapter\AdapterInterface&\PHPUnit\Framework\MockObject\MockObject $adapter */
         $adapter = $this
             ->getMockBuilder(SQLiteAdapter::class)
             ->setConstructorArgs([SQLITE_DB_CONFIG, new ArrayInput([]), new NullOutput()])


### PR DESCRIPTION
PR reworks how we handle the foreign key pragma in sqlite, so that we turn on the pragma before doing any plan actions, and turn it back on after all actions have run (vs doing it within an action sequence, potentially repeatedly). This is accomplished by introducing a new `pre` and `post` hook to the `executeActions` flow that the sqlite adapter specifically takes advantage of. This should make it possible to potentially re-order and rework how certain plans are generated for sqlite, with an immediate goal of allowing a user to both change a primary key and set identity on it within the same alter chain.

The only downside I could think of is that this may make us do the FK validation step more often as some commands could avoid it, but it's quick enough that I don't think there's real harm in it.