### PR TITLE
Setting limit to null omits it from definition

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1364,8 +1364,8 @@ class MysqlAdapter extends PdoAdapter
         }
         if ($column->getPrecision() && $column->getScale() !== null) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
-        } elseif (isset($sqlType['limit'])) {
-            $def .= '(' . $sqlType['limit'] . ')';
+        } elseif ($column->getLimit() || (!$column->hasLimitSet() && isset($sqlType['limit']))) {
+            $def .= '(' . ($column->getLimit() ?: $sqlType['limit']) . ')';
         }
 
         $values = $column->getValues();

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1364,8 +1364,8 @@ class MysqlAdapter extends PdoAdapter
         }
         if ($column->getPrecision() && $column->getScale() !== null) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
-        } elseif ($column->getLimit() || (!$column->hasLimitSet() && isset($sqlType['limit']))) {
-            $def .= '(' . ($column->getLimit() ?: $sqlType['limit']) . ')';
+        } elseif (($column->getLimit() !== null || !$column->hasLimitSet()) && isset($sqlType['limit'])) {
+            $def .= '(' . $sqlType['limit'] . ')';
         }
 
         $values = $column->getValues();

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1280,7 +1280,7 @@ class PostgresAdapter extends PdoAdapter
                     self::PHINX_TYPE_BINARY,
                 ], true)
             ) {
-                if ($column->getLimit() || isset($sqlType['limit'])) {
+                if ($column->getLimit() || (!$column->hasLimitSet() && isset($sqlType['limit']))) {
                     $buffer[] = sprintf('(%s)', $column->getLimit() ?: $sqlType['limit']);
                 }
             }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1864,7 +1864,7 @@ PCRE_PATTERN;
             $def = strtoupper($sqlType['name']);
 
             $limitable = in_array(strtoupper($sqlType['name']), $this->definitionsWithLimits, true);
-            if (($column->getLimit() || isset($sqlType['limit'])) && $limitable) {
+            if (($column->getLimit() || (!$column->hasLimitSet() && isset($sqlType['limit']))) && $limitable) {
                 $def .= '(' . ($column->getLimit() ?: $sqlType['limit']) . ')';
             }
         }

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1250,7 +1250,7 @@ ORDER BY T.[name], I.[index_id];";
                     $column->getPrecision() ?: $sqlType['precision'],
                     $column->getScale() ?: $sqlType['scale'],
                 );
-            } elseif (!in_array($sqlType['name'], $noLimits) && ($column->getLimit() || isset($sqlType['limit']))) {
+            } elseif (!in_array($sqlType['name'], $noLimits) && ($column->getLimit() || (!$column->hasLimitSet() && isset($sqlType['limit'])))) {
                 $buffer[] = sprintf('(%s)', $column->getLimit() ?: $sqlType['limit']);
             }
         }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -78,6 +78,11 @@ class Column
     /**
      * @var bool
      */
+    protected bool $limitSet = false;
+
+    /**
+     * @var bool
+     */
     protected bool $null = true;
 
     /**
@@ -229,6 +234,7 @@ class Column
     public function setLimit(?int $limit)
     {
         $this->limit = $limit;
+        $this->limitSet = true;
 
         return $this;
     }
@@ -241,6 +247,11 @@ class Column
     public function getLimit(): ?int
     {
         return $this->limit;
+    }
+
+    public function hasLimitSet(): bool
+    {
+        return $this->limitSet;
     }
 
     /**


### PR DESCRIPTION
Right now, when a `limit` is not included in a column definition or it's set to `null` explicitly, phinx will use some default limit for the column type (e.g. `255` for character varying). Phinx is an opinionated migrations library that tries to encourage best practices (like setting limits on character varying) by default, so I don't really want to change the default behavior when limit is omitted, but this PR modifies the behavior of passing `null`, where now the limit will be fully omitted from the definition, allowing an escape hatch from phinx's defaults.

While this is BC breaking, I'd consider the fact that an explicit `null` was ignored a bug, so won't cut a major release for this PR.

Supersedes #2233 which made a BC only for postgres character varying, which I don't particularly like as I think it makes things confusing if going from one adapter to another.