### PR TITLE
fix: MariaDB 12 uses numeric foreign keys by default

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -971,6 +971,7 @@ class MysqlAdapter extends PdoAdapter
             $tableName,
         ));
         foreach ($rows as $row) {
+            $foreignKeys[$row['CONSTRAINT_NAME']]['constraint'] = $row['CONSTRAINT_NAME'];
             $foreignKeys[$row['CONSTRAINT_NAME']]['table'] = $row['TABLE_NAME'];
             $foreignKeys[$row['CONSTRAINT_NAME']]['columns'][] = $row['COLUMN_NAME'];
             $foreignKeys[$row['CONSTRAINT_NAME']]['referenced_table'] = $row['REFERENCED_TABLE_NAME'];
@@ -999,7 +1000,7 @@ class MysqlAdapter extends PdoAdapter
     protected function getDropForeignKeyInstructions(string $tableName, string $constraint): AlterInstructions
     {
         $alter = sprintf(
-            'DROP FOREIGN KEY %s',
+            'DROP FOREIGN KEY `%s`',
             $constraint,
         );
 
@@ -1019,9 +1020,9 @@ class MysqlAdapter extends PdoAdapter
 
         $matches = [];
         $foreignKeys = $this->getForeignKeys($tableName);
-        foreach ($foreignKeys as $name => $key) {
-            if (array_map('mb_strtolower', $key['columns']) === $columns) {
-                $matches[] = $name;
+        foreach ($foreignKeys as $foreignKey) {
+            if (array_map('mb_strtolower', $foreignKey['columns']) === $columns) {
+                $matches[] = $foreignKey['constraint'];
             }
         }
 


### PR DESCRIPTION
MariaDB 12.2 (I think also 12.1) if you do not specify a foreign key name, will use numeric strings ("1", "2", "3" etc)

When you go to drop a foreign key, it puts the constraint name as the key in the array. PHP sees it as a numeric string and changes it to an int.

So e.g. the following would previously fail, with an error that $constraint should be a string, int given:

```php
<?php

final class LmsWithdrawalByTeacher extends \Phinx\Migration\AbstractMigration
{
    public function change(): void
    {
        $this->table('s_class_withdrawal')
            ->addColumn('recorded_by_id', 'integer', [
                'null'  => true,
                'after' => 'date',
            ])
            ->addForeignKey('recorded_by_id', 's_teacher')
            ->update();

        $this->table('s_class_withdrawal')
            ->dropForeignKey('recorded_by_id')
            ->update();
    }
}
```

Should also fix #924 