### PR TITLE
fixed typo in format warning message

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -55,7 +55,7 @@ class Create extends AbstractCommand
         parent::configure();
 
         $this->setDescription('Create a new migration')
-            ->addArgument('name', InputArgument::OPTIONAL, 'Class name of the migration (in CamelCase)')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Class name of the migration (in PascalCase)')
             ->setHelp(sprintf(
                 '%sCreates a new database migration%s',
                 PHP_EOL,
@@ -194,7 +194,7 @@ class Create extends AbstractCommand
         } else {
             if (!Util::isValidPhinxClassName($className)) {
                 throw new InvalidArgumentException(sprintf(
-                    'The migration class name "%s" is invalid. Please use CamelCase format.',
+                    'The migration class name "%s" is invalid. Please use PascalCase format.',
                     $className,
                 ));
             }


### PR DESCRIPTION
This pull request updates the naming convention for migration class names in the `Create` command to use PascalCase instead of CamelCase. The changes ensure consistency in the format and provide clear guidance to users.

### Updates to naming convention:

* [`src/Phinx/Console/Command/Create.php`](diffhunk://#diff-97d6d3bf0fdbfbabdbc99e17ca8b51971dceff15c96afb1e32c0d3431a6101adL58-R58): Updated the argument description in the `configure` method to specify that the migration class name should be in PascalCase.
* [`src/Phinx/Console/Command/Create.php`](diffhunk://#diff-97d6d3bf0fdbfbabdbc99e17ca8b51971dceff15c96afb1e32c0d3431a6101adL197-R197): Updated the error message in the `execute` method to indicate that the migration class name must use PascalCase format.