### PR TITLE
Fix errors with custom autoload

### DIFF
--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -94,6 +94,10 @@ class PhinxApplication extends Application
         }
 
         // Otherwise fallback to the version as reported by composer
-        return $this->version = InstalledVersions::getPrettyVersion('robmorgan/phinx') ?? 'UNKNOWN';
+        if (class_exists(InstalledVersions::class)) {
+            return $this->version = InstalledVersions::getPrettyVersion('robmorgan/phinx') ?? 'UNKNOWN';
+        }
+
+        return $this->version = 'UNKNOWN';
     }
 }


### PR DESCRIPTION
When we prefix this library with https://github.com/BrianHenryIE/strauss it creates its own composer autoloader and it is impossible to use cli