### PR TITLE
Fix deprecations in phpstan config

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,9 +4,9 @@ includes:
 parameters:
 	level: 6
 	treatPhpDocTypesAsCertain: false
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
 	paths:
 		- src/
 	ignoreErrors:
 		- '#Unsafe usage of new static\(\)\.#'
+		- identifier: missingType.iterableValue
+		- identifier: missingType.generics


### PR DESCRIPTION
Fix the following deprecation warnings when running phpstan:

```
Note: Using configuration file /home/runner/work/phinx/phinx/phpstan.neon.
⚠️  You're using a deprecated config option checkMissingIterableValueType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing array typehints.

If you want to continue ignoring missing typehints from arrays,
add missingType.iterableValue error identifier to your ignoreErrors:

parameters:
	ignoreErrors:
		-
			identifier: missingType.iterableValue

⚠️  You're using a deprecated config option checkGenericClassInNonGenericObjectType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing generic typehints.

If you want to continue ignoring missing typehints from generics,
add missingType.generics error identifier to your ignoreErrors:

parameters:
	ignoreErrors:
		-
			identifier: missingType.generics
```