### PR TITLE
Make configuration a top-level option

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -107,7 +107,6 @@ abstract class AbstractCommand extends Command
      */
     protected function configure(): void
     {
-        $this->addOption('--configuration', '-c', InputOption::VALUE_REQUIRED, 'The configuration file to load');
         $this->addOption('--parser', '-p', InputOption::VALUE_REQUIRED, 'Parser used to read the config file. Defaults to YAML');
         $this->addOption('--no-info', null, InputOption::VALUE_NONE, 'Hides all debug information');
     }

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -88,9 +88,6 @@ class Init extends Command
      */
     protected function resolvePath(InputInterface $input, string $format): string
     {
-        // get the migration path from the config
-        $path = (string)$input->getArgument('path');
-
         if (!in_array($format, static::$supportedFormats, true)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid format "%s". Format must be either ' . implode(', ', static::$supportedFormats) . '.',
@@ -98,9 +95,26 @@ class Init extends Command
             ));
         }
 
-        // Fallback
+        // We either get the path to where to create the config path by:
+        //   1. The path argument if set
+        //   2. The configuration option if set
+        //   3. Fallback to a default path of the current directory
+        $path = (string)$input->getArgument('path');
+
         if (!$path) {
-            $path = getcwd() . DIRECTORY_SEPARATOR . self::FILE_NAME . '.' . $format;
+            if ($input->hasOption('configuration')) {
+                $path = (string)$input->getOption('configuration');
+                if (DIRECTORY_SEPARATOR === '/') {
+                    $isAbsolute = ($path[0] === '/');
+                } else {
+                    $isAbsolute = (preg_match('/^[a-zA-Z]:\\\\/', $path) === 1 || $path[0] === '\\');
+                }
+                if (!$isAbsolute) {
+                    $path = getcwd() . DIRECTORY_SEPARATOR . $path;
+                }
+            } else {
+                $path = getcwd() . DIRECTORY_SEPARATOR . self::FILE_NAME . '.' . $format;
+            }
         }
 
         // Adding file name if necessary

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -102,7 +102,8 @@ class Init extends Command
         $path = (string)$input->getArgument('path');
 
         if (!$path) {
-            if ($input->hasOption('configuration')) {
+            $path = $input->hasOption('configuration') ? (string)$input->getOption('configuration') : null;
+            if ($path) {
                 $path = (string)$input->getOption('configuration');
                 if (DIRECTORY_SEPARATOR === '/') {
                     $isAbsolute = ($path[0] === '/');

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -20,7 +20,9 @@ use Phinx\Console\Command\SeedRun;
 use Phinx\Console\Command\Status;
 use Phinx\Console\Command\Test;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use \Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -52,6 +54,19 @@ class PhinxApplication extends Application
             new SeedRun(),
             new ListAliases(),
         ]);
+    }
+
+    /**
+     * Setup default input definition.
+     *
+     * @return InputDefinition the overridden input definition.
+     */
+    protected function getDefaultInputDefinition(): InputDefinition
+    {
+        $definition = parent::getDefaultInputDefinition();
+        $definition->addOption(new \Symfony\Component\Console\Input\InputOption('--configuration', '-c', InputOption::VALUE_REQUIRED, 'The configuration file to load'));
+
+        return $definition;
     }
 
     /**

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -22,7 +22,7 @@ use Phinx\Console\Command\Test;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -59,12 +59,12 @@ class PhinxApplication extends Application
     /**
      * Setup default input definition.
      *
-     * @return InputDefinition the overridden input definition.
+     * @return \Symfony\Component\Console\Input\InputDefinition the overridden input definition.
      */
     protected function getDefaultInputDefinition(): InputDefinition
     {
         $definition = parent::getDefaultInputDefinition();
-        $definition->addOption(new \Symfony\Component\Console\Input\InputOption('--configuration', '-c', InputOption::VALUE_REQUIRED, 'The configuration file to load'));
+        $definition->addOption(new InputOption('--configuration', '-c', InputOption::VALUE_REQUIRED, 'The configuration file to load'));
 
         return $definition;
     }

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -82,9 +82,53 @@ class InitTest extends TestCase
         $this->writeConfig(uniqid() . $format);
     }
 
+    public function configurationOptionDataProvider(): array
+    {
+        return [
+            ['phinx.php'],
+            [sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.php'],
+        ];
+    }
+
+    /**
+     * @dataProvider configurationOptionDataProvider
+     */
+    public function testConfigurationOption($configPath): void
+    {
+        $currentDir = getcwd();
+        $expectedPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phinx.php';
+        try {
+            chdir(sys_get_temp_dir());
+            $application = new PhinxApplication();
+            $application->add(new Init());
+            $command = $application->find('init');
+            $commandTester = new CommandTester($command);
+
+            $command = [
+                '--configuration' => $configPath,
+                'command' => $command->getName(),
+            ];
+
+            $exitCode = $commandTester->execute($command, ['decorated' => false]);
+            $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
+
+            $this->assertStringContainsString(
+                "created $expectedPath",
+                $commandTester->getDisplay(),
+            );
+
+            $this->assertFileExists(
+                $expectedPath,
+                'Phinx configuration not existent',
+            );
+        } finally {
+            chdir($currentDir);
+        }
+    }
+
     public function testDefaults()
     {
-        $current_dir = getcwd();
+        $currentDir = getcwd();
 
         try {
             chdir(sys_get_temp_dir());
@@ -107,13 +151,13 @@ class InitTest extends TestCase
                 'Phinx configuration not existent',
             );
         } finally {
-            chdir($current_dir);
+            chdir($currentDir);
         }
     }
 
     public function testYamlFormat()
     {
-        $current_dir = getcwd();
+        $currentDir = getcwd();
 
         try {
             chdir(sys_get_temp_dir());
@@ -136,7 +180,7 @@ class InitTest extends TestCase
                 'Phinx configuration not existent',
             );
         } finally {
-            chdir($current_dir);
+            chdir($currentDir);
         }
     }
 


### PR DESCRIPTION
PR moves the `--configuration` option to the top-level, making it possible to do stuff like `phinx --configuration phinx.yml status`, whereas right now `--configuration` must follow the command (e.g. `phinx status --configuration phinx.yml`). This should make it drastically simpler to run multiple different phinx commands (migrate, rollback, status in my case) where in the terminal, I can hit up, delete the command, and then type a new command, without needing to left key past `--configuration phinx.yml`.

As this is a top-level command, I've added support for it to `init` command as well since that was the only command that currently didn't use it, though the `path` argument still takes precedence