### PR TITLE
Fix php85 mysql attr constant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.4']
+        php-version: ['8.1', '8.5']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Setup MySQL latest
-      if: matrix.db-type == 'mysql' && matrix.php-version == '8.4'
+      if: matrix.db-type == 'mysql' && matrix.php-version == '8.5'
       run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:8.4
 
     - name: Setup MySQL 8.0

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -147,7 +147,11 @@ class MysqlAdapter extends PdoAdapter
             // https://php.net/manual/en/ref.pdo-mysql.php#pdo-mysql.constants
             foreach ($options as $key => $option) {
                 if (strpos($key, 'mysql_attr_') === 0) {
-                    $pdoConstant = '\PDO::' . strtoupper($key);
+                    if (PHP_VERSION_ID < 80400) {
+                        $pdoConstant = '\PDO::' . strtoupper($key);
+                    } else {
+                        $pdoConstant = '\PDO\Mysql::' . strtoupper(substr($key, 6));
+                    }
                     if (!defined($pdoConstant)) {
                         throw new UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
                     }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2731,19 +2731,19 @@ INPUT;
     public function pdoAttributeProvider()
     {
         return [
-            ['mysql_attr_invalid'],
-            ['attr_invalid'],
+            ['mysql_attr_invalid', PHP_VERSION_ID < 80400 ? '\PDO::MYSQL_ATTR_INVALID' : '\PDO\Mysql::ATTR_INVALID'],
+            ['attr_invalid', '\PDO::ATTR_INVALID'],
         ];
     }
 
     /**
      * @dataProvider pdoAttributeProvider
      */
-    public function testInvalidPdoAttribute($attribute)
+    public function testInvalidPdoAttribute($attribute, $constant)
     {
         $adapter = new MysqlAdapter(MYSQL_DB_CONFIG + [$attribute => true]);
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (\PDO::' . strtoupper($attribute) . ')');
+        $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (' . $constant . ')');
         $adapter->connect();
     }
 
@@ -2796,5 +2796,19 @@ INPUT;
     {
         $adapter = new MysqlAdapter(MYSQL_DB_CONFIG);
         $this->assertFalse($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
+    }
+
+    public function testMysqlPdoMultiStatementsEnabled()
+    {
+        $adapter = new MysqlAdapter(MYSQL_DB_CONFIG + ['mysql_attr_multi_statements' => true]);
+        $result = $adapter->fetchAll('SELECT 1 a; SELECT 2 b;');
+        $this->assertSame([['a' => 1, 0 => 1]], $result);
+    }
+
+    public function testMysqlPdoMultiStatementsDisabled()
+    {
+        $adapter = new MysqlAdapter(MYSQL_DB_CONFIG + ['mysql_attr_multi_statements' => false]);
+        $this->expectException(PDOException::class);
+        $adapter->fetchAll('SELECT 1 a; SELECT 2 b;');
     }
 }


### PR DESCRIPTION
[PHP 8.4](https://www.php.net/releases/8.4/en.php#pdo_driver_specific_subclasses) introduced driver-specific PDO subclases (e.g. `\PDO\Mysql`). [PHP 8.5](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.pdo) deprecated `\PDO::MYSQL_*` (etc) constants.

I'm using phinx with `mysql_attr_multi_statements: 0` and on PHP 8.5 I get

```
PHP Deprecated:  Constant PDO::MYSQL_ATTR_MULTI_STATEMENTS is deprecated since 8.5, use Pdo\Mysql::ATTR_MULTI_STATEMENTS instead in vendor/robmorgan/phinx/src/Phinx/Db/Adapter/MysqlAdapter.php on line 154
```
This PR should fix it.

I checked the other drivers as well, and the only other one with similar functionality is the SqlServerAdapter. However, that one doesn't seem to have the a PDO subclass.