### PR TITLE
Improve precision and scale behavior across adapters

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4,9 +4,3 @@ parameters:
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: src/Phinx/Db/Adapter/MysqlAdapter.php
-
-		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 2
-			path: src/Phinx/Db/Adapter/SqlServerAdapter.php
-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,8 +5,3 @@ parameters:
 			count: 1
 			path: src/Phinx/Db/Adapter/MysqlAdapter.php
 
-		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 2
-			path: src/Phinx/Db/Adapter/SqlServerAdapter.php
-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 2
-			path: src/Phinx/Db/Adapter/SqlServerAdapter.php
-
-		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: src/Phinx/Db/Adapter/MysqlAdapter.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 2
+			path: src/Phinx/Db/Adapter/SqlServerAdapter.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 2
+			path: src/Phinx/Db/Adapter/SqlServerAdapter.php
+
+		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: src/Phinx/Db/Adapter/MysqlAdapter.php

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1359,8 +1359,8 @@ class MysqlAdapter extends PdoAdapter
         if ($column->getPrecision() || $column->getScale()) {
             $def .= sprintf(
                 '(%s, %s)',
-                $column->getPrecision() ?: $sqlType['precision'],
-                $column->getScale() ?: $sqlType['scale'],
+                $column->getPrecision() ?: ($sqlType['precision'] ?? 10),
+                $column->getScale() ?: ($sqlType['scale'] ?? 0),
             );
         } elseif (isset($sqlType['limit'])) {
             $def .= '(' . $sqlType['limit'] . ')';

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -956,9 +956,10 @@ class MysqlAdapter extends PdoAdapter
     {
         $type = (string)$type;
         switch ($type) {
+            case static::PHINX_TYPE_DECIMAL:
+                return ['name' => $type, 'precision' => 10, 'scale' => 0];
             case static::PHINX_TYPE_FLOAT:
             case static::PHINX_TYPE_DOUBLE:
-            case static::PHINX_TYPE_DECIMAL:
             case static::PHINX_TYPE_DATE:
             case static::PHINX_TYPE_ENUM:
             case static::PHINX_TYPE_SET:
@@ -1355,8 +1356,12 @@ class MysqlAdapter extends PdoAdapter
             $sqlType = $this->getSqlType($column->getType(), $column->getLimit());
             $def = strtoupper($sqlType['name']);
         }
-        if ($column->getPrecision() && $column->getScale() !== null) {
-            $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
+        if ($column->getPrecision() || $column->getScale()) {
+            $def .= sprintf(
+                '(%s, %s)',
+                $column->getPrecision() ?: $sqlType['precision'],
+                $column->getScale() ?: $sqlType['scale'],
+            );
         } elseif (isset($sqlType['limit'])) {
             $def .= '(' . $sqlType['limit'] . ')';
         }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -956,10 +956,9 @@ class MysqlAdapter extends PdoAdapter
     {
         $type = (string)$type;
         switch ($type) {
-            case static::PHINX_TYPE_DECIMAL:
-                return ['name' => $type, 'precision' => 10, 'scale' => 0];
             case static::PHINX_TYPE_FLOAT:
             case static::PHINX_TYPE_DOUBLE:
+            case static::PHINX_TYPE_DECIMAL:
             case static::PHINX_TYPE_DATE:
             case static::PHINX_TYPE_ENUM:
             case static::PHINX_TYPE_SET:
@@ -1356,12 +1355,8 @@ class MysqlAdapter extends PdoAdapter
             $sqlType = $this->getSqlType($column->getType(), $column->getLimit());
             $def = strtoupper($sqlType['name']);
         }
-        if ($column->getPrecision() || $column->getScale()) {
-            $def .= sprintf(
-                '(%s, %s)',
-                $column->getPrecision() ?: ($sqlType['precision'] ?? 10),
-                $column->getScale() ?: ($sqlType['scale'] ?? 0),
-            );
+        if ($column->getPrecision() && $column->getScale() !== null) {
+            $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         } elseif (isset($sqlType['limit'])) {
             $def .= '(' . $sqlType['limit'] . ')';
         }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1868,8 +1868,12 @@ PCRE_PATTERN;
                 $def .= '(' . ($column->getLimit() ?: $sqlType['limit']) . ')';
             }
         }
-        if ($column->getPrecision() && $column->getScale()) {
-            $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
+        if ($column->getPrecision() || $column->getScale()) {
+            $def .= sprintf(
+                '(%s, %s)',
+                $column->getPrecision() ?: 10,
+                $column->getScale() ?: 0,
+            );
         }
 
         $default = $column->getDefault();

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1868,7 +1868,7 @@ PCRE_PATTERN;
                 $def .= '(' . ($column->getLimit() ?: $sqlType['limit']) . ')';
             }
         }
-        if ($column->getPrecision() || $column->getScale()) {
+        if ($column->getPrecision() && $column->getScale() !== null) {
             $def .= sprintf(
                 '(%s, %s)',
                 $column->getPrecision() ?: 10,

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1869,11 +1869,7 @@ PCRE_PATTERN;
             }
         }
         if ($column->getPrecision() && $column->getScale() !== null) {
-            $def .= sprintf(
-                '(%s, %s)',
-                $column->getPrecision() ?: 10,
-                $column->getScale() ?: 0,
-            );
+            $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         }
 
         $default = $column->getDefault();

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1063,8 +1063,9 @@ ORDER BY T.[name], I.[index_id];";
     {
         $type = (string)$type;
         switch ($type) {
-            case static::PHINX_TYPE_FLOAT:
             case static::PHINX_TYPE_DECIMAL:
+                return ['name' => $type, 'precision' => 18, 'scale' => 0];
+            case static::PHINX_TYPE_FLOAT:
             case static::PHINX_TYPE_DATETIME:
             case static::PHINX_TYPE_TIME:
             case static::PHINX_TYPE_DATE:
@@ -1237,7 +1238,7 @@ ORDER BY T.[name], I.[index_id];";
                 'tinyint',
                 'smallint',
             ];
-            if ($sqlType['name'] === static::PHINX_TYPE_DECIMAL && $column->getPrecision() && $column->getScale()) {
+            if ($sqlType['name'] === static::PHINX_TYPE_DECIMAL && ($column->getPrecision() || $column->getScale())) {
                 $buffer[] = sprintf(
                     '(%s, %s)',
                     $column->getPrecision() ?: $sqlType['precision'],

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -476,7 +476,7 @@ class SqlServerAdapter extends PdoAdapter
                    ->setNull($columnInfo['null'] !== 'NO')
                    ->setDefault($this->parseDefault($columnInfo['default']))
                    ->setIdentity($columnInfo['identity'] === '1')
-                   ->setScale($columnInfo['scale'])
+                   ->setScale($columnInfo['scale'] ? (int)$columnInfo['scale'] : null)
                    ->setComment($this->getColumnComment($columnInfo['table_name'], $columnInfo['name']));
 
             if (!empty($columnInfo['char_length'])) {

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -484,7 +484,7 @@ class SqlServerAdapter extends PdoAdapter
             }
 
             if ($type === self::PHINX_TYPE_DECIMAL) {
-                $column->setPrecision($columnInfo['precision']);
+                $column->setPrecision((int)$columnInfo['precision']);
             }
 
             $columns[$columnInfo['name']] = $column;

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -476,10 +476,15 @@ class SqlServerAdapter extends PdoAdapter
                    ->setNull($columnInfo['null'] !== 'NO')
                    ->setDefault($this->parseDefault($columnInfo['default']))
                    ->setIdentity($columnInfo['identity'] === '1')
+                   ->setScale($columnInfo['scale'])
                    ->setComment($this->getColumnComment($columnInfo['table_name'], $columnInfo['name']));
 
             if (!empty($columnInfo['char_length'])) {
                 $column->setLimit((int)$columnInfo['char_length']);
+            }
+
+            if ($type === self::PHINX_TYPE_DECIMAL) {
+                $column->setPrecision($columnInfo['numeric_precision']);
             }
 
             $columns[$columnInfo['name']] = $column;

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -484,7 +484,7 @@ class SqlServerAdapter extends PdoAdapter
             }
 
             if ($type === self::PHINX_TYPE_DECIMAL) {
-                $column->setPrecision($columnInfo['numeric_precision']);
+                $column->setPrecision($columnInfo['precision']);
             }
 
             $columns[$columnInfo['name']] = $column;

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1389,8 +1389,9 @@ class MysqlAdapterTest extends TestCase
             ['column6', 'float', []],
             ['column7', 'decimal', []],
             ['decimal_precision_scale', 'decimal', ['precision' => 10, 'scale' => 2]],
+            ['decimal_precision_zero_scale', 'decimal', ['precision' => 15, 'scale' => 0]],
             ['decimal_limit', 'decimal', ['limit' => 10]],
-            ['decimal_precision', 'decimal', ['precision' => 10]],
+            ['decimal_precision', 'decimal', ['precision' => 15]],
             ['column8', 'datetime', []],
             ['column9', 'time', []],
             ['column10', 'timestamp', []],
@@ -2725,21 +2726,6 @@ INPUT;
         ));
         $colDef = $rows[0];
         $this->assertEqualsIgnoringCase('CURRENT_TIMESTAMP(3)', $colDef['COLUMN_DEFAULT']);
-    }
-
-    public function testCreateTableWithZeroScale(): void
-    {
-        $this->adapter->connect();
-        $table = new Table('test_table', ['id' => false], $this->adapter);
-        $table
-            ->addColumn('col_1', 'decimal', ['null' => false, 'precision' => 15, 'scale' => 0])
-            ->create();
-
-        $columns = $table->getColumns();
-        $this->assertCount(1, $columns);
-        $this->assertSame('col_1', $columns[0]->getName());
-        $this->assertSame(15, $columns[0]->getPrecision());
-        $this->assertSame(0, $columns[0]->getScale());
     }
 
     public function pdoAttributeProvider()

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -1391,7 +1391,7 @@ class MysqlAdapterTest extends TestCase
             ['decimal_precision_scale', 'decimal', ['precision' => 10, 'scale' => 2]],
             ['decimal_precision_zero_scale', 'decimal', ['precision' => 15, 'scale' => 0]],
             ['decimal_limit', 'decimal', ['limit' => 10]],
-            ['decimal_precision', 'decimal', ['precision' => 15]],
+            ['decimal_precision', 'decimal', ['precision' => 10]],
             ['column8', 'datetime', []],
             ['column9', 'time', []],
             ['column10', 'timestamp', []],

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1258,6 +1258,7 @@ class PostgresAdapterTest extends TestCase
             ['column13', 'string', ['limit' => 10]],
             ['column16', 'interval', []],
             ['decimal_precision_scale', 'decimal', ['precision' => 10, 'scale' => 2]],
+            ['decimal_precision_zero_scale', 'decimal', ['precision' => 12, 'scale' => 0]],
             ['decimal_limit', 'decimal', ['limit' => 10]],
             ['decimal_precision', 'decimal', ['precision' => 10]],
         ];
@@ -1283,6 +1284,18 @@ class PostgresAdapterTest extends TestCase
             $this->assertEquals($actualType, $columns[1]->getType());
         } else {
             $this->assertEquals(['name' => $actualType] + $options, $columns[1]->getType());
+        }
+
+        if (isset($options['limit'])) {
+            $this->assertEquals($options['limit'], $columns[1]->getLimit());
+        }
+
+        if (isset($options['precision'])) {
+            $this->assertEquals($options['precision'], $columns[1]->getPrecision());
+        }
+
+        if (isset($options['scale'])) {
+            $this->assertEquals($options['scale'], $columns[1]->getScale());
         }
     }
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1319,6 +1319,9 @@ class SQLiteAdapterTest extends TestCase
             ['column15', 'smallinteger', []],
             ['column15', 'integer', []],
             ['column23', 'json', []],
+            ['decimal_precision_scale', 'decimal', ['precision' => 10, 'scale' => 2]],
+            ['decimal_precision_zero_scale', 'decimal', ['precision' => 10, 'scale' => 0]],
+            ['decimal_precision', 'decimal', ['precision' => 10]],
         ];
     }
 

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -1321,8 +1321,37 @@ class SQLiteAdapterTest extends TestCase
             ['column23', 'json', []],
             ['decimal_precision_scale', 'decimal', ['precision' => 10, 'scale' => 2]],
             ['decimal_precision_zero_scale', 'decimal', ['precision' => 10, 'scale' => 0]],
-            ['decimal_precision', 'decimal', ['precision' => 10]],
         ];
+    }
+
+    /**
+     * @dataProvider columnsProvider
+     */
+    public function testGetColumns($colName, $type, $options)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn($colName, $type, $options)->save();
+
+        $columns = $this->adapter->getColumns('t');
+        $this->assertCount(2, $columns);
+        $this->assertEquals($colName, $columns[1]->getName());
+        $this->assertEquals($type, $columns[1]->getType());
+
+        if (isset($options['limit'])) {
+            $this->assertEquals($options['limit'], $columns[1]->getLimit());
+        }
+
+        if (isset($options['precision'])) {
+            $this->assertEquals($options['precision'], $columns[1]->getPrecision());
+        }
+
+        if (isset($options['scale'])) {
+            $this->assertEquals($options['scale'], $columns[1]->getScale());
+        }
+
+        if (isset($options['comment'])) {
+            $this->assertEquals($options['comment'], $columns[1]->getComment());
+        }
     }
 
     public function testAddIndex()
@@ -3169,7 +3198,7 @@ INPUT;
      * @covers \Phinx\Db\Adapter\SQLiteAdapter::getTableInfo
      * @covers \Phinx\Db\Adapter\SQLiteAdapter::getColumns
      */
-    public function testGetColumns()
+    public function testGetMultipleColumns()
     {
         $conn = $this->adapter->getConnection();
         $conn->exec('create table t(a integer, b text, c char(5), d integer(12,6), e integer not null, f integer null)');

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -731,15 +731,15 @@ WHERE t.name='ntable'");
         $this->assertEquals($type, $columns[$colName]->getType());
 
         if (isset($options['limit'])) {
-            $this->assertEquals($options['limit'], $columns[1]->getLimit());
+            $this->assertEquals($options['limit'], $columns[$colName]->getLimit());
         }
 
         if (isset($options['precision'])) {
-            $this->assertEquals($options['precision'], $columns[1]->getPrecision());
+            $this->assertEquals($options['precision'], $columns[$colName]->getPrecision());
         }
 
         if (isset($options['scale'])) {
-            $this->assertEquals($options['scale'], $columns[1]->getScale());
+            $this->assertEquals($options['scale'], $columns[$colName]->getScale());
         }
     }
 

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -709,6 +709,7 @@ WHERE t.name='ntable'");
             ['column13', 'tinyinteger', ['default' => 5]],
             ['column14', 'smallinteger', ['default' => 5]],
             ['decimal_precision_scale', 'decimal', ['precision' => 10, 'scale' => 2]],
+            ['decimal_precision_zero_scale', 'decimal', ['precision' => 10, 'scale' => 0]],
             ['decimal_limit', 'decimal', ['limit' => 10]],
             ['decimal_precision', 'decimal', ['precision' => 10]],
         ];
@@ -728,6 +729,18 @@ WHERE t.name='ntable'");
         $this->assertCount(2, $columns);
         $this->assertEquals($colName, $columns[$colName]->getName());
         $this->assertEquals($type, $columns[$colName]->getType());
+
+        if (isset($options['limit'])) {
+            $this->assertEquals($options['limit'], $columns[1]->getLimit());
+        }
+
+        if (isset($options['precision'])) {
+            $this->assertEquals($options['precision'], $columns[1]->getPrecision());
+        }
+
+        if (isset($options['scale'])) {
+            $this->assertEquals($options['scale'], $columns[1]->getScale());
+        }
     }
 
     public function testAddIndex()


### PR DESCRIPTION
PR is a continuation of the work done in #2377, bringing that change across providers as makes sense. As part of this, now:

1. For sqlite, we will apply `(p,s)` args if `precision` is not empty and scale is not null, so that doing `(10,0)` is possible (same as mysql)
2. For sqlserver, if precision or scale is defined and you're using a decimal, than we will apply the `(p,s)` args with an appropriate default of `(18,0)` (defaults used as defined in [the sqlserver decimal docs](https://learn.microsoft.com/en-us/sql/t-sql/data-types/decimal-and-numeric-transact-sql?view=sql-server-ver17))  is one is omitted. So it's possible to do just `'scale' => 5`, and then precision will be implicitly set to `18`, and you'll get `(18,5)`. This brings its behavior in line with how postgres works (though it has a default of `10` for precision).
3. For sqlserver, when fetching columns, for decimals, we set precision. We also now always set `scale` as well (though it's expected that this will only be defined for numeric types anyway).

As part of this, I did learn that under the hood, precision and limit are equivalent for defining a column, which does prevent just using a precision for mysql and sqlite. It would separate out the behavior, but this would be a breaking change and thought would need to be made on the best approach.