### PR TITLE
Add test for mysql zero scale column def fix

### DIFF
--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2732,13 +2732,13 @@ INPUT;
         $this->adapter->connect();
         $table = new Table('test_table', ['id' => false], $this->adapter);
         $table
-            ->addColumn('col_1', 'decimal', ['null' => false, 'precision' => 10, 'scale' => 0])
+            ->addColumn('col_1', 'decimal', ['null' => false, 'precision' => 15, 'scale' => 0])
             ->create();
 
         $columns = $table->getColumns();
         $this->assertCount(1, $columns);
         $this->assertSame('col_1', $columns[0]->getName());
-        $this->assertSame(10, $columns[0]->getPrecision());
+        $this->assertSame(15, $columns[0]->getPrecision());
         $this->assertSame(0, $columns[0]->getScale());
     }
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2727,6 +2727,21 @@ INPUT;
         $this->assertEqualsIgnoringCase('CURRENT_TIMESTAMP(3)', $colDef['COLUMN_DEFAULT']);
     }
 
+    public function testCreateTableWithZeroScale(): void
+    {
+        $this->adapter->connect();
+        $table = new Table('test_table', ['id' => false], $this->adapter);
+        $table
+            ->addColumn('col_1', 'decimal', ['null' => false, 'precision' => 10, 'scale' => 0])
+            ->create();
+
+        $columns = $table->getColumns();
+        $this->assertCount(1, $columns);
+        $this->assertSame('col_1', $columns[0]->getName());
+        $this->assertSame(10, $columns[0]->getPrecision());
+        $this->assertSame(0, $columns[0]->getScale());
+    }
+
     public function pdoAttributeProvider()
     {
         return [


### PR DESCRIPTION
PR adds a test for the fix done in #2377, validating the case where when `scale` is set to `0`, then we do still get `decimal(15,0)` in the column definition.

For reference, the default value for precision if the arguments are omitted is 10.