### PR TITLE
Fix SQL injection in hasDatabase() by quoting database name in adapters

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1419,8 +1419,8 @@ class MysqlAdapter extends PdoAdapter
     {
         $rows = $this->fetchAll(
             sprintf(
-                'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \'%s\'',
-                $name,
+                'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = %s',
+                $this->getConnection()->quote($name),
             ),
         );
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1206,8 +1206,7 @@ class PostgresAdapter extends PdoAdapter
      */
     public function hasDatabase(string $name): bool
     {
-        $name = $this->getConnection()->quote($name);
-        $sql = sprintf("SELECT count(*) FROM pg_database WHERE datname = '%s'", $name);
+        $sql = sprintf("SELECT count(*) FROM pg_database WHERE datname = %s", $this->getConnection()->quote($name));
         $result = $this->fetchRow($sql);
 
         return $result['count'] > 0;

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1206,7 +1206,7 @@ class PostgresAdapter extends PdoAdapter
      */
     public function hasDatabase(string $name): bool
     {
-        $sql = sprintf("SELECT count(*) FROM pg_database WHERE datname = %s", $this->getConnection()->quote($name));
+        $sql = sprintf('SELECT count(*) FROM pg_database WHERE datname = %s', $this->getConnection()->quote($name));
         $result = $this->fetchRow($sql);
 
         return $result['count'] > 0;

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1206,6 +1206,7 @@ class PostgresAdapter extends PdoAdapter
      */
     public function hasDatabase(string $name): bool
     {
+        $name = $this->getConnection()->quote($name);
         $sql = sprintf("SELECT count(*) FROM pg_database WHERE datname = '%s'", $name);
         $result = $this->fetchRow($sql);
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1198,8 +1198,8 @@ ORDER BY T.[name], I.[index_id];";
         /** @var array<string, mixed> $result */
         $result = $this->fetchRow(
             sprintf(
-                "SELECT count(*) as [count] FROM master.dbo.sysdatabases WHERE [name] = '%s'",
-                $name,
+                "SELECT count(*) as [count] FROM master.dbo.sysdatabases WHERE [name] = %s",
+                $this->getConnection()->quote($name),
             ),
         );
 

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1198,7 +1198,7 @@ ORDER BY T.[name], I.[index_id];";
         /** @var array<string, mixed> $result */
         $result = $this->fetchRow(
             sprintf(
-                "SELECT count(*) as [count] FROM master.dbo.sysdatabases WHERE [name] = %s",
+                'SELECT count(*) as [count] FROM master.dbo.sysdatabases WHERE [name] = %s',
                 $this->getConnection()->quote($name),
             ),
         );

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2030,6 +2030,11 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasDatabase(MYSQL_DB_CONFIG['name']));
     }
 
+    public function testHasDatabaseWithSingleQuoteInName()
+    {
+        $this->assertFalse($this->adapter->hasDatabase("fake'database'name"));
+    }
+
     public function testDropDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('phinx_temp_database'));

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -1949,6 +1949,11 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasDatabase(PGSQL_DB_CONFIG['name']));
     }
 
+    public function testHasDatabaseWithSingleQuoteInName()
+    {
+        $this->assertFalse($this->adapter->hasDatabase("fake'database'name"));
+    }
+
     public function testDropDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('phinx_temp_database'));

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -1184,6 +1184,11 @@ WHERE t.name='ntable'");
         $this->assertTrue($this->adapter->hasDatabase(SQLSRV_DB_CONFIG['name']));
     }
 
+    public function testHasDatabaseWithSingleQuoteInName()
+    {
+        $this->assertFalse($this->adapter->hasDatabase("fake'database'name"));
+    }
+
     public function testDropDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('phinx_temp_database'));


### PR DESCRIPTION
Update query generation for reflection methods in adapter layers to mitigate potential sql injection. While phinx should never have user controlled data provided to it, security researchers don't know that.

This will stay as a draft until I have more time to go through the rest of the sprintf() queries in each adapter.