### PR TITLE
Set minimum-stability to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "bin": [
         "bin/phinx"
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
All required and require-dev dependencies are tagged stable releases — there is no longer a need for `minimum-stability: dev` paired with `prefer-stable: true`.

Setting `minimum-stability` explicitly to `stable` is cleaner than relying on `dev` with `prefer-stable`.