### PR TITLE
Fix cache key for phar workflow

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies


### PR DESCRIPTION
PR fixes the computation of the cache key for the phar workflow, where it was previously relying on taking the hash of the `composer.lock` file, but since we don't check that in, was just coming up blank. Moved it to use `composer.json` like the other workflows.