### PR TITLE
Update set output usage in GH workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
     - name: Get date part for cache key
       id: key-date
-      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+      run: echo "date=$(Get-Date -Format 'yyyy-MM')" >> $env:GITHUB_OUTPUT
 
     - name: Setup PHP extensions cache
       id: php-ext-cache
@@ -164,7 +164,7 @@ jobs:
 
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(composer config cache-files-dir)" >> $env:GITHUB_OUTPUT
 
     - name: Cache composer dependencies
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,11 @@ jobs:
 
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Get date part for cache key
       id: key-date
-      run: echo "::set-output name=date::$(date +'%Y-%m')"
+      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
     - name: Cache composer dependencies
       uses: actions/cache@v4
@@ -130,7 +130,7 @@ jobs:
 
     - name: Get date part for cache key
       id: key-date
-      run: echo "::set-output name=date::$(date +'%Y-%m')"
+      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
     - name: Setup PHP extensions cache
       id: php-ext-cache
@@ -164,7 +164,7 @@ jobs:
 
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache composer dependencies
       uses: actions/cache@v4
@@ -202,11 +202,11 @@ jobs:
 
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Get date part for cache key
       id: key-date
-      run: echo "::set-output name=date::$(date +'%Y-%m')"
+      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
     - name: Cache composer dependencies
       uses: actions/cache@v4

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
PR updates the workflows to stop using the deprecated `set-output` commands in favor of the currently supported `GITHUB_OUTPUT` variable, per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

Should fix the warnings showing up when viewing an action run.