### PR TITLE
Fix Decimal Column Definition Issue When Scale is 0

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1355,7 +1355,7 @@ class MysqlAdapter extends PdoAdapter
             $sqlType = $this->getSqlType($column->getType(), $column->getLimit());
             $def = strtoupper($sqlType['name']);
         }
-        if ($column->getPrecision() && $column->getScale()) {
+        if ($column->getPrecision() && $column->getScale() !== null) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         } elseif (isset($sqlType['limit'])) {
             $def .= '(' . $sqlType['limit'] . ')';


### PR DESCRIPTION
In CakePHP's MySQL adapter, when defining a Decimal column with scale set to 0 (e.g. `DECIMAL(65,0)` or `DECIMAL(10,0))`, the generated SQL definition was missing precision information.
Specifically, when users need to create a `DECIMAL(65)` column (precision=65, scale=0), due to the condition check `$column->getScale()` returning 0, which is treated as false in boolean context, the entire condition `$column->getPrecision()` && `$column->getScale()` evaluates to false, causing the precision and scale definition to be skipped.