### PR TITLE
[2386] SqlServerAdapter::getColumns returns non-associative array

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -428,7 +428,7 @@ interface AdapterInterface
      * Returns table columns
      *
      * @param string $tableName Table name
-     * @return list<\Phinx\Db\Table\Column>
+     * @return \Phinx\Db\Table\Column[]
      */
     public function getColumns(string $tableName): array;
 

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -428,7 +428,7 @@ interface AdapterInterface
      * Returns table columns
      *
      * @param string $tableName Table name
-     * @return \Phinx\Db\Table\Column[]
+     * @return list<\Phinx\Db\Table\Column>
      */
     public function getColumns(string $tableName): array;
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -487,7 +487,7 @@ class SqlServerAdapter extends PdoAdapter
                 $column->setPrecision((int)$columnInfo['precision']);
             }
 
-            $columns[$columnInfo['name']] = $column;
+            $columns[] = $column;
         }
 
         return $columns;
@@ -626,10 +626,10 @@ SQL;
      */
     protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions
     {
-        $columns = $this->getColumns($tableName);
+        $column = $this->getColumn($tableName, $columnName);
         $changeDefault =
-            $newColumn->getDefault() !== $columns[$columnName]->getDefault() ||
-            $newColumn->getType() !== $columns[$columnName]->getType();
+            $newColumn->getDefault() !== $column?->getDefault() ||
+            $newColumn->getType() !== $column?->getType();
 
         $instructions = new AlterInstructions();
 
@@ -1381,5 +1381,26 @@ ORDER BY T.[name], I.[index_id];";
         ] + $options;
 
         return $this->decoratedConnection = $this->buildConnection(SqlServerDriver::class, $options);
+    }
+
+    /**
+     * Gets a table column
+     *
+     * @param string $tableName
+     * @param string $columnName
+     * @return \Phinx\Db\Table\Column|null
+     */
+    private function getColumn(string $tableName, string $columnName): ?Column
+    {
+        $columns = $this->getColumns($tableName);
+
+        $filteredColumns = array_filter(
+            $columns,
+            static function ($column) use ($columnName) {
+                return $column->getName() === $columnName;
+            },
+        );
+
+        return array_pop($filteredColumns);
     }
 }

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -479,7 +479,7 @@ WHERE t.name='ntable'");
         }
     }
 
-    public function testAddColumnWithNotNullableNoDefault()
+    public function testAddColumnWithNotNullableNoDefault(): void
     {
         $table = new Table('table1', [], $this->adapter);
         $table
@@ -488,10 +488,12 @@ WHERE t.name='ntable'");
 
         $columns = $this->adapter->getColumns('table1');
         $this->assertCount(2, $columns);
-        $this->assertArrayHasKey('id', $columns);
-        $this->assertArrayHasKey('col', $columns);
-        $this->assertFalse($columns['col']->isNull());
-        $this->assertNull($columns['col']->getDefault());
+        $firstColumn = $columns[0];
+        $this->assertSame('id', $firstColumn->getName());
+        $secondColumn = $columns[1];
+        $this->assertSame('col', $secondColumn->getName());
+        $this->assertFalse($secondColumn->isNull());
+        $this->assertNull($secondColumn->getDefault());
     }
 
     public function testAddColumnWithDefaultBool()
@@ -522,7 +524,7 @@ WHERE t.name='ntable'");
             ->addColumn('checked', Literal::from('bit'), ['default' => 0])
             ->save();
 
-        $column = $this->adapter->getColumns('table1')['checked'];
+        $column = $this->adapter->getColumns('table1')[1];
 
         $this->assertSame('checked', $column->getName());
         $this->assertSame('boolean', $column->getType());
@@ -530,7 +532,7 @@ WHERE t.name='ntable'");
         $this->assertTrue($column->getNull());
     }
 
-    public function testAddColumnWithCustomType()
+    public function testAddColumnWithCustomType(): void
     {
         $this->adapter->setDataDomain([
             'custom' => [
@@ -549,18 +551,17 @@ WHERE t.name='ntable'");
         $this->assertTrue($this->adapter->hasTable('table1'));
 
         $columns = $this->adapter->getColumns('table1');
-        $this->assertArrayHasKey('custom', $columns);
-        $this->assertArrayHasKey('custom_ext', $columns);
+        $this->assertCount(3, $columns);
 
-        $column = $this->adapter->getColumns('table1')['custom'];
-        $this->assertSame('custom', $column->getName());
-        $this->assertSame('geometry', (string)$column->getType());
-        $this->assertTrue($column->getNull());
+        $customColumn = $columns[1];
+        $this->assertSame('custom', $customColumn->getName());
+        $this->assertSame('geometry', (string)$customColumn->getType());
+        $this->assertTrue($customColumn->getNull());
 
-        $column = $this->adapter->getColumns('table1')['custom_ext'];
-        $this->assertSame('custom_ext', $column->getName());
-        $this->assertSame('geometry', (string)$column->getType());
-        $this->assertFalse($column->getNull());
+        $customExtColumn = $columns[2];
+        $this->assertSame('custom_ext', $customExtColumn->getName());
+        $this->assertSame('geometry', (string)$customExtColumn->getType());
+        $this->assertFalse($customExtColumn->getNull());
     }
 
     public function testRenameColumn()
@@ -632,7 +633,7 @@ WHERE t.name='ntable'");
         }
     }
 
-    public function testChangeColumnDefaults()
+    public function testChangeColumnDefaults(): void
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string', ['default' => 'test'])
@@ -640,7 +641,7 @@ WHERE t.name='ntable'");
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
 
         $columns = $this->adapter->getColumns('t');
-        $this->assertSame('test', $columns['column1']->getDefault());
+        $this->assertSame('test', $columns[1]->getDefault());
 
         $newColumn1 = new Column();
         $newColumn1
@@ -650,10 +651,10 @@ WHERE t.name='ntable'");
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
 
         $columns = $this->adapter->getColumns('t');
-        $this->assertSame('another test', $columns['column1']->getDefault());
+        $this->assertSame('another test', $columns[1]->getDefault());
     }
 
-    public function testChangeColumnDefaultToNull()
+    public function testChangeColumnDefaultToNull(): void
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'string', ['null' => true, 'default' => 'test'])
@@ -664,10 +665,10 @@ WHERE t.name='ntable'");
             ->setDefault(null);
         $table->changeColumn('column1', $newColumn1)->save();
         $columns = $this->adapter->getColumns('t');
-        $this->assertNull($columns['column1']->getDefault());
+        $this->assertNull($columns[1]->getDefault());
     }
 
-    public function testChangeColumnDefaultToZero()
+    public function testChangeColumnDefaultToZero(): void
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'integer')
@@ -678,7 +679,7 @@ WHERE t.name='ntable'");
             ->setDefault(0);
         $table->changeColumn('column1', $newColumn1)->save();
         $columns = $this->adapter->getColumns('t');
-        $this->assertSame(0, $columns['column1']->getDefault());
+        $this->assertSame(0, $columns[1]->getDefault());
     }
 
     public function testDropColumn()

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -691,7 +691,7 @@ WHERE t.name='ntable'");
         $this->assertFalse($this->adapter->hasColumn('t', 'column1'));
     }
 
-    public function columnsProvider()
+    public static function columnsProvider(): array
     {
         return [
             ['column1', 'string', ['null' => true, 'default' => null]],
@@ -718,7 +718,7 @@ WHERE t.name='ntable'");
     /**
      * @dataProvider columnsProvider
      */
-    public function testGetColumns($colName, $type, $options)
+    public function testGetColumns($colName, $type, $options): void
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -727,19 +727,23 @@ WHERE t.name='ntable'");
 
         $columns = $this->adapter->getColumns('t');
         $this->assertCount(2, $columns);
-        $this->assertEquals($colName, $columns[$colName]->getName());
-        $this->assertEquals($type, $columns[$colName]->getType());
+
+        $specificColumn = $this->getColumn('t', $colName);
+        $this->assertNotNull($specificColumn);
+
+        $this->assertEquals($colName, $specificColumn->getName());
+        $this->assertEquals($type, $specificColumn->getType());
 
         if (isset($options['limit'])) {
-            $this->assertEquals($options['limit'], $columns[$colName]->getLimit());
+            $this->assertEquals($options['limit'], $specificColumn->getLimit());
         }
 
         if (isset($options['precision'])) {
-            $this->assertEquals($options['precision'], $columns[$colName]->getPrecision());
+            $this->assertEquals($options['precision'], $specificColumn->getPrecision());
         }
 
         if (isset($options['scale'])) {
-            $this->assertEquals($options['scale'], $columns[$colName]->getScale());
+            $this->assertEquals($options['scale'], $specificColumn->getScale());
         }
     }
 
@@ -1662,5 +1666,19 @@ INPUT;
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (\PDO::' . strtoupper($attribute) . ')');
         $adapter->connect();
+    }
+
+    private function getColumn(string $tableName, string $columnName): ?Column
+    {
+        $columns = $this->adapter->getColumns($tableName);
+
+        $filteredColumns = array_filter(
+            $columns,
+            static function ($column) use ($columnName) {
+                return $column->getName() === $columnName;
+            },
+        );
+
+        return array_pop($filteredColumns);
     }
 }


### PR DESCRIPTION
Fix for https://github.com/cakephp/phinx/issues/2386