### PR TITLE
Update upload asset step for phar workflow

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -40,12 +40,15 @@ jobs:
         run: ~/.composer/vendor/bin/box compile
 
       - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v8
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./phinx.phar
-          asset_name: phinx.phar
-          asset_content_type: application/octet-stream
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const fs = require('fs').promises;
+            await github.rest.repos.uploadReleaseAsset({
+              name: 'phinx.phar',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: ${{ github.event.release.id }},
+              data: await fs.readFile('./phinx.phar')  # The file to upload.
+            });

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -49,6 +49,6 @@ jobs:
               name: 'phinx.phar',
               owner: context.repo.owner,
               repo: context.repo.repo,
-              release_id: ${{ github.event.release.id }},
-              data: await fs.readFile('./phinx.phar')  # The file to upload.
+              release_id: context.payload.release.id,
+              data: await fs.readFile('./phinx.phar')
             });


### PR DESCRIPTION
PR updates the upload release asset step in the `phar.yml` workflow from using `actions/upload-release-asset` (which was archived and hasn't seen any updates in years) to just using the direct REST API to upload the asset. `actions/upload-release-asset` does recommend using https://github.com/softprops/action-gh-release, but that action assumes that it does the entire lifecycle of creating a release, which I don't need here, I just need to upload a singular asset.