### PR TITLE
Improve quote behavior of CURRENT_TIMESTAMP default

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -581,7 +581,8 @@ class MysqlAdapter extends PdoAdapter
                 $extra = ' ' . implode(' ', $extras);
 
                 if (($row['Default'] !== null)) {
-                    $extra .= $this->getDefaultValueDefinition($row['Default']);
+                    $phinxType = $this->getPhinxType($row['Type']);
+                    $extra .= $this->getDefaultValueDefinition($row['Default'], $phinxType['name']);
                 }
                 $definition = $row['Type'] . ' ' . $null . $extra . $comment;
 

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -725,9 +725,16 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     protected function getDefaultValueDefinition(mixed $default, string|Literal|null $columnType = null): string
     {
+        $datetimeTypes = [
+            static::PHINX_TYPE_DATETIME,
+            static::PHINX_TYPE_TIMESTAMP,
+            static::PHINX_TYPE_TIME,
+            static::PHINX_TYPE_DATE,
+        ];
+
         if ($default instanceof Literal) {
             $default = (string)$default;
-        } elseif (is_string($default) && stripos($default, 'CURRENT_TIMESTAMP') !== 0) {
+        } elseif (is_string($default) && (!in_array($columnType, $datetimeTypes) || !preg_match('/^(CURRENT_(TIMESTAMP|TIME|DATE))|(NOW)(\(\d*\))?$/i', $default))) {
             // Ensure a defaults of CURRENT_TIMESTAMP(3) is not quoted.
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -603,7 +603,7 @@ SQL;
         if ($default === null) {
             $default = 'DEFAULT NULL';
         } else {
-            $default = ltrim($this->getDefaultValueDefinition($default));
+            $default = ltrim($this->getDefaultValueDefinition($default, $newColumn->getType()));
         }
 
         if (empty($default)) {
@@ -1264,7 +1264,7 @@ ORDER BY T.[name], I.[index_id];";
             if ($column->getDefault() === null && $column->isNull()) {
                 $buffer[] = ' DEFAULT NULL';
             } else {
-                $buffer[] = $this->getDefaultValueDefinition($column->getDefault());
+                $buffer[] = $this->getDefaultValueDefinition($column->getDefault(), $column->getType());
             }
         }
 

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -543,7 +543,9 @@ class Table
             throw new RuntimeException('Cannot set both created_at and updated_at columns to false');
         }
 
-        $columnType = FeatureFlags::$addTimestampsUseDateTime ? 'datetime' : 'timestamp';
+        $columnType = FeatureFlags::$addTimestampsUseDateTime
+            ? AdapterInterface::PHINX_TYPE_DATETIME
+            : AdapterInterface::PHINX_TYPE_TIMESTAMP;
 
         if ($createdAt) {
             $this->addColumn($createdAt, $columnType, [

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -8,6 +8,7 @@ use Cake\I18n\DateTime;
 use PDO;
 use PDOException;
 use Phinx\Config\Config;
+use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Util\Literal;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -260,5 +261,47 @@ class PdoAdapterTest extends TestCase
 
         $method = new ReflectionMethod($this->adapter, 'quoteValue');
         $this->assertSame($expected, $method->invoke($this->adapter, $input));
+    }
+
+    public function defaultValueDefinitionDataProvider(): array
+    {
+        return [
+            ['some string', AdapterInterface::PHINX_TYPE_STRING, " DEFAULT 'some string'"],
+            [123, AdapterInterface::PHINX_TYPE_INTEGER, ' DEFAULT 123'],
+            [true, AdapterInterface::PHINX_TYPE_BOOLEAN, ' DEFAULT 1'],
+            [false, AdapterInterface::PHINX_TYPE_BOOLEAN, ' DEFAULT 0'],
+            [null, AdapterInterface::PHINX_TYPE_STRING, ''],
+            [Literal::from('foo'), AdapterInterface::PHINX_TYPE_STRING, ' DEFAULT foo'],
+            ['CURRENT_TIMESTAMP', AdapterInterface::PHINX_TYPE_STRING, " DEFAULT 'CURRENT_TIMESTAMP'"],
+            ['CURRENT_TIMESTAMP', AdapterInterface::PHINX_TYPE_DATETIME, ' DEFAULT CURRENT_TIMESTAMP'],
+            ['CURRENT_TIMESTAMP(3)', AdapterInterface::PHINX_TYPE_DATETIME, ' DEFAULT CURRENT_TIMESTAMP(3)'],
+            ['CURRENT_TIMESTAMP()', AdapterInterface::PHINX_TYPE_DATETIME, ' DEFAULT CURRENT_TIMESTAMP()'],
+            ['CURRENT_TIMESTAMP', AdapterInterface::PHINX_TYPE_TIMESTAMP, ' DEFAULT CURRENT_TIMESTAMP'],
+            ['CURRENT_TIME', AdapterInterface::PHINX_TYPE_TIME, ' DEFAULT CURRENT_TIME'],
+            ['CURRENT_DATE', AdapterInterface::PHINX_TYPE_DATE, ' DEFAULT CURRENT_DATE'],
+            ['NOW', AdapterInterface::PHINX_TYPE_DATETIME, ' DEFAULT NOW'],
+        ];
+    }
+
+    /**
+     * @dataProvider defaultValueDefinitionDataProvider
+     */
+    public function testGetDefaultValueDefinition($input, $columnType, $expected): void
+    {
+        /** @var \PDO&\PHPUnit\Framework\MockObject\MockObject $pdo */
+        $pdo = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['quote'])
+            ->getMock();
+
+        $pdo->method('quote')
+            ->willReturnCallback(function (string $input) {
+                return "'$input'";
+            });
+
+        $this->adapter->setConnection($pdo);
+
+        $method = new ReflectionMethod($this->adapter, 'getDefaultValueDefinition');
+        $this->assertSame($expected, $method->invoke($this->adapter, $input, $columnType));
     }
 }


### PR DESCRIPTION
Closes #1891

This is a port of cakephp/migrations#923 with some additional changes.

PR improves the behavior of how we handle the string `"CURRENT_TIMESTAMP"` as a default such that it will now only not be quote if the column type is explicitly `datetime`, `timestamp`, `date`, or `time`. This should make behavior across adapters consistent where for mysql using `CURRENT_TIMESTAMP` with a string column would throw an error while postgres would implicitly cast it to a string.

I've also added similar behavior to the `CURRENT_DATETIME`, `CURRENT_TIME`, `CURRENT_DATE`, and `NOW` functions since those are also somewhat common in my experience as defaults for `datetime`, `time`, and `date` respectfully. 